### PR TITLE
Implemented horizontal scale-up

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,7 +82,6 @@ jobs:
           sudo sysctl -w net.ipv4.tcp_retries2=5
           
           tox -e ha-integration
-
       - name: Setup tmate session
         if: ${{ failure() }}
         uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,3 +82,7 @@ jobs:
           sudo sysctl -w net.ipv4.tcp_retries2=5
           
           tox -e ha-integration
+
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,7 @@
 name: Tests
 on:
   workflow_call:
+  pull_request:
   push:
     branches:
       - main
@@ -65,22 +66,3 @@ jobs:
           sudo sysctl -w net.ipv4.tcp_retries2=5
           
           tox -e tls-integration
-
-    integration-test-lxd-ha:
-      name: Integration tests for HA (lxd)
-      runs-on: ubuntu-22.04
-      steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          provider: lxd
-      - name: Run integration tests
-        run: |
-          # set sysctl values in case the cloudinit-userdata not applied
-          sudo sysctl -w vm.max_map_count=262144
-          sudo sysctl -w vm.swappiness=0
-          sudo sysctl -w net.ipv4.tcp_retries2=5
-          
-          tox -e ha-integration

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,3 +65,22 @@ jobs:
           sudo sysctl -w net.ipv4.tcp_retries2=5
           
           tox -e tls-integration
+
+    integration-test-lxd-ha:
+      name: Integration tests for HA (lxd)
+      runs-on: ubuntu-22.04
+      steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: lxd
+      - name: Run integration tests
+        run: |
+          # set sysctl values in case the cloudinit-userdata not applied
+          sudo sysctl -w vm.max_map_count=262144
+          sudo sysctl -w vm.swappiness=0
+          sudo sysctl -w net.ipv4.tcp_retries2=5
+          
+          tox -e ha-integration

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,6 @@ name: Tests
 on:
   workflow_call:
   pull_request:
-  push:
-    branches:
-      - main
 
 jobs:
   lint:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,3 +66,22 @@ jobs:
           sudo sysctl -w net.ipv4.tcp_retries2=5
           
           tox -e tls-integration
+
+  integration-test-lxd-ha:
+    name: Integration tests for HA (lxd)
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: lxd
+      - name: Run integration tests
+        run: |
+          # set sysctl values in case the cloudinit-userdata not applied
+          sudo sysctl -w vm.max_map_count=262144
+          sudo sysctl -w vm.swappiness=0
+          sudo sysctl -w net.ipv4.tcp_retries2=5
+          
+          tox -e ha-integration

--- a/lib/charms/opensearch/v0/constants_charm.py
+++ b/lib/charms/opensearch/v0/constants_charm.py
@@ -18,6 +18,7 @@ LIBPATCH = 1
 WaitingToStart = "Waiting for OpenSearch to start..."
 InstallError = "Could not install OpenSearch."
 CertsExpirationError = "The certificates: {} need to be refreshed."
+WaitingForBusyShards = "The shards: {} need to complete building."
 TLSNotFullyConfigured = "Waiting for TLS to be fully configured..."
 TLSRelationBrokenError = (
     "Relation broken with the TLS Operator while TLS not fully configured. Stopping OpenSearch."

--- a/lib/charms/opensearch/v0/helper_cluster.py
+++ b/lib/charms/opensearch/v0/helper_cluster.py
@@ -127,7 +127,7 @@ class ClusterState:
     def busy_shards_by_unit(
         opensearch: OpenSearchDistribution, host: str = None
     ) -> Dict[str, List[str]]:
-        """Get the busy shards of the indexes of the cluster."""
+        """Get the busy shards of each index in the cluster."""
         shards = ClusterState.shards(opensearch, host)
 
         busy_shards = {}

--- a/lib/charms/opensearch/v0/helper_conf_setter.py
+++ b/lib/charms/opensearch/v0/helper_conf_setter.py
@@ -241,36 +241,36 @@ class YamlConfigSetter:
             return
 
         try:
-            leaf_level = self.__leaf_level(source, node_keys)
+            leaf_container = self.__leaf_container(source, node_keys)
             leaf_key = node_keys.pop(0)
 
-            if leaf_key in leaf_level and (
-                isinstance(leaf_level[leaf_key], Mapping) or not leaf_key.startswith("[")
-            ):
-                del leaf_level[leaf_key]
+            # remove simple type elements and entire collections by key
+            if leaf_key in leaf_container and not leaf_key[0] not in {"{", "["}:
+                del leaf_container[leaf_key]
                 return
 
+            # remove element from set
             if leaf_key.startswith("{"):
-                leaf_level.remove(leaf_key[1:-1])
+                leaf_container.remove(leaf_key[1:-1])
                 return
 
-            # list
-            target_index = self.__target_array_index(leaf_level, leaf_key)
-            del leaf_level[target_index]
+            # remove element from list
+            target_index = self.__target_array_index(leaf_container, leaf_key)
+            del leaf_container[target_index]
         except AttributeError:
             # element not found
             pass
 
-    def __leaf_level(self, current, node_names: List[str]):
+    def __leaf_container(self, current, node_names: List[str]):
         if len(node_names) == 1:
             return current
 
         current_key = node_names.pop(0)
         if current_key.startswith("[") and current_key.endswith("]"):
             target_index = self.__target_array_index(current, current_key)
-            return self.__leaf_level(current[target_index], node_names)
+            return self.__leaf_container(current[target_index], node_names)
 
-        return self.__leaf_level(current[current_key], node_names)
+        return self.__leaf_container(current[current_key], node_names)
 
     @staticmethod
     def __target_array_index(source: list, node_key: str) -> int:
@@ -303,7 +303,7 @@ class YamlConfigSetter:
         """Reformat a multiline YAML array into one with square braces."""
         leaf_k = node_keys[-1]
 
-        leaf_l = self.__leaf_level(data, node_keys)
+        leaf_l = self.__leaf_container(data, node_keys)
         leaf_l[leaf_k] = self.__flow_style()
         leaf_l[leaf_k].extend(val)
 

--- a/lib/charms/opensearch/v0/helper_conf_setter.py
+++ b/lib/charms/opensearch/v0/helper_conf_setter.py
@@ -245,7 +245,7 @@ class YamlConfigSetter:
             leaf_key = node_keys.pop(0)
 
             # remove simple type elements and entire collections by key
-            if leaf_key in leaf_container and not leaf_key[0] not in {"{", "["}:
+            if leaf_key in leaf_container and leaf_key[0] not in {"{", "["}:
                 del leaf_container[leaf_key]
                 return
 

--- a/lib/charms/opensearch/v0/helper_conf_setter.py
+++ b/lib/charms/opensearch/v0/helper_conf_setter.py
@@ -240,22 +240,26 @@ class YamlConfigSetter:
         if source is None:
             return
 
-        leaf_level = self.__leaf_level(source, node_keys)
-        leaf_key = node_keys.pop(0)
+        try:
+            leaf_level = self.__leaf_level(source, node_keys)
+            leaf_key = node_keys.pop(0)
 
-        if leaf_key in leaf_level and (
-            isinstance(leaf_level[leaf_key], Mapping) or not leaf_key.startswith("[")
-        ):
-            del leaf_level[leaf_key]
-            return
+            if leaf_key in leaf_level and (
+                isinstance(leaf_level[leaf_key], Mapping) or not leaf_key.startswith("[")
+            ):
+                del leaf_level[leaf_key]
+                return
 
-        if leaf_key.startswith("{"):
-            leaf_level.remove(leaf_key[1:-1])
-            return
+            if leaf_key.startswith("{"):
+                leaf_level.remove(leaf_key[1:-1])
+                return
 
-        # list
-        target_index = self.__target_array_index(leaf_level, leaf_key)
-        del leaf_level[target_index]
+            # list
+            target_index = self.__target_array_index(leaf_level, leaf_key)
+            del leaf_level[target_index]
+        except AttributeError:
+            # element not found
+            pass
 
     def __leaf_level(self, current, node_names: List[str]):
         if len(node_names) == 1:

--- a/lib/charms/opensearch/v0/helper_conf_setter.py
+++ b/lib/charms/opensearch/v0/helper_conf_setter.py
@@ -259,6 +259,7 @@ class YamlConfigSetter:
             del leaf_container[target_index]
         except AttributeError:
             # element not found
+            logger.debug("Target element not found.")
             pass
 
     def __leaf_container(self, current, node_names: List[str]):

--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -304,14 +304,14 @@ class OpenSearchDistribution(ABC):
         if max_map_count < 262144:
             missing_requirements.append("vm.max_map_count should be at least 262144")
 
-        swappiness = int(subprocess.getoutput("sysctl vm.swappiness").split("=")[-1].strip())
-        if swappiness > 0:
-            missing_requirements.append("vm.swappiness should be 0")
-
-        tcp_retries = int(
-            subprocess.getoutput("sysctl net.ipv4.tcp_retries2").split("=")[-1].strip()
-        )
-        if tcp_retries > 5:
-            missing_requirements.append("net.ipv4.tcp_retries2 should be 5")
+        # swappiness = int(subprocess.getoutput("sysctl vm.swappiness").split("=")[-1].strip())
+        # if swappiness > 0:
+        #     missing_requirements.append("vm.swappiness should be 0")
+        #
+        # tcp_retries = int(
+        #     subprocess.getoutput("sysctl net.ipv4.tcp_retries2").split("=")[-1].strip()
+        # )
+        # if tcp_retries > 5:
+        #     missing_requirements.append("net.ipv4.tcp_retries2 should be 5")
 
         return missing_requirements

--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -304,14 +304,14 @@ class OpenSearchDistribution(ABC):
         if max_map_count < 262144:
             missing_requirements.append("vm.max_map_count should be at least 262144")
 
-        # swappiness = int(subprocess.getoutput("sysctl vm.swappiness").split("=")[-1].strip())
-        # if swappiness > 0:
-        #     missing_requirements.append("vm.swappiness should be 0")
-        #
-        # tcp_retries = int(
-        #     subprocess.getoutput("sysctl net.ipv4.tcp_retries2").split("=")[-1].strip()
-        # )
-        # if tcp_retries > 5:
-        #     missing_requirements.append("net.ipv4.tcp_retries2 should be 5")
+        swappiness = int(subprocess.getoutput("sysctl vm.swappiness").split("=")[-1].strip())
+        if swappiness > 0:
+            missing_requirements.append("vm.swappiness should be 0")
+
+        tcp_retries = int(
+            subprocess.getoutput("sysctl net.ipv4.tcp_retries2").split("=")[-1].strip()
+        )
+        if tcp_retries > 5:
+            missing_requirements.append("net.ipv4.tcp_retries2 should be 5")
 
         return missing_requirements

--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -3,11 +3,13 @@
 
 """Base class for Opensearch distributions."""
 
+import json
 import logging
 import os
 import pathlib
 import socket
 import subprocess
+import typing
 from abc import ABC, abstractmethod
 from os.path import exists
 from pathlib import Path
@@ -174,7 +176,7 @@ class OpenSearchDistribution(ABC):
         endpoint: str,
         payload: Optional[Dict[str, any]] = None,
         host: Optional[str] = None,
-    ) -> Dict[str, any]:
+    ) -> typing.Union[Dict[str, any], List[any]]:
         """Make an HTTP request.
 
         Args:
@@ -202,7 +204,7 @@ class OpenSearchDistribution(ABC):
                 resp = s.request(
                     method=method.upper(),
                     url=full_url,
-                    data=payload,
+                    data=json.dumps(payload),
                     verify=f"{self.paths.certs}/chain.pem",
                     headers={"Accept": "application/json", "Content-Type": "application/json"},
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ asyncio_mode = "auto"
 markers = [
     "charm_tests",
     "tls_tests",
+    "ha_tests",
 ]
 
 # Formatting tools configuration

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 bcrypt==4.0.1
-cryptography==38.0.1
-jsonschema==4.16.0
+cryptography==38.0.3
+jsonschema==4.17.0
 ops==1.5.3
 requests==2.28.1
 ruamel.yaml==0.17.21

--- a/src/charm.py
+++ b/src/charm.py
@@ -307,7 +307,9 @@ class OpenSearchOperatorCharm(OpenSearchBaseCharm):
         # defer the start until all the shards are "started"
         if self.app_peers_data.get("leader_ip"):
             try:
-                busy_shards = ClusterState.busy_shards_by_unit(self.opensearch)
+                busy_shards = ClusterState.busy_shards_by_unit(
+                    self.opensearch, self.app_peers_data.get("leader_ip")
+                )
                 if busy_shards:
                     message = WaitingForBusyShards.format(
                         " - ".join([f"{key}/{','.join(val)}" for key, val in busy_shards.items()])
@@ -315,6 +317,8 @@ class OpenSearchOperatorCharm(OpenSearchBaseCharm):
                     self.unit.status = BlockedStatus(message)
                     return False
             except OpenSearchHttpError:
+                # this means that the leader is not started yet, so it's a new cluster,
+                # we can safely start the service
                 pass
 
         try:

--- a/src/charm.py
+++ b/src/charm.py
@@ -317,8 +317,8 @@ class OpenSearchOperatorCharm(OpenSearchBaseCharm):
                     self.unit.status = BlockedStatus(message)
                     return False
             except OpenSearchHttpError:
-                # this means that the leader is not started yet, so it's a new cluster,
-                # we can safely start the service
+                # this means that the leader unit is not reachable (not started yet),
+                # meaning that it's a new cluster, so we can safely start the OpenSearch service
                 pass
 
         try:

--- a/src/charm.py
+++ b/src/charm.py
@@ -308,8 +308,9 @@ class OpenSearchOperatorCharm(OpenSearchBaseCharm):
             self.unit.status = BlockedStatus(" - ".join(missing_sys_reqs))
             return False
 
-        # check if there are shards that are "busy" or "relocating"
-        # defer the start until all the shards are "started"
+        # When a new unit joins, replica shards are automatically added to it. In order to prevent
+        # overloading the cluster, units must be started one at a time. So we defer starting
+        # opensearch until all shards in other units are in a "started" or "unassigned" state.
         if not self.unit.is_leader() and self.app_peers_data.get("leader_ip"):
             try:
                 busy_shards = ClusterState.busy_shards_by_unit(

--- a/src/opensearch.py
+++ b/src/opensearch.py
@@ -51,15 +51,7 @@ class OpenSearchSnap(OpenSearchDistribution):
             logger.error(f"Failed to install opensearch. \n{e}")
             raise OpenSearchInstallError()
 
-        plugs = [
-            "log-observe",
-            "mount-observe",
-            "process-control",
-            "procsys-read",
-            "system-observe",
-        ]
-        for plug in plugs:
-            self._run_cmd(f"snap connect opensearch:{plug}")
+        self._run_cmd("snap connect opensearch:process-control")
 
     def start(self):
         """Start the snap exposed "daemon" service."""
@@ -132,7 +124,7 @@ class OpenSearchTarball(OpenSearchDistribution):
         """Temporary (will be deleted later) - Download and Un-tar the opensearch distro."""
         try:
             response = requests.get(
-                "https://artifacts.opensearch.org/releases/bundle/opensearch/2.3.0/opensearch-2.3.0-linux-x64.tar.gz"
+                "https://artifacts.opensearch.org/releases/bundle/opensearch/2.4.0/opensearch-2.4.0-linux-x64.tar.gz"
             )
 
             tarball_path = "opensearch.tar.gz"

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+from typing import Dict, List
+
+from pytest_operator.plugin import OpsTest
+from tenacity import retry, stop_after_attempt, wait_fixed, wait_random
+
+from tests.integration.helpers import http_request
+
+
+@retry(
+    wait=wait_fixed(wait=5) + wait_random(0, 5),
+    stop=stop_after_attempt(15),
+)
+async def get_shards_by_status(ops_test: OpsTest, unit_ip: str) -> Dict[str, List[str]]:
+    """Returns whether all shards are marked as STARTED.
+
+    Args:
+        ops_test: The ops test framework instance.
+        unit_ip: The ip of the OpenSearch unit.
+
+    Returns:
+        Whether all indexes have been successfully replicated and shards started.
+    """
+    response = await http_request(
+        ops_test,
+        f"https://{unit_ip}:9200/_cat/shards",
+        "GET",
+    )
+
+    indexes_by_status = {}
+    for shard in response:
+        status = shard["status"]
+        if status not in indexes_by_status:
+            indexes_by_status[status] = []
+
+        indexes_by_status[status].append(f"{shard['node']}/{shard['index']}")
+
+    return indexes_by_status

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -14,7 +14,7 @@ from tests.integration.helpers import http_request
     stop=stop_after_attempt(15),
 )
 async def get_shards_by_status(ops_test: OpsTest, unit_ip: str) -> Dict[str, List[str]]:
-    """Returns whether all shards are marked as STARTED.
+    """Returns all shard statuses for all indexes in the cluster.
 
     Args:
         ops_test: The ops test framework instance.

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -13,7 +13,7 @@ from tests.integration.helpers import http_request
     wait=wait_fixed(wait=5) + wait_random(0, 5),
     stop=stop_after_attempt(15),
 )
-async def get_shards_by_status(ops_test: OpsTest, unit_ip: str) -> Dict[str, List[str]]:
+async def get_shards_by_state(ops_test: OpsTest, unit_ip: str) -> Dict[str, List[str]]:
     """Returns all shard statuses for all indexes in the cluster.
 
     Args:
@@ -31,10 +31,10 @@ async def get_shards_by_status(ops_test: OpsTest, unit_ip: str) -> Dict[str, Lis
 
     indexes_by_status = {}
     for shard in response:
-        status = shard["status"]
-        if status not in indexes_by_status:
-            indexes_by_status[status] = []
+        state = shard["state"]
+        if state not in indexes_by_status:
+            indexes_by_status[state] = []
 
-        indexes_by_status[status].append(f"{shard['node']}/{shard['index']}")
+        indexes_by_status[state].append(f"{shard['node']}/{shard['index']}")
 
     return indexes_by_status

--- a/tests/integration/ha/test_horizontal_scaling.py
+++ b/tests/integration/ha/test_horizontal_scaling.py
@@ -7,7 +7,7 @@ import logging
 import pytest
 from pytest_operator.plugin import OpsTest
 
-from tests.integration.ha.helpers import get_shards_by_status
+from tests.integration.ha.helpers import get_shards_by_state
 from tests.integration.helpers import (
     APP_NAME,
     MODEL_CONFIG,
@@ -69,7 +69,7 @@ async def test_horizontal_scale_up(ops_test: OpsTest) -> None:
 
     assert await check_cluster_formation_successful(ops_test, leader_unit_ip, unit_names)
 
-    shards_by_status = await get_shards_by_status(ops_test, leader_unit_ip)
+    shards_by_status = await get_shards_by_state(ops_test, leader_unit_ip)
     assert not shards_by_status.get("INITIALIZING")
     assert not shards_by_status.get("RELOCATING")
     assert not shards_by_status.get("UNASSIGNED")

--- a/tests/integration/ha/test_horizontal_scaling.py
+++ b/tests/integration/ha/test_horizontal_scaling.py
@@ -7,30 +7,25 @@ import logging
 import pytest
 from pytest_operator.plugin import OpsTest
 
+from tests.integration.ha.helpers import get_shards_by_status
 from tests.integration.helpers import (
     APP_NAME,
     MODEL_CONFIG,
     SERIES,
     UNIT_IDS,
     check_cluster_formation_successful,
-    get_application_unit_ips_names,
     get_application_unit_names,
     get_leader_unit_ip,
 )
-from tests.integration.tls.helpers import (
-    check_security_index_initialised,
-    check_unit_tls_configured,
-)
+from tests.integration.tls.test_tls import TLS_CERTIFICATES_APP_NAME
 
 logger = logging.getLogger(__name__)
 
-TLS_CERTIFICATES_APP_NAME = "tls-certificates-operator"
 
-
-@pytest.mark.tls_tests
+@pytest.mark.ha_tests
 @pytest.mark.abort_on_fail
 @pytest.mark.skip_if_deployed
-async def test_build_and_deploy_active(ops_test: OpsTest) -> None:
+async def test_build_and_deploy(ops_test: OpsTest) -> None:
     """Build and deploy one unit of MongoDB."""
     my_charm = await ops_test.build_charm(".")
     await ops_test.model.set_config(MODEL_CONFIG)
@@ -41,6 +36,8 @@ async def test_build_and_deploy_active(ops_test: OpsTest) -> None:
         series=SERIES,
     )
     await ops_test.model.wait_for_idle()
+
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=1000)
     assert len(ops_test.model.applications[APP_NAME].units) == len(UNIT_IDS)
 
     # Deploy TLS Certificates operator.
@@ -55,28 +52,24 @@ async def test_build_and_deploy_active(ops_test: OpsTest) -> None:
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=5000)
 
 
-@pytest.mark.tls_tests
+@pytest.mark.ha_tests
 @pytest.mark.abort_on_fail
-async def test_security_index_initialised(ops_test: OpsTest) -> None:
-    """Test that the security index is well initialised."""
-    # Wait for the leader unit to initialize the security index.
-    leader_unit_ip = await get_leader_unit_ip(ops_test)
-    assert await check_security_index_initialised(ops_test, leader_unit_ip)
+async def test_horizontal_scale_up(ops_test: OpsTest) -> None:
+    """Tests that new added units to the cluster are discoverable."""
+    # scale up
+    await ops_test.model.applications[APP_NAME].scale(scale_change=2)
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME], status="active", timeout=1000, wait_for_exact_units=5
+    )
+    num_units = len(ops_test.model.applications[APP_NAME].units)
+    assert num_units == 5
 
-
-@pytest.mark.tls_tests
-@pytest.mark.abort_on_fail
-async def test_tls_configured(ops_test: OpsTest) -> None:
-    """Test that TLS is enabled when relating to the TLS Certificates Operator."""
-    for unit_name, unit_ip in get_application_unit_ips_names(ops_test).items():
-        assert await check_unit_tls_configured(ops_test, unit_ip, unit_name)
-
-
-@pytest.mark.tls_tests
-@pytest.mark.abort_on_fail
-async def test_cluster_formation_after_tls(ops_test: OpsTest) -> None:
-    """Test that the cluster formation is successful after TLS setup."""
     unit_names = get_application_unit_names(ops_test)
     leader_unit_ip = await get_leader_unit_ip(ops_test)
 
     assert await check_cluster_formation_successful(ops_test, leader_unit_ip, unit_names)
+
+    shards_by_status = await get_shards_by_status(ops_test, leader_unit_ip)
+    assert not shards_by_status["INITIALIZING"]
+    assert not shards_by_status["RELOCATING"]
+    assert not shards_by_status["UNASSIGNED"]

--- a/tests/integration/ha/test_horizontal_scaling.py
+++ b/tests/integration/ha/test_horizontal_scaling.py
@@ -32,13 +32,13 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
 
     await ops_test.model.deploy(
         my_charm,
-        num_units=len(UNIT_IDS),
+        num_units=1,
         series=SERIES,
     )
     await ops_test.model.wait_for_idle()
 
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=1000)
-    assert len(ops_test.model.applications[APP_NAME].units) == len(UNIT_IDS)
+    assert len(ops_test.model.applications[APP_NAME].units) == 1
 
     # Deploy TLS Certificates operator.
     config = {"generate-self-signed-certificates": "true", "ca-common-name": "CN_CA"}
@@ -59,10 +59,10 @@ async def test_horizontal_scale_up(ops_test: OpsTest) -> None:
     # scale up
     await ops_test.model.applications[APP_NAME].add_unit(count=2)
     await ops_test.model.wait_for_idle(
-        apps=[APP_NAME], status="active", timeout=1000, wait_for_exact_units=5
+        apps=[APP_NAME], status="active", timeout=1000, wait_for_exact_units=3
     )
     num_units = len(ops_test.model.applications[APP_NAME].units)
-    assert num_units == 5
+    assert num_units == 3
 
     unit_names = get_application_unit_names(ops_test)
     leader_unit_ip = await get_leader_unit_ip(ops_test)

--- a/tests/integration/ha/test_horizontal_scaling.py
+++ b/tests/integration/ha/test_horizontal_scaling.py
@@ -49,7 +49,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
 
     # Relate it to OpenSearch to set up TLS.
     await ops_test.model.relate(APP_NAME, TLS_CERTIFICATES_APP_NAME)
-    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=5000)
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
 
 
 @pytest.mark.ha_tests

--- a/tests/integration/ha/test_horizontal_scaling.py
+++ b/tests/integration/ha/test_horizontal_scaling.py
@@ -57,7 +57,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
 async def test_horizontal_scale_up(ops_test: OpsTest) -> None:
     """Tests that new added units to the cluster are discoverable."""
     # scale up
-    await ops_test.model.applications[APP_NAME].scale(scale_change=2)
+    await ops_test.model.applications[APP_NAME].add_unit(count=2)
     await ops_test.model.wait_for_idle(
         apps=[APP_NAME], status="active", timeout=1000, wait_for_exact_units=5
     )
@@ -70,6 +70,6 @@ async def test_horizontal_scale_up(ops_test: OpsTest) -> None:
     assert await check_cluster_formation_successful(ops_test, leader_unit_ip, unit_names)
 
     shards_by_status = await get_shards_by_status(ops_test, leader_unit_ip)
-    assert not shards_by_status["INITIALIZING"]
-    assert not shards_by_status["RELOCATING"]
-    assert not shards_by_status["UNASSIGNED"]
+    assert not shards_by_status.get("INITIALIZING")
+    assert not shards_by_status.get("RELOCATING")
+    assert not shards_by_status.get("UNASSIGNED")

--- a/tests/integration/ha/test_horizontal_scaling.py
+++ b/tests/integration/ha/test_horizontal_scaling.py
@@ -12,7 +12,6 @@ from tests.integration.helpers import (
     APP_NAME,
     MODEL_CONFIG,
     SERIES,
-    UNIT_IDS,
     check_cluster_formation_successful,
     get_application_unit_names,
     get_leader_unit_ip,

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -10,6 +10,7 @@ import requests
 import yaml
 from ops.model import StatusBase
 from pytest_operator.plugin import OpsTest
+from tenacity import retry, stop_after_attempt, wait_fixed, wait_random
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
@@ -18,6 +19,17 @@ SERIES = "jammy"
 UNIT_IDS = [0, 1, 2]
 
 TARBALL_INSTALL_CERTS_DIR = "/etc/opensearch/config/certificates"
+
+MODEL_CONFIG = {
+    "logging-config": "<root>=INFO;unit=DEBUG",
+    "update-status-hook-interval": "1m",
+    "cloudinit-userdata": """postruncmd:
+        - [ 'sysctl', '-w', 'vm.max_map_count=262144' ]
+        - [ 'sysctl', '-w', 'fs.file-max=1048576' ]
+        - [ 'sysctl', '-w', 'vm.swappiness=0' ]
+        - [ 'sysctl', '-w', 'net.ipv4.tcp_retries2=5' ]
+    """,
+}
 
 
 logger = logging.getLogger(__name__)
@@ -139,3 +151,40 @@ async def http_request(
             return resp.status_code
 
         return resp.json()
+
+
+@retry(
+    wait=wait_fixed(wait=5) + wait_random(0, 5),
+    stop=stop_after_attempt(15),
+)
+async def check_cluster_formation_successful(
+    ops_test: OpsTest, unit_ip: str, unit_names: List[str]
+) -> bool:
+    """Returns whether the cluster formation was successful and all nodes successfully joined.
+
+    Args:
+        ops_test: The ops test framework instance.
+        unit_ip: The ip of the unit of the OpenSearch unit.
+        unit_names: The list of unit names in the cluster.
+
+    Returns:
+        Whether The cluster formation is successful.
+    """
+    unit_names_set = set(unit_names)
+
+    response = await http_request(ops_test, f"https://{unit_ip}:9200/_nodes", "GET")
+    if "_nodes" not in response or "nodes" not in response:
+        return False
+
+    successful_nodes = response["_nodes"]["successful"]
+    if successful_nodes < len(unit_names):
+        return False
+
+    for node_id, node_desc in response["nodes"].items():
+        node_name = node_desc["name"]
+        if node_name not in unit_names_set:
+            return False
+
+        unit_names_set.remove(node_name)
+
+    return len(unit_names_set) == 0

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -170,8 +170,6 @@ async def check_cluster_formation_successful(
     Returns:
         Whether The cluster formation is successful.
     """
-    unit_names_set = set(unit_names)
-
     response = await http_request(ops_test, f"https://{unit_ip}:9200/_nodes", "GET")
     if "_nodes" not in response or "nodes" not in response:
         return False
@@ -180,11 +178,5 @@ async def check_cluster_formation_successful(
     if successful_nodes < len(unit_names):
         return False
 
-    for node_id, node_desc in response["nodes"].items():
-        node_name = node_desc["name"]
-        if node_name not in unit_names_set:
-            return False
-
-        unit_names_set.remove(node_name)
-
-    return len(unit_names_set) == 0
+    registered_nodes = [node_desc["name"] for node_desc in response["nodes"].values()]
+    return set(unit_names) == set(registered_nodes)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -7,7 +7,7 @@ import logging
 import pytest
 from pytest_operator.plugin import OpsTest
 
-from tests.integration.helpers import APP_NAME, SERIES, UNIT_IDS
+from tests.integration.helpers import APP_NAME, MODEL_CONFIG, SERIES, UNIT_IDS
 
 logger = logging.getLogger(__name__)
 
@@ -18,18 +18,7 @@ logger = logging.getLogger(__name__)
 async def test_build_and_deploy(ops_test: OpsTest) -> None:
     """Build and deploy one unit of MongoDB."""
     my_charm = await ops_test.build_charm(".")
-    await ops_test.model.set_config(
-        {
-            "logging-config": "<root>=INFO;unit=DEBUG",
-            "update-status-hook-interval": "1m",
-            "cloudinit-userdata": """postruncmd:
-                - [ 'sysctl', '-w', 'vm.max_map_count=262144' ]
-                - [ 'sysctl', '-w', 'fs.file-max=1048576' ]
-                - [ 'sysctl', '-w', 'vm.swappiness=0' ]
-                - [ 'sysctl', '-w', 'net.ipv4.tcp_retries2=5' ]
-        """,
-        }
-    )
+    await ops_test.model.set_config(MODEL_CONFIG)
 
     await ops_test.model.deploy(
         my_charm,

--- a/tests/integration/tls/helpers.py
+++ b/tests/integration/tls/helpers.py
@@ -2,8 +2,6 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from typing import List
-
 from pytest_operator.plugin import OpsTest
 from tenacity import retry, stop_after_attempt, wait_fixed, wait_random
 
@@ -50,40 +48,3 @@ async def check_unit_tls_configured(ops_test: OpsTest, unit_ip: str, unit_name: 
     """
     response = await http_request(ops_test, f"https://{unit_ip}:9200", "GET")
     return response["name"] == unit_name
-
-
-@retry(
-    wait=wait_fixed(wait=5) + wait_random(0, 5),
-    stop=stop_after_attempt(15),
-)
-async def check_cluster_formation_successful(
-    ops_test: OpsTest, unit_ip: str, unit_names: List[str]
-) -> bool:
-    """Returns whether TLS is enabled on the specific OpenSearch unit.
-
-    Args:
-        ops_test: The ops test framework instance.
-        unit_ip: The ip of the unit of the OpenSearch unit.
-        unit_names: The list of unit names in the cluster.
-
-    Returns:
-        Whether TLS is well configured.
-    """
-    unit_names_set = set(unit_names)
-
-    response = await http_request(ops_test, f"https://{unit_ip}:9200/_nodes", "GET")
-    if "_nodes" not in response or "nodes" not in response:
-        return False
-
-    successful_nodes = response["_nodes"]["successful"]
-    if successful_nodes < len(unit_names):
-        return False
-
-    for node_id, node_desc in response["nodes"].items():
-        node_name = node_desc["name"]
-        if node_name not in unit_names_set:
-            return False
-
-        unit_names_set.remove(node_name)
-
-    return len(unit_names_set) == 0

--- a/tests/integration/tls/test_tls.py
+++ b/tests/integration/tls/test_tls.py
@@ -52,7 +52,7 @@ async def test_build_and_deploy_active(ops_test: OpsTest) -> None:
 
     # Relate it to OpenSearch to set up TLS.
     await ops_test.model.relate(APP_NAME, TLS_CERTIFICATES_APP_NAME)
-    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=5000)
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
 
 
 @pytest.mark.tls_tests

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -14,12 +14,14 @@ from charms.opensearch.v0.opensearch_distro import (
     OpenSearchHttpError,
     OpenSearchInstallError,
 )
+from helpers import patch_network_get
 from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
 
 from charm import OpenSearchOperatorCharm
 
 
+@patch_network_get("1.1.1.1")
 class TestCharm(unittest.TestCase):
     @patch("charms.opensearch.v0.opensearch_distro.OpenSearchDistribution._create_directories")
     def setUp(self, _create_directories):
@@ -56,6 +58,7 @@ class TestCharm(unittest.TestCase):
     def test_on_leader_elected_index_initialised(self, _initialize_admin_user):
         # security_index_initialised
         self.charm.app_peers_data["security_index_initialised"] = "True"
+        self.harness.set_leader(True)
         self.charm.on.leader_elected.emit()
         _initialize_admin_user.assert_not_called()
 

--- a/tests/unit/test_helper_cluster.py
+++ b/tests/unit/test_helper_cluster.py
@@ -4,59 +4,86 @@
 """Unit test for the helper_cluster library."""
 
 import unittest
+from unittest.mock import patch
 
-from charms.opensearch.v0.helper_cluster import ClusterTopology, Node
+from charms.opensearch.v0.helper_cluster import ClusterState, ClusterTopology, Node
+from ops.testing import Harness
+
+from charm import OpenSearchOperatorCharm
 
 
 class TestHelperCluster(unittest.TestCase):
-    def setUp(self) -> None:
-        self.cluster_topology = ClusterTopology()
+    @patch("charms.opensearch.v0.opensearch_distro.OpenSearchDistribution._create_directories")
+    def setUp(self, _create_directories) -> None:
+        self.harness = Harness(OpenSearchOperatorCharm)
+        self.addCleanup(self.harness.cleanup)
+        self.harness.begin()
+        self.charm = self.harness.charm
+
+        self.opensearch = self.charm.opensearch
+
         self.nodes_0 = []
         self.nodes_1 = [Node("cm1", ["cluster_manager", "data"], "2.2.2.2")]
         self.nodes_2 = self.nodes_1 + [Node("data1", ["voting_only", "data"], "2.2.2.3")]
         self.nodes_3 = self.nodes_2 + [Node("cm2", ["cluster_manager", "data"], "2.2.2.4")]
         self.nodes_4 = self.nodes_3 + [Node("data2", ["data"], "2.2.2.5")]
 
-    def test_roles_suggestion(self):
+    def test_topology_roles_suggestion(self):
         """Test the suggestion of roles for a new node."""
         self.assertCountEqual(
-            self.cluster_topology.suggest_roles(self.nodes_0), ["cluster_manager", "data"]
+            ClusterTopology.suggest_roles(self.nodes_0), ["cluster_manager", "data"]
         )
+        self.assertCountEqual(ClusterTopology.suggest_roles(self.nodes_1), ["voting_only", "data"])
         self.assertCountEqual(
-            self.cluster_topology.suggest_roles(self.nodes_1), ["voting_only", "data"]
+            ClusterTopology.suggest_roles(self.nodes_2), ["cluster_manager", "data"]
         )
-        self.assertCountEqual(
-            self.cluster_topology.suggest_roles(self.nodes_2), ["cluster_manager", "data"]
-        )
-        self.assertCountEqual(self.cluster_topology.suggest_roles(self.nodes_3), ["data"])
+        self.assertCountEqual(ClusterTopology.suggest_roles(self.nodes_3), ["data"])
 
-    def test_remaining_nodes_for_bootstrap(self):
+    def test_topology_remaining_nodes_for_bootstrap(self):
         """Test if cluster is bootstrapped."""
-        self.assertTrue(self.cluster_topology.remaining_nodes_for_bootstrap(self.nodes_0) == 3)
-        self.assertTrue(self.cluster_topology.remaining_nodes_for_bootstrap(self.nodes_1) == 2)
-        self.assertTrue(self.cluster_topology.remaining_nodes_for_bootstrap(self.nodes_2) == 1)
-        self.assertTrue(self.cluster_topology.remaining_nodes_for_bootstrap(self.nodes_3) == 0)
-        self.assertTrue(self.cluster_topology.remaining_nodes_for_bootstrap(self.nodes_4) == 0)
+        self.assertTrue(ClusterTopology.remaining_nodes_for_bootstrap(self.nodes_0) == 3)
+        self.assertTrue(ClusterTopology.remaining_nodes_for_bootstrap(self.nodes_1) == 2)
+        self.assertTrue(ClusterTopology.remaining_nodes_for_bootstrap(self.nodes_2) == 1)
+        self.assertTrue(ClusterTopology.remaining_nodes_for_bootstrap(self.nodes_3) == 0)
+        self.assertTrue(ClusterTopology.remaining_nodes_for_bootstrap(self.nodes_4) == 0)
 
-    def test_get_cluster_managers_ips(self):
+    def test_topology_get_cluster_managers_ips(self):
         """Test correct retrieval of cm ips from a list of nodes."""
         self.assertCountEqual(
-            self.cluster_topology.get_cluster_managers_ips(self.nodes_4), ["2.2.2.2", "2.2.2.4"]
+            ClusterTopology.get_cluster_managers_ips(self.nodes_4), ["2.2.2.2", "2.2.2.4"]
         )
 
-    def test_get_cluster_managers_names(self):
+    def test_topology_get_cluster_managers_names(self):
         """Test correct retrieval of cm ips from a list of nodes."""
         self.assertCountEqual(
-            self.cluster_topology.get_cluster_managers_names(self.nodes_4), ["cm1", "cm2"]
+            ClusterTopology.get_cluster_managers_names(self.nodes_4), ["cm1", "cm2"]
         )
 
-    def test_nodes_count_by_role(self):
+    def test_topology_nodes_count_by_role(self):
         """Test correct mapping role / count of nodes with the role."""
         self.assertDictEqual(
-            self.cluster_topology.nodes_count_by_role(self.nodes_4),
+            ClusterTopology.nodes_count_by_role(self.nodes_4),
             {
                 "cluster_manager": 2,
                 "voting_only": 1,
                 "data": 4,
             },
+        )
+
+    @patch("charms.opensearch.v0.helper_cluster.ClusterState.shards")
+    def test_state_busy_shards_by_unit(self, shards):
+        """Test the busy shards filtering."""
+        shards.return_value = [
+            {"index": "index1", "state": "STARTED", "node": "opensearch-0"},
+            {"index": "index1", "state": "INITIALIZING", "node": "opensearch-1"},
+            {"index": "index2", "state": "STARTED", "node": "opensearch-0"},
+            {"index": "index2", "state": "RELOCATING", "node": "opensearch-1"},
+            {"index": "index3", "state": "STARTED", "node": "opensearch-0"},
+            {"index": "index3", "state": "STARTED", "node": "opensearch-1"},
+            {"index": "index4", "state": "STARTED", "node": "opensearch-2"},
+            {"index": "index4", "state": "INITIALIZING", "node": "opensearch-2"},
+        ]
+        self.assertDictEqual(
+            ClusterState.busy_shards_by_unit(self.opensearch),
+            {"opensearch-1": ["index1", "index2"], "opensearch-2": ["index4"]},
         )

--- a/tests/unit/test_helper_conf_setter.py
+++ b/tests/unit/test_helper_conf_setter.py
@@ -72,6 +72,8 @@ class TestHelperConfSetter(unittest.TestCase):
         self.conf.delete(input_file, "simple_key", output_file=output_file)
         self.assertFalse("simple_key" in self.conf.load(output_file))
 
+        self.conf.delete(input_file, "non_existing_key.non_existing", output_file=output_file)
+
         self.conf.delete(input_file, "obj/simple_array/[1]", output_file=output_file)
         self.assertFalse("elt2" in self.conf.load(output_file)["obj"]["simple_array"])
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,8 @@ envlist = lint, unit
 [vars]
 src_path = {toxinidir}/src/
 tst_path = {toxinidir}/tests/
-;lib_path = {toxinidir}/lib/charms/operator_name_with_underscores
-all_path = {[vars]src_path} {[vars]tst_path} 
+lib_path = {toxinidir}/lib/charms/opensearch/v0/
+all_path = {[vars]src_path} {[vars]lib_path} {[vars]tst_path}
 
 [testenv]
 setenv =
@@ -45,7 +45,7 @@ deps =
     codespell
 commands =
     # uncomment the following line if this charm owns a lib
-    # codespell {[vars]lib_path}
+    codespell {[vars]lib_path}
     codespell {toxinidir}/. --skip {toxinidir}/.git --skip {toxinidir}/.tox \
       --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
       --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
@@ -58,10 +58,11 @@ commands =
 description = Run unit tests
 deps =
     pytest
+    pytest-asyncio
     coverage[toml]
     -r{toxinidir}/requirements.txt
 commands =
-    coverage run --source={[vars]src_path} \
+    coverage run --source={[vars]src_path} --source={[vars]lib_path} \
         -m pytest --ignore={[vars]tst_path}integration -v --tb native -s {posargs}
     coverage report
 
@@ -69,6 +70,7 @@ commands =
 description = Run charm integration tests
 deps =
     pytest
+    pytest-asyncio
     juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
     pytest-operator
     -r{toxinidir}/requirements.txt
@@ -79,6 +81,7 @@ commands =
 description = Run TLS integration tests
 deps =
     pytest
+    pytest-asyncio
     juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
     pytest-operator
     -r{toxinidir}/requirements.txt
@@ -89,6 +92,7 @@ commands =
 description = Run HA integration tests
 deps =
     pytest
+    pytest-asyncio
     juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
     pytest-operator
     -r{toxinidir}/requirements.txt
@@ -99,6 +103,7 @@ commands =
 description = Run all integration tests
 deps =
     pytest
+    pytest-asyncio
     juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
     pytest-operator
     -r{toxinidir}/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -85,6 +85,16 @@ deps =
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} -m tls_tests
 
+[testenv:ha-integration]
+description = Run HA integration tests
+deps =
+    pytest
+    juju==2.9.11 # juju 3.0.0 has issues with retrieving action results
+    pytest-operator
+    -r{toxinidir}/requirements.txt
+commands =
+    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} -m ha_tests
+
 [testenv:integration]
 description = Run all integration tests
 deps =


### PR DESCRIPTION
# Issue
This PR addresses [DPE-879](https://warthogs.atlassian.net/browse/DPE-879) and [DPE-881](https://warthogs.atlassian.net/browse/DPE-881) and [DPE-785](https://warthogs.atlassian.net/browse/DPE-785).
Namely, this PR addresses:
- Implementing the scale-up feature on VM charm.
- Integration and unit tests for the scale-up feature on VM charm.
- Removal of the `seed_hosts` property from the config of the cluster manager nodes once cluster bootstrapped.
- minor refactoring on the integration tests.
- Bumped version of OpenSearch to `2.4.0`

# Solution
The scale up is done automatically through OpenSearch's node discovery mechanism which was implemented on a previous PR.
However, we add the deferral of the node registration and OpenSearch start, until all shards (replicas) of the cluster are in a `STARTED` or `UNASSIGNED` state. This to reduce the network latency on the cluster.

 ## Main files to review:
- `lib/charms/opensearch/v0/helper_cluster.py`
- `src/charm.py`
- `tests/integration/ha/helpers.py`
- `tests/integration/ha/test_horizontal_scaling.py`
- `tests/unit/test_helper_cluster.py`
