### PR TITLE
Snap install retry and path updates + lib update

### DIFF
--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -1019,7 +1019,7 @@ class KafkaRequiresEvent(RelationEvent):
 
     @property
     def bootstrap_server(self) -> Optional[str]:
-        """Returns a a comma-seperated list of broker uris."""
+        """Returns a comma-separated list of broker uris."""
         return self.relation.data[self.relation.app].get("endpoints")
 
     @property
@@ -1108,7 +1108,7 @@ class KafkaProvides(DataProvides):
 
         Args:
             relation_id: the identifier for a particular relation.
-            zookeeper_uris: comma-seperated list of ZooKeeper server uris.
+            zookeeper_uris: comma-separated list of ZooKeeper server uris.
         """
         self._update_relation_data(relation_id, {"zookeeper-uris": zookeeper_uris})
 
@@ -1159,12 +1159,173 @@ class KafkaRequires(DataRequires):
             # “endpoints_changed“ event if “topic_created“ is triggered.
             return
 
-        # Emit an endpoints (bootstap-server) changed event if the Kafka endpoints
+        # Emit an endpoints (bootstrap-server) changed event if the Kafka endpoints
         # added or changed this info in the relation databag.
         if "endpoints" in diff.added or "endpoints" in diff.changed:
             # Emit the default event (the one without an alias).
             logger.info("endpoints changed on %s", datetime.now())
             self.on.bootstrap_server_changed.emit(
+                event.relation, app=event.app, unit=event.unit
+            )  # here check if this is the right design
+            return
+
+
+# Opensearch related events
+
+
+class OpenSearchProvidesEvent(RelationEvent):
+    """Base class for OpenSearch events."""
+
+    @property
+    def index(self) -> Optional[str]:
+        """Returns the index that was requested."""
+        return self.relation.data[self.relation.app].get("index")
+
+
+class IndexRequestedEvent(OpenSearchProvidesEvent, ExtraRoleEvent):
+    """Event emitted when a new index is requested for use on this relation."""
+
+
+class OpenSearchProvidesEvents(CharmEvents):
+    """OpenSearch events.
+
+    This class defines the events that OpenSearch can emit.
+    """
+
+    index_requested = EventSource(IndexRequestedEvent)
+
+
+class OpenSearchRequiresEvent(DatabaseRequiresEvent):
+    """Base class for OpenSearch requirer events."""
+
+
+class IndexCreatedEvent(AuthenticationEvent, OpenSearchRequiresEvent):
+    """Event emitted when a new index is created for use on this relation."""
+
+
+class OpenSearchRequiresEvents(CharmEvents):
+    """OpenSearch events.
+
+    This class defines the events that the opensearch requirer can emit.
+    """
+
+    index_created = EventSource(IndexCreatedEvent)
+    endpoints_changed = EventSource(DatabaseEndpointsChangedEvent)
+    authentication_updated = EventSource(AuthenticationEvent)
+
+
+# OpenSearch Provides and Requires Objects
+
+
+class OpenSearchProvides(DataProvides):
+    """Provider-side of the OpenSearch relation."""
+
+    on = OpenSearchProvidesEvents()
+
+    def __init__(self, charm: CharmBase, relation_name: str) -> None:
+        super().__init__(charm, relation_name)
+
+    def _on_relation_changed(self, event: RelationChangedEvent) -> None:
+        """Event emitted when the relation has changed."""
+        # Only the leader should handle this event.
+        if not self.local_unit.is_leader():
+            return
+
+        # Check which data has changed to emit customs events.
+        diff = self._diff(event)
+
+        # Emit an index requested event if the setup key (index name and optional extra user roles)
+        # have been added to the relation databag by the application.
+        if "index" in diff.added:
+            self.on.index_requested.emit(event.relation, app=event.app, unit=event.unit)
+
+    def set_index(self, relation_id: int, index: str) -> None:
+        """Set the index in the application relation databag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            index: the index as it is _created_ on the provider charm. This needn't match the
+                requested index, and can be used to present a different index name if, for example,
+                the requested index is invalid.
+        """
+        self._update_relation_data(relation_id, {"index": index})
+
+    def set_endpoints(self, relation_id: int, endpoints: str) -> None:
+        """Set the endpoints in the application relation databag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            endpoints: the endpoint addresses for opensearch nodes.
+        """
+        self._update_relation_data(relation_id, {"endpoints": endpoints})
+
+    def set_version(self, relation_id: int, version: str) -> None:
+        """Set the database version in the application relation databag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            version: database version.
+        """
+        self._update_relation_data(relation_id, {"version": version})
+
+
+class OpenSearchRequires(DataRequires):
+    """Requires-side of the OpenSearch relation."""
+
+    on = OpenSearchRequiresEvents()
+
+    def __init__(
+            self, charm, relation_name: str, index: str, extra_user_roles: Optional[str] = None
+        ):
+        """Manager of OpenSearch client relations."""
+        super().__init__(charm, relation_name, extra_user_roles)
+        self.charm = charm
+        self.index = index
+
+    def _on_relation_joined_event(self, event: RelationJoinedEvent) -> None:
+        """Event emitted when the application joins the OpenSearch relation."""
+        # Sets both index and extra user roles in the relation if the roles are provided.
+        # Otherwise, sets only the index.
+        data = {"index": self.index}
+        if self.extra_user_roles:
+            data["extra-user-roles"] = self.extra_user_roles
+
+        self._update_relation_data(event.relation.id, data)
+
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        """Event emitted when the OpenSearch relation has changed.
+
+        This event triggers individual custom events depending on the changing relation.
+        """
+        # Check which data has changed to emit customs events.
+        diff = self._diff(event)
+
+        # Check if the index is created
+        # (the OpenSearch charm shares the credentials).
+        if "username" in diff.added and "password" in diff.added:
+            # Emit the default event (the one without an alias).
+            logger.info("index created at: %s", datetime.now())
+            self.on.index_created.emit(event.relation, app=event.app, unit=event.unit)
+
+            # To avoid unnecessary application restarts do not trigger
+            # “endpoints_changed“ or "authentication_updated" event if “index_created“ is
+            # triggered.
+            return
+
+        # Check if authentication has updated, emit event if so
+        updates = {"password", "tls", "tls-ca"}
+        if len(set(diff._asdict().keys()) - updates) < len(diff):
+            logger.info("authentication updated at: %s", datetime.now())
+            self.on.authentication_updated.emit(event.relation, app=event.app, unit=event.unit)
+
+            return
+
+        # Emit a endpoints changed event if the OpenSearch application added or changed this info
+        # in the relation databag.
+        if "endpoints" in diff.added or "endpoints" in diff.changed:
+            # Emit the default event (the one without an alias).
+            logger.info("endpoints changed on %s", datetime.now())
+            self.on.endpoints_changed.emit(
                 event.relation, app=event.app, unit=event.unit
             )  # here check if this is the right design
             return

--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -16,7 +16,7 @@
 
 This library contains the Requires and Provides classes for handling the relation
 between an application and multiple managed application supported by the data-team:
-MySQL, Postgresql, MongoDB, Redis,  and Kakfa.
+MySQL, Postgresql, MongoDB, Redis, and Kafka.
 
 ### Database (MySQL, Postgresql, MongoDB, and Redis)
 
@@ -303,7 +303,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 9
 
 PYDEPS = ["ops>=2.0.0"]
 
@@ -661,6 +661,11 @@ class DatabaseRequiresEvent(RelationEvent):
     """Base class for database events."""
 
     @property
+    def database(self) -> Optional[str]:
+        """Returns the database name."""
+        return self.relation.data[self.relation.app].get("database")
+
+    @property
     def endpoints(self) -> Optional[str]:
         """Returns a comma separated list of read/write endpoints."""
         return self.relation.data[self.relation.app].get("endpoints")
@@ -682,7 +687,7 @@ class DatabaseRequiresEvent(RelationEvent):
     def uris(self) -> Optional[str]:
         """Returns the connection URIs.
 
-        MongoDB, Redis.
+        MongoDB, Redis, OpenSearch.
         """
         return self.relation.data[self.relation.app].get("uris")
 
@@ -742,6 +747,18 @@ class DatabaseProvides(DataProvides):
         # extra user roles) was added to the relation databag by the application.
         if "database" in diff.added:
             self.on.database_requested.emit(event.relation, app=event.app, unit=event.unit)
+
+    def set_database(self, relation_id: int, database_name: str) -> None:
+        """Set database name.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            database_name: database name.
+        """
+        self._update_relation_data(relation_id, {"database": database_name})
 
     def set_endpoints(self, relation_id: int, connection_strings: str) -> None:
         """Set database primary connections.
@@ -973,6 +990,11 @@ class KafkaProvidesEvent(RelationEvent):
         """Returns the topic that was requested."""
         return self.relation.data[self.relation.app].get("topic")
 
+    @property
+    def consumer_group_prefix(self) -> Optional[str]:
+        """Returns the consumer-group-prefix that was requested."""
+        return self.relation.data[self.relation.app].get("consumer-group-prefix")
+
 
 class TopicRequestedEvent(KafkaProvidesEvent, ExtraRoleEvent):
     """Event emitted when a new topic is requested for use on this relation."""
@@ -991,8 +1013,13 @@ class KafkaRequiresEvent(RelationEvent):
     """Base class for Kafka events."""
 
     @property
+    def topic(self) -> Optional[str]:
+        """Returns the topic."""
+        return self.relation.data[self.relation.app].get("topic")
+
+    @property
     def bootstrap_server(self) -> Optional[str]:
-        """Returns a a comma-separated list of broker uris."""
+        """Returns a a comma-seperated list of broker uris."""
         return self.relation.data[self.relation.app].get("endpoints")
 
     @property
@@ -1049,6 +1076,15 @@ class KafkaProvides(DataProvides):
         if "topic" in diff.added:
             self.on.topic_requested.emit(event.relation, app=event.app, unit=event.unit)
 
+    def set_topic(self, relation_id: int, topic: str) -> None:
+        """Set topic name in the application relation databag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            topic: the topic name.
+        """
+        self._update_relation_data(relation_id, {"topic": topic})
+
     def set_bootstrap_server(self, relation_id: int, bootstrap_server: str) -> None:
         """Set the bootstrap server in the application relation databag.
 
@@ -1072,7 +1108,7 @@ class KafkaProvides(DataProvides):
 
         Args:
             relation_id: the identifier for a particular relation.
-            zookeeper_uris: comma-separated list of ZooKeeper server uris.
+            zookeeper_uris: comma-seperated list of ZooKeeper server uris.
         """
         self._update_relation_data(relation_id, {"zookeeper-uris": zookeeper_uris})
 
@@ -1082,26 +1118,30 @@ class KafkaRequires(DataRequires):
 
     on = KafkaRequiresEvents()
 
-    def __init__(self, charm, relation_name: str, topic: str, extra_user_roles: str = None):
+    def __init__(
+        self,
+        charm,
+        relation_name: str,
+        topic: str,
+        extra_user_roles: Optional[str] = None,
+        consumer_group_prefix: Optional[str] = None,
+    ):
         """Manager of Kafka client relations."""
         # super().__init__(charm, relation_name)
         super().__init__(charm, relation_name, extra_user_roles)
         self.charm = charm
         self.topic = topic
+        self.consumer_group_prefix = consumer_group_prefix or ""
 
     def _on_relation_joined_event(self, event: RelationJoinedEvent) -> None:
         """Event emitted when the application joins the Kafka relation."""
-        # Sets both topic and extra user roles in the relation
-        # if the roles are provided. Otherwise, sets only the topic.
-        self._update_relation_data(
-            event.relation.id,
-            {
-                "topic": self.topic,
-                "extra-user-roles": self.extra_user_roles,
-            }
-            if self.extra_user_roles is not None
-            else {"topic": self.topic},
-        )
+        # Sets topic, extra user roles, and "consumer-group-prefix" in the relation
+        relation_data = {
+            f: getattr(self, f.replace("-", "_"), "")
+            for f in ["consumer-group-prefix", "extra-user-roles", "topic"]
+        }
+
+        self._update_relation_data(event.relation.id, relation_data)
 
     def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
         """Event emitted when the Kafka relation has changed."""
@@ -1119,173 +1159,12 @@ class KafkaRequires(DataRequires):
             # “endpoints_changed“ event if “topic_created“ is triggered.
             return
 
-        # Emit an endpoints (bootstrap-server) changed event if the Kakfa endpoints
+        # Emit an endpoints (bootstap-server) changed event if the Kafka endpoints
         # added or changed this info in the relation databag.
         if "endpoints" in diff.added or "endpoints" in diff.changed:
             # Emit the default event (the one without an alias).
             logger.info("endpoints changed on %s", datetime.now())
             self.on.bootstrap_server_changed.emit(
-                event.relation, app=event.app, unit=event.unit
-            )  # here check if this is the right design
-            return
-
-
-# Opensearch related events
-
-
-class OpenSearchProvidesEvent(RelationEvent):
-    """Base class for OpenSearch events."""
-
-    @property
-    def index(self) -> Optional[str]:
-        """Returns the index that was requested."""
-        return self.relation.data[self.relation.app].get("index")
-
-
-class IndexRequestedEvent(OpenSearchProvidesEvent, ExtraRoleEvent):
-    """Event emitted when a new index is requested for use on this relation."""
-
-
-class OpenSearchProvidesEvents(CharmEvents):
-    """OpenSearch events.
-
-    This class defines the events that OpenSearch can emit.
-    """
-
-    index_requested = EventSource(IndexRequestedEvent)
-
-
-class OpenSearchRequiresEvent(DatabaseRequiresEvent):
-    """Base class for OpenSearch requirer events."""
-
-
-class IndexCreatedEvent(AuthenticationEvent, OpenSearchRequiresEvent):
-    """Event emitted when a new index is created for use on this relation."""
-
-
-class OpenSearchRequiresEvents(CharmEvents):
-    """OpenSearch events.
-
-    This class defines the events that the opensearch requirer can emit.
-    """
-
-    index_created = EventSource(IndexCreatedEvent)
-    endpoints_changed = EventSource(DatabaseEndpointsChangedEvent)
-    authentication_updated = EventSource(AuthenticationEvent)
-
-
-# OpenSearch Provides and Requires Objects
-
-
-class OpenSearchProvides(DataProvides):
-    """Provider-side of the OpenSearch relation."""
-
-    on = OpenSearchProvidesEvents()
-
-    def __init__(self, charm: CharmBase, relation_name: str) -> None:
-        super().__init__(charm, relation_name)
-
-    def _on_relation_changed(self, event: RelationChangedEvent) -> None:
-        """Event emitted when the relation has changed."""
-        # Only the leader should handle this event.
-        if not self.local_unit.is_leader():
-            return
-
-        # Check which data has changed to emit customs events.
-        diff = self._diff(event)
-
-        # Emit an index requested event if the setup key (index name and optional extra user roles)
-        # have been added to the relation databag by the application.
-        if "index" in diff.added:
-            self.on.index_requested.emit(event.relation, app=event.app, unit=event.unit)
-
-    def set_index(self, relation_id: int, index: str) -> None:
-        """Set the index in the application relation databag.
-
-        Args:
-            relation_id: the identifier for a particular relation.
-            index: the index as it is _created_ on the provider charm. This needn't match the
-                requested index, and can be used to present a different index name if, for example,
-                the requested index is invalid.
-        """
-        self._update_relation_data(relation_id, {"index": index})
-
-    def set_endpoints(self, relation_id: int, endpoints: str) -> None:
-        """Set the endpoints in the application relation databag.
-
-        Args:
-            relation_id: the identifier for a particular relation.
-            endpoints: the endpoint addresses for opensearch nodes.
-        """
-        self._update_relation_data(relation_id, {"endpoints": endpoints})
-
-    def set_version(self, relation_id: int, version: str) -> None:
-        """Set the database version in the application relation databag.
-
-        Args:
-            relation_id: the identifier for a particular relation.
-            version: database version.
-        """
-        self._update_relation_data(relation_id, {"version": version})
-
-
-class OpenSearchRequires(DataRequires):
-    """Requires-side of the OpenSearch relation."""
-
-    on = OpenSearchRequiresEvents()
-
-    def __init__(
-            self, charm, relation_name: str, index: str, extra_user_roles: Optional[str] = None
-        ):
-        """Manager of OpenSearch client relations."""
-        super().__init__(charm, relation_name, extra_user_roles)
-        self.charm = charm
-        self.index = index
-
-    def _on_relation_joined_event(self, event: RelationJoinedEvent) -> None:
-        """Event emitted when the application joins the OpenSearch relation."""
-        # Sets both index and extra user roles in the relation if the roles are provided.
-        # Otherwise, sets only the index.
-        data = {"index": self.index}
-        if self.extra_user_roles:
-            data["extra-user-roles"] = self.extra_user_roles
-
-        self._update_relation_data(event.relation.id, data)
-
-    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
-        """Event emitted when the OpenSearch relation has changed.
-
-        This event triggers individual custom events depending on the changing relation.
-        """
-        # Check which data has changed to emit customs events.
-        diff = self._diff(event)
-
-        # Check if the index is created
-        # (the OpenSearch charm shares the credentials).
-        if "username" in diff.added and "password" in diff.added:
-            # Emit the default event (the one without an alias).
-            logger.info("index created at: %s", datetime.now())
-            self.on.index_created.emit(event.relation, app=event.app, unit=event.unit)
-
-            # To avoid unnecessary application restarts do not trigger
-            # “endpoints_changed“ or "authentication_updated" event if “index_created“ is
-            # triggered.
-            return
-
-        # Check if authentication has updated, emit event if so
-        updates = {"password", "tls", "tls-ca"}
-        if len(set(diff._asdict().keys()) - updates) < len(diff):
-            logger.info("authentication updated at: %s", datetime.now())
-            self.on.authentication_updated.emit(event.relation, app=event.app, unit=event.unit)
-
-            return
-
-        # Emit a endpoints changed event if the OpenSearch application added or changed this info
-        # in the relation databag.
-        if "endpoints" in diff.added or "endpoints" in diff.changed:
-            # Emit the default event (the one without an alias).
-            logger.info("endpoints changed on %s", datetime.now())
-            self.on.endpoints_changed.emit(
                 event.relation, app=event.app, unit=event.unit
             )  # here check if this is the right design
             return

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -27,4 +27,4 @@ requires:
 storage:
   opensearch-data:
     type: filesystem
-    location: /var/snap/opensearch/common  # /mnt/opensearch/data
+    location: /var/snap/opensearch  # /mnt/opensearch/data

--- a/src/opensearch.py
+++ b/src/opensearch.py
@@ -38,6 +38,8 @@ class OpenSearchSnap(OpenSearchDistribution):
     """Snap distribution of opensearch, only overrides properties and logic proper to the snap."""
 
     _BASE_SNAP_DIR = "/var/snap/opensearch"
+    _SNAP_DATA = f"{_BASE_SNAP_DIR}/current"
+    _SNAP_COMMON = f"{_BASE_SNAP_DIR}/common"
 
     def __init__(self, charm, peer_relation: str):
         super().__init__(charm, peer_relation)
@@ -108,12 +110,12 @@ class OpenSearchSnap(OpenSearchDistribution):
           - OPENSEARCH_CONF: writeable by root or snap_daemon ($SNAP_COMMON) where config files are
         """
         return Paths(
-            home=f"{self._BASE_SNAP_DIR}/current",
-            conf=f"{self._BASE_SNAP_DIR}/current/config",
-            data=f"{self._BASE_SNAP_DIR}/common/data",
-            logs=f"{self._BASE_SNAP_DIR}/common/logs",
-            jdk=f"{self._BASE_SNAP_DIR}/current/jdk",
-            tmp=f"{self._BASE_SNAP_DIR}/common/tmp",
+            home=f"{self._SNAP_DATA}",
+            conf=f"{self._SNAP_DATA}/config",
+            data=f"{self._SNAP_COMMON}/data",
+            logs=f"{self._SNAP_COMMON}/logs",
+            jdk=f"{self._SNAP_DATA}/jdk",
+            tmp=f"{self._SNAP_COMMON}/tmp",
         )
 
     def write_file(self, path: str, data: str, override: bool = True):

--- a/src/opensearch.py
+++ b/src/opensearch.py
@@ -45,6 +45,11 @@ class OpenSearchSnap(OpenSearchDistribution):
         cache = snap.SnapCache()
         self._opensearch = cache["opensearch"]
 
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=2, max=10),
+        reraise=True,
+    )
     @override
     def install(self):
         """Install opensearch from the snapcraft store."""

--- a/src/opensearch.py
+++ b/src/opensearch.py
@@ -109,7 +109,7 @@ class OpenSearchSnap(OpenSearchDistribution):
         """
         return Paths(
             home=f"{self._BASE_SNAP_DIR}/current",
-            conf=f"{self._BASE_SNAP_DIR}/common/config",
+            conf=f"{self._BASE_SNAP_DIR}/current/config",
             data=f"{self._BASE_SNAP_DIR}/common/data",
             logs=f"{self._BASE_SNAP_DIR}/common/logs",
             jdk=f"{self._BASE_SNAP_DIR}/current/jdk",

--- a/tests/integration/relations/opensearch_provider/application-charm/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/tests/integration/relations/opensearch_provider/application-charm/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -16,7 +16,7 @@
 
 This library contains the Requires and Provides classes for handling the relation
 between an application and multiple managed application supported by the data-team:
-MySQL, Postgresql, MongoDB, Redis,  and Kakfa.
+MySQL, Postgresql, MongoDB, Redis, and Kafka.
 
 ### Database (MySQL, Postgresql, MongoDB, and Redis)
 
@@ -303,7 +303,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 9
 
 PYDEPS = ["ops>=2.0.0"]
 
@@ -661,6 +661,11 @@ class DatabaseRequiresEvent(RelationEvent):
     """Base class for database events."""
 
     @property
+    def database(self) -> Optional[str]:
+        """Returns the database name."""
+        return self.relation.data[self.relation.app].get("database")
+
+    @property
     def endpoints(self) -> Optional[str]:
         """Returns a comma separated list of read/write endpoints."""
         return self.relation.data[self.relation.app].get("endpoints")
@@ -682,7 +687,7 @@ class DatabaseRequiresEvent(RelationEvent):
     def uris(self) -> Optional[str]:
         """Returns the connection URIs.
 
-        MongoDB, Redis.
+        MongoDB, Redis, OpenSearch.
         """
         return self.relation.data[self.relation.app].get("uris")
 
@@ -742,6 +747,18 @@ class DatabaseProvides(DataProvides):
         # extra user roles) was added to the relation databag by the application.
         if "database" in diff.added:
             self.on.database_requested.emit(event.relation, app=event.app, unit=event.unit)
+
+    def set_database(self, relation_id: int, database_name: str) -> None:
+        """Set database name.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            database_name: database name.
+        """
+        self._update_relation_data(relation_id, {"database": database_name})
 
     def set_endpoints(self, relation_id: int, connection_strings: str) -> None:
         """Set database primary connections.
@@ -973,6 +990,11 @@ class KafkaProvidesEvent(RelationEvent):
         """Returns the topic that was requested."""
         return self.relation.data[self.relation.app].get("topic")
 
+    @property
+    def consumer_group_prefix(self) -> Optional[str]:
+        """Returns the consumer-group-prefix that was requested."""
+        return self.relation.data[self.relation.app].get("consumer-group-prefix")
+
 
 class TopicRequestedEvent(KafkaProvidesEvent, ExtraRoleEvent):
     """Event emitted when a new topic is requested for use on this relation."""
@@ -991,8 +1013,13 @@ class KafkaRequiresEvent(RelationEvent):
     """Base class for Kafka events."""
 
     @property
+    def topic(self) -> Optional[str]:
+        """Returns the topic."""
+        return self.relation.data[self.relation.app].get("topic")
+
+    @property
     def bootstrap_server(self) -> Optional[str]:
-        """Returns a a comma-separated list of broker uris."""
+        """Returns a comma-seperated list of broker uris."""
         return self.relation.data[self.relation.app].get("endpoints")
 
     @property
@@ -1049,6 +1076,15 @@ class KafkaProvides(DataProvides):
         if "topic" in diff.added:
             self.on.topic_requested.emit(event.relation, app=event.app, unit=event.unit)
 
+    def set_topic(self, relation_id: int, topic: str) -> None:
+        """Set topic name in the application relation databag.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            topic: the topic name.
+        """
+        self._update_relation_data(relation_id, {"topic": topic})
+
     def set_bootstrap_server(self, relation_id: int, bootstrap_server: str) -> None:
         """Set the bootstrap server in the application relation databag.
 
@@ -1082,26 +1118,30 @@ class KafkaRequires(DataRequires):
 
     on = KafkaRequiresEvents()
 
-    def __init__(self, charm, relation_name: str, topic: str, extra_user_roles: str = None):
+    def __init__(
+        self,
+        charm,
+        relation_name: str,
+        topic: str,
+        extra_user_roles: Optional[str] = None,
+        consumer_group_prefix: Optional[str] = None,
+    ):
         """Manager of Kafka client relations."""
         # super().__init__(charm, relation_name)
         super().__init__(charm, relation_name, extra_user_roles)
         self.charm = charm
         self.topic = topic
+        self.consumer_group_prefix = consumer_group_prefix or ""
 
     def _on_relation_joined_event(self, event: RelationJoinedEvent) -> None:
         """Event emitted when the application joins the Kafka relation."""
-        # Sets both topic and extra user roles in the relation
-        # if the roles are provided. Otherwise, sets only the topic.
-        self._update_relation_data(
-            event.relation.id,
-            {
-                "topic": self.topic,
-                "extra-user-roles": self.extra_user_roles,
-            }
-            if self.extra_user_roles is not None
-            else {"topic": self.topic},
-        )
+        # Sets topic, extra user roles, and "consumer-group-prefix" in the relation
+        relation_data = {
+            f: getattr(self, f.replace("-", "_"), "")
+            for f in ["consumer-group-prefix", "extra-user-roles", "topic"]
+        }
+
+        self._update_relation_data(event.relation.id, relation_data)
 
     def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
         """Event emitted when the Kafka relation has changed."""
@@ -1116,10 +1156,10 @@ class KafkaRequires(DataRequires):
             self.on.topic_created.emit(event.relation, app=event.app, unit=event.unit)
 
             # To avoid unnecessary application restarts do not trigger
-            # “endpoints_changed“ event if “topic_created“ is triggered.
+            # "endpoints_changed" event if "topic_created" is triggered.
             return
 
-        # Emit an endpoints (bootstrap-server) changed event if the Kakfa endpoints
+        # Emit an endpoints (bootstrap-server) changed event if the Kafka endpoints
         # added or changed this info in the relation databag.
         if "endpoints" in diff.added or "endpoints" in diff.changed:
             # Emit the default event (the one without an alias).
@@ -1268,7 +1308,7 @@ class OpenSearchRequires(DataRequires):
             self.on.index_created.emit(event.relation, app=event.app, unit=event.unit)
 
             # To avoid unnecessary application restarts do not trigger
-            # “endpoints_changed“ or "authentication_updated" event if “index_created“ is
+            # "endpoints_changed" or "authentication_updated" event if "index_created" is
             # triggered.
             return
 


### PR DESCRIPTION
This PR contains:
- a retry on the installation of the OpenSearch snap.
- change of location of the config from SNAP_COMMON to SNAP_DATA
- update of the data interfaces lib to incorporate new upstream fixes)


## Notes:
The integration tests will pass once [new snap released](https://github.com/canonical/opensearch-snap/pull/21)