### PR TITLE
Increased retry wait in integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,13 @@ jobs:
         with:
           provider: lxd
       - name: Run integration tests
-        run: tox -e charm-integration
+        run: |
+          # set sysctl values in case the cloudinit-userdata not applied
+          sudo sysctl -w vm.max_map_count=262144
+          sudo sysctl -w vm.swappiness=0
+          sudo sysctl -w net.ipv4.tcp_retries2=5
+          
+          tox -e charm-integration
 
   integration-test-lxd-tls:
     name: Integration tests for TLS (lxd)

--- a/tests/integration/tls/helpers.py
+++ b/tests/integration/tls/helpers.py
@@ -11,7 +11,7 @@ from tests.integration.helpers import http_request
 
 
 @retry(
-    wait=wait_fixed(wait=3) + wait_random(1, 3),
+    wait=wait_fixed(wait=5) + wait_random(0, 5),
     stop=stop_after_attempt(15),
 )
 async def check_security_index_initialised(ops_test: OpsTest, unit_ip: str) -> bool:
@@ -34,7 +34,7 @@ async def check_security_index_initialised(ops_test: OpsTest, unit_ip: str) -> b
 
 
 @retry(
-    wait=wait_fixed(wait=3) + wait_random(1, 3),
+    wait=wait_fixed(wait=5) + wait_random(0, 5),
     stop=stop_after_attempt(15),
 )
 async def check_unit_tls_configured(ops_test: OpsTest, unit_ip: str, unit_name: str) -> bool:
@@ -53,7 +53,7 @@ async def check_unit_tls_configured(ops_test: OpsTest, unit_ip: str, unit_name: 
 
 
 @retry(
-    wait=wait_fixed(wait=3) + wait_random(1, 3),
+    wait=wait_fixed(wait=5) + wait_random(0, 5),
     stop=stop_after_attempt(15),
 )
 async def check_cluster_formation_successful(

--- a/tests/integration/tls/helpers.py
+++ b/tests/integration/tls/helpers.py
@@ -5,16 +5,14 @@
 from typing import List
 
 from pytest_operator.plugin import OpsTest
-from tenacity import retry, retry_if_not_result, stop_after_attempt, wait_exponential, retry_if_exception_type
+from tenacity import retry, stop_after_attempt, wait_fixed, wait_random
 
 from tests.integration.helpers import http_request
 
 
 @retry(
-    wait=wait_exponential(multiplier=1, min=2, max=30),
+    wait=wait_fixed(wait=3) + wait_random(1, 3),
     stop=stop_after_attempt(15),
-    retry_error_callback=(lambda state: state.outcome.result()),
-    retry=(retry_if_not_result(lambda result: True if result else False) | retry_if_exception_type()),
 )
 async def check_security_index_initialised(ops_test: OpsTest, unit_ip: str) -> bool:
     """Returns whether the security index is initialised.
@@ -36,10 +34,8 @@ async def check_security_index_initialised(ops_test: OpsTest, unit_ip: str) -> b
 
 
 @retry(
-    wait=wait_exponential(multiplier=1, min=2, max=30),
+    wait=wait_fixed(wait=3) + wait_random(1, 3),
     stop=stop_after_attempt(15),
-    retry_error_callback=(lambda state: state.outcome.result()),
-    retry=(retry_if_not_result(lambda result: True if result else False) | retry_if_exception_type()),
 )
 async def check_unit_tls_configured(ops_test: OpsTest, unit_ip: str, unit_name: str) -> bool:
     """Returns whether TLS is enabled on the specific OpenSearch unit.
@@ -57,10 +53,8 @@ async def check_unit_tls_configured(ops_test: OpsTest, unit_ip: str, unit_name: 
 
 
 @retry(
-    wait=wait_exponential(multiplier=1, min=2, max=30),
+    wait=wait_fixed(wait=3) + wait_random(1, 3),
     stop=stop_after_attempt(15),
-    retry_error_callback=(lambda state: state.outcome.result()),
-    retry=(retry_if_not_result(lambda result: True if result else False) | retry_if_exception_type()),
 )
 async def check_cluster_formation_successful(
     ops_test: OpsTest, unit_ip: str, unit_names: List[str]

--- a/tests/integration/tls/helpers.py
+++ b/tests/integration/tls/helpers.py
@@ -5,7 +5,7 @@
 from typing import List
 
 from pytest_operator.plugin import OpsTest
-from tenacity import retry, retry_if_not_result, stop_after_attempt, wait_exponential
+from tenacity import retry, retry_if_not_result, stop_after_attempt, wait_exponential, retry_if_exception_type
 
 from tests.integration.helpers import http_request
 
@@ -14,7 +14,7 @@ from tests.integration.helpers import http_request
     wait=wait_exponential(multiplier=1, min=2, max=30),
     stop=stop_after_attempt(15),
     retry_error_callback=(lambda state: state.outcome.result()),
-    retry=retry_if_not_result(lambda result: True if result else False),
+    retry=(retry_if_not_result(lambda result: True if result else False) | retry_if_exception_type()),
 )
 async def check_security_index_initialised(ops_test: OpsTest, unit_ip: str) -> bool:
     """Returns whether the security index is initialised.
@@ -39,7 +39,7 @@ async def check_security_index_initialised(ops_test: OpsTest, unit_ip: str) -> b
     wait=wait_exponential(multiplier=1, min=2, max=30),
     stop=stop_after_attempt(15),
     retry_error_callback=(lambda state: state.outcome.result()),
-    retry=retry_if_not_result(lambda result: True if result else False),
+    retry=(retry_if_not_result(lambda result: True if result else False) | retry_if_exception_type()),
 )
 async def check_unit_tls_configured(ops_test: OpsTest, unit_ip: str, unit_name: str) -> bool:
     """Returns whether TLS is enabled on the specific OpenSearch unit.
@@ -60,7 +60,7 @@ async def check_unit_tls_configured(ops_test: OpsTest, unit_ip: str, unit_name: 
     wait=wait_exponential(multiplier=1, min=2, max=30),
     stop=stop_after_attempt(15),
     retry_error_callback=(lambda state: state.outcome.result()),
-    retry=retry_if_not_result(lambda result: True if result else False),
+    retry=(retry_if_not_result(lambda result: True if result else False) | retry_if_exception_type()),
 )
 async def check_cluster_formation_successful(
     ops_test: OpsTest, unit_ip: str, unit_names: List[str]


### PR DESCRIPTION
This PR contains: 
- Increase in retry intervals for integration tests that consume HTTP endpoints, to throttle requests
- addition of randomness in the retry waits