### PR TITLE
Simplify relation users

### DIFF
--- a/lib/charms/opensearch/v0/constants_charm.py
+++ b/lib/charms/opensearch/v0/constants_charm.py
@@ -50,9 +50,6 @@ AdminUserInitProgress = "Configuring admin user..."
 HorizontalScaleUpSuggest = "Horizontal scale up advised: {} shards unassigned."
 WaitingForOtherUnitServiceOps = "Waiting for other units to complete the ops on their service."
 
-# Client Relation Statuses
-ClientRelationBadRoleRequestMessage = "bad relation request - client application has not provided correctly formatted extra user roles. "
-
 
 # Relation Interfaces
 ClientRelationName = "opensearch-client"

--- a/lib/charms/opensearch/v0/opensearch_relation_provider.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_provider.py
@@ -13,22 +13,16 @@ roles will be mapped to a dedicated user for the relation, which will be removed
 Default security values can be found in the opensearch documentation here:
 https://opensearch.org/docs/latest/security/access-control/index/.
 
-TODO add databag reference information
-TODO add tls
 """
 
-import json
 import logging
-from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, List
 
 from charms.data_platform_libs.v0.data_interfaces import (
     DatabaseProvides,
     DatabaseRequestedEvent,
 )
 from charms.opensearch.v0.constants_charm import (
-    ClientRelationBadRoleRequestMessage,
     ClientRelationName,
     PeerRelationName,
 )
@@ -70,7 +64,7 @@ class ExtraUserRolePermissions(Enum):
         "cluster_permissions": ["cluster_monitor"],
         "index_permissions": [
             {
-                "index_patterns": [],
+                "index_patterns": [TODO index name goes here],
                 "dls": "",
                 "fls": [],
                 "masked_fields": [],

--- a/tests/integration/relations/opensearch_provider/application-charm/src/charm.py
+++ b/tests/integration/relations/opensearch_provider/application-charm/src/charm.py
@@ -37,10 +37,7 @@ class ApplicationCharm(CharmBase):
         # (these events are defined in the database requires charm library).
         database_name = f'{self.app.name.replace("-", "_")}_first_database'
 
-        permissive_roles = json.dumps({"roles": ["all_access"]})
-        self.first_database = DatabaseRequires(
-            self, "first-database", database_name, permissive_roles
-        )
+        self.first_database = DatabaseRequires(self, "first-database", database_name, "")
         self.framework.observe(
             self.first_database.on.database_created, self._on_first_database_created
         )
@@ -51,16 +48,8 @@ class ApplicationCharm(CharmBase):
         # Events related to the second database that is requested
         # (these events are defined in the database requires charm library).
         database_name = f'{self.app.name.replace("-", "_")}_second_database'
-        # TODO change this to use new permissions
-        roles = {
-            "roles": ["readall"],
-            "permissions": ["TODO find some permissions", ""],
-            "action_groups": ["TODO find some action groups", ""],
-        }
-        complex_roles = json.dumps(roles)
-        self.second_database = DatabaseRequires(
-            self, "second-database", database_name, complex_roles
-        )
+
+        self.second_database = DatabaseRequires(self, "second-database", database_name, "admin")
         self.framework.observe(
             self.second_database.on.database_created, self._on_second_database_created
         )


### PR DESCRIPTION
## Proposal
Simplify relation users in line with the [spec](https://github.com/canonical/charm-relation-interfaces/tree/main/interfaces/opensearch_client/v0). Requirer charms now need to send either "admin" or "default" to receive relevant permissions. 

## Context
- These permissions are a first draft, but require focus when reviewing. 
  - [Opensearch Permissions Docs](https://opensearch.org/docs/latest/security/access-control/permissions/)

## Release Notes
- Simplify user creation to two values
- Updated tests. 

## Testing
- Integration & unit tests have been updated to match the new user permissions. 

## TODO 
- Add admin permissions list
