### PR TITLE
[DPE-1962] Continuous writing in tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,51 +93,50 @@ jobs:
         env:
           CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}
 
-
   # These tests currently compete for access to the 4-core runner amongst individual test runs in
   # this repo, and with other charms. Therefore, this runner should be used sparingly until we can
   # access more runners.
-  # heavy-integration-test:
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       tox-environments:
-  #         - ha-integration
-  #   name: ${{ matrix.tox-environments }}
-  #   needs:
-  #     - lint
-  #     - unit-test
-  #     - build
-  #   runs-on: Ubuntu_4C_16M
-  #   timeout-minutes: 120
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #     - name: Setup operator environment
-  #       # TODO: Replace with custom image on self-hosted runner
-  #       uses: charmed-kubernetes/actions-operator@main
-  #       with:
-  #         provider: lxd
-  #     - name: Download packed charm(s)
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: ${{ needs.build.outputs.artifact-name }}
-  #     - name: Select tests
-  #       id: select-tests
-  #       run: |
-  #         if [ "${{ github.event_name }}" == "schedule" ]
-  #         then
-  #           echo Running unstable and stable tests
-  #           echo "mark_expression=" >> $GITHUB_OUTPUT
-  #         else
-  #           echo Skipping unstable tests
-  #           echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
-  #         fi
-  #     - name: Run integration tests
-  #       run: |
-  #         # set sysctl values in case the cloudinit-userdata not applied
-  #         sudo sysctl -w vm.max_map_count=262144 vm.swappiness=0 net.ipv4.tcp_retries2=5
-
-  #         tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}'
-  #       env:
-  #         CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}
+  heavy-integration-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        tox-environments:
+          - ha-integration
+    name: ${{ matrix.tox-environments }}
+    needs:
+      - lint
+      - unit-test
+      - build
+    runs-on: Ubuntu_4C_16M
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup operator environment
+        # TODO: Replace with custom image on self-hosted runner
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: lxd
+      - name: Download packed charm(s)
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.build.outputs.artifact-name }}
+      - name: Select tests
+        id: select-tests
+        run: |
+          if [ "${{ github.event_name }}" == "schedule" ]
+          then
+            echo Running unstable and stable tests
+            echo "mark_expression=" >> $GITHUB_OUTPUT
+          else
+            echo Skipping unstable tests
+            echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
+          fi
+      - name: Run integration tests
+        run: |
+          # set sysctl values in case the cloudinit-userdata not applied
+          sudo sysctl -w vm.max_map_count=262144 vm.swappiness=0 net.ipv4.tcp_retries2=5
+          
+          tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}'
+        env:
+          CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,7 +101,7 @@ jobs:
       fail-fast: false
       matrix:
         tox-environments:
-          - ha-integration
+          - h-scaling-integration
     name: ${{ matrix.tox-environments }}
     needs:
       - lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,7 +107,7 @@ jobs:
       - lint
       - unit-test
       - build
-    runs-on: Ubuntu_4C_16M
+    runs-on: Ubuntu_4C_16G
     timeout-minutes: 120
     steps:
       - name: Checkout

--- a/lib/charms/opensearch/v0/helper_cluster.py
+++ b/lib/charms/opensearch/v0/helper_cluster.py
@@ -183,15 +183,21 @@ class ClusterState:
         reraise=True,
     )
     def shards(
-        opensearch: OpenSearchDistribution, host: Optional[str] = None
+        opensearch: OpenSearchDistribution,
+        host: Optional[str] = None,
+        alt_hosts: Optional[List[str]] = None,
     ) -> List[Dict[str, str]]:
         """Get all shards of all indexes in the cluster."""
-        return opensearch.request("GET", "/_cat/shards", host=host)
+        return opensearch.request("GET", "/_cat/shards", host=host, alt_hosts=alt_hosts)
 
     @staticmethod
-    def shards_by_state(opensearch: OpenSearchDistribution) -> Dict[str, List[str]]:
+    def shards_by_state(
+        opensearch: OpenSearchDistribution,
+        host: Optional[str] = None,
+        alt_hosts: Optional[List[str]] = None,
+    ) -> Dict[str, List[str]]:
         """Get the shards count by state."""
-        shards = ClusterState.shards(opensearch)
+        shards = ClusterState.shards(opensearch, host=host, alt_hosts=alt_hosts)
 
         shards_state_map = {}
         for shard in shards:
@@ -203,10 +209,12 @@ class ClusterState:
 
     @staticmethod
     def busy_shards_by_unit(
-        opensearch: OpenSearchDistribution, host: Optional[str] = None
+        opensearch: OpenSearchDistribution,
+        host: Optional[str] = None,
+        alt_hosts: Optional[List[str]] = None,
     ) -> Dict[str, List[str]]:
         """Get the busy shards of each index in the cluster."""
-        shards = ClusterState.shards(opensearch, host)
+        shards = ClusterState.shards(opensearch, host=host, alt_hosts=alt_hosts)
 
         busy_shards = {}
         for shard in shards:

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -518,7 +518,12 @@ class OpenSearchBaseCharm(CharmBase):
             return
 
         try:
-            self.opensearch.start()
+            self.opensearch.start(
+                ok_when_service_active=(
+                    self.unit.is_leader()
+                    and self.peers_data.get(Scope.APP, "admin_user_initialized")
+                )
+            )
             self._post_start_init()
             self.status.clear(WaitingToStart)
         except OpenSearchStartTimeoutError:

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -530,9 +530,9 @@ class OpenSearchBaseCharm(CharmBase):
 
         try:
             self.opensearch.start(
-                wait_until_http_200=not (
-                    self.unit.is_leader()
-                    and not self.peers_data.get(Scope.APP, "security_index_initialised", False)
+                wait_until_http_200=(
+                    not self.unit.is_leader()
+                    or self.peers_data.get(Scope.APP, "security_index_initialised", False)
                 )
             )
             self._post_start_init()

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -14,7 +14,6 @@ from charms.opensearch.v0.constants_charm import (
     CertsExpirationError,
     ClientRelationName,
     ClusterHealthRed,
-    ClusterHealthYellow,
     NoNodeUpInCluster,
     PeerRelationName,
     RequestUnitServiceOps,
@@ -25,7 +24,6 @@ from charms.opensearch.v0.constants_charm import (
     TLSNotFullyConfigured,
     TLSRelationBrokenError,
     TooManyNodesRemoved,
-    WaitingForBusyShards,
     WaitingForSpecificBusyShards,
     WaitingToStart,
 )
@@ -60,6 +58,7 @@ from charms.opensearch.v0.opensearch_exceptions import (
     OpenSearchStartTimeoutError,
     OpenSearchStopError,
 )
+from charms.opensearch.v0.opensearch_health import HealthColors, OpenSearchHealth
 from charms.opensearch.v0.opensearch_nodes_exclusions import (
     ALLOCS_TO_DELETE,
     VOTING_TO_DELETE,
@@ -122,6 +121,7 @@ class OpenSearchBaseCharm(CharmBase):
         self.secrets = SecretsDataStore(self, PeerRelationName)
         self.tls = OpenSearchTLS(self, TLS_RELATION)
         self.status = Status(self)
+        self.health = OpenSearchHealth(self)
 
         self.service_manager = RollingOpsManager(
             self, relation=SERVICE_MANAGER, callback=self._start_opensearch
@@ -158,9 +158,12 @@ class OpenSearchBaseCharm(CharmBase):
             # Leader election event happening after a previous leader got killed
             if not self.opensearch.is_node_up():
                 event.defer()
-            else:
-                self._apply_cluster_health()
-                self._compute_and_broadcast_updated_topology(self._get_nodes(True))
+                return
+
+            if self.health.apply() == HealthColors.YELLOW_TEMP:
+                event.defer()
+
+            self._compute_and_broadcast_updated_topology(self._get_nodes(True))
             return
 
         if not self.peers_data.get(Scope.APP, "admin_user_initialized"):
@@ -247,17 +250,19 @@ class OpenSearchBaseCharm(CharmBase):
 
     def _on_peer_relation_changed(self, event: RelationChangedEvent):
         """Handle peer relation changes."""
+        if (
+            self.unit.is_leader()
+            and self.opensearch.is_node_up()
+            and self.health.apply() == HealthColors.YELLOW_TEMP
+        ):
+            # we defer because we want the temporary status to be updated
+            event.defer()
+
         data = event.relation.data.get(event.unit if self.unit.is_leader() else event.app)
         if not data:
             return
 
         if self.unit.is_leader():
-            cluster_health_color = data.get("health", "green")
-            if cluster_health_color != "green":
-                self.app.status = BlockedStatus(
-                    ClusterHealthRed if cluster_health_color == "red" else ClusterHealthYellow
-                )
-
             if data.get("bootstrap_contributor"):
                 contributor_count = self.peers_data.get(
                     Scope.APP, "bootstrap_contributors_count", 0
@@ -285,7 +290,11 @@ class OpenSearchBaseCharm(CharmBase):
             for node in self._get_nodes(True)
             if node.name != event.departing_unit.name.replace("/", "-")
         ]
-        self._compute_and_broadcast_updated_topology(remaining_nodes)
+
+        if len(remaining_nodes) == self.app.planned_units():
+            self._compute_and_broadcast_updated_topology(remaining_nodes)
+        else:
+            event.defer()
 
     def _on_opensearch_data_storage_detaching(self, _: StorageDetachingEvent):
         """Triggered when removing unit, Prior to the storage being detached."""
@@ -298,7 +307,7 @@ class OpenSearchBaseCharm(CharmBase):
 
         # attempt lock acquisition through index creation, should crash if index already created
         # meaning another unit is holding the lock
-        if self.opensearch.is_started() and self.alt_hosts:
+        if self.opensearch.is_node_up() and self.alt_hosts:
             self.opensearch.request("PUT", "/.ops_stop", retries=3)
 
             # TODO query if current is CM + is_leader
@@ -315,8 +324,8 @@ class OpenSearchBaseCharm(CharmBase):
             if not self.alt_hosts:
                 raise OpenSearchHAError(NoNodeUpInCluster)
 
-            health = self._apply_cluster_health(wait_for_green_first=True, use_localhost=False)
-            if health == "red":
+            health_color = self.health.apply(use_localhost=False)
+            if health_color == HealthColors.RED:
                 raise OpenSearchHAError(ClusterHealthRed)
         finally:
             # release lock
@@ -357,7 +366,9 @@ class OpenSearchBaseCharm(CharmBase):
         # if there are exclusions to be removed
         if self.unit.is_leader():
             self.opensearch_exclusions.cleanup()
-            self._apply_cluster_health()
+            if self.health.apply() == HealthColors.YELLOW_TEMP:
+                event.defer()
+                return
 
         for relation in self.model.relations.get(ClientRelationName, []):
             self.opensearch_provider.update_endpoints(relation)
@@ -519,9 +530,9 @@ class OpenSearchBaseCharm(CharmBase):
 
         try:
             self.opensearch.start(
-                ok_when_service_active=(
+                wait_until_http_200=not (
                     self.unit.is_leader()
-                    and self.peers_data.get(Scope.APP, "admin_user_initialized")
+                    and not self.peers_data.get(Scope.APP, "security_index_initialised", False)
                 )
             )
             self._post_start_init()
@@ -554,8 +565,8 @@ class OpenSearchBaseCharm(CharmBase):
         # Remove the 'starting' flag on the unit
         self.peers_data.delete(Scope.UNIT, "starting")
 
-        # Apply cluster health status
-        self._apply_cluster_health(wait_for_green_first=True, use_localhost=True)
+        # apply cluster health
+        self.health.apply()
 
     def _stop_opensearch(self) -> None:
         """Stop OpenSearch if possible."""
@@ -796,61 +807,11 @@ class OpenSearchBaseCharm(CharmBase):
             return
 
         updated_nodes = ClusterTopology.recompute_nodes_conf(current_nodes)
+
         self.peers_data.put_object(Scope.APP, "nodes_config", updated_nodes)
 
-    def _apply_cluster_health(
-        self, wait_for_green_first: bool = False, use_localhost: bool = True
-    ) -> str:
-        """Fetch cluster health and set it on the app status."""
-        response: Optional[Dict[str, any]] = None
-        if wait_for_green_first:
-            try:
-                response = ClusterState.health(
-                    self.opensearch,
-                    True,
-                    host=self.unit_ip if use_localhost else None,
-                    alt_hosts=self.alt_hosts,
-                )
-            except OpenSearchHttpError:
-                # it timed out, settle with current status, fetched next without the 1min wait
-                pass
-
-        if not response:
-            response = ClusterState.health(
-                self.opensearch,
-                False,
-                host=self.unit_ip if use_localhost else None,
-                alt_hosts=self.alt_hosts,
-            )
-
-        status = response["status"].lower()
-        if not self.unit.is_leader():
-            # this is needed in case the leader is in an error state and doesn't
-            # report the status itself
-            self.peers_data.put(Scope.UNIT, "health", status)
-            return status
-
-        # cluster health is green
-        if status == "green":
-            self.status.clear(ClusterHealthRed, app=True)
-            self.status.clear(ClusterHealthYellow, app=True)
-            self.status.clear(WaitingForBusyShards, app=True)
-            return "green"
-
-        # some primary shards are unassigned
-        if status == "red":
-            self.app.status = BlockedStatus(ClusterHealthRed)
-            return "red"
-
-        # some replica shards are unassigned
-        shards_by_state = ClusterState.shards_by_state(self.opensearch)
-        busy_shards = shards_by_state.get("INITIALIZING", 0) + shards_by_state.get("RELOCATING", 0)
-        self.app.status = (
-            BlockedStatus(ClusterHealthYellow)
-            if busy_shards == 0
-            else WaitingStatus(WaitingForBusyShards)
-        )
-        return "yellow"
+        # since the above won't trigger a peer rel changed on leader, we'll trigger it manually
+        self.on[PeerRelationName].relation_changed.emit(self.model.get_relation(PeerRelationName))
 
     def _check_certs_expiration(self, event: UpdateStatusEvent) -> None:
         """Checks the certificates' expiration."""

--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -88,8 +88,12 @@ class OpenSearchDistribution(ABC):
         """Install the package."""
         pass
 
-    def start(self):
+    def start(self, ok_when_service_active: bool = False):
         """Start the opensearch service."""
+
+        def _is_connected():
+            return self.is_started() if ok_when_service_active else self.is_node_up()
+
         if self.is_started():
             return
 
@@ -97,7 +101,7 @@ class OpenSearchDistribution(ABC):
         self._start_service()
 
         start = datetime.now()
-        while not self.is_node_up() and (datetime.now() - start).seconds < 75:
+        while not _is_connected() and (datetime.now() - start).seconds < 75:
             time.sleep(3)
         else:
             raise OpenSearchStartTimeoutError()

--- a/lib/charms/opensearch/v0/opensearch_health.py
+++ b/lib/charms/opensearch/v0/opensearch_health.py
@@ -1,0 +1,149 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Base class for the OpenSearch Health management."""
+import logging
+from typing import Dict, Optional
+
+from charms.opensearch.v0.constants_charm import (
+    ClusterHealthRed,
+    ClusterHealthYellow,
+    WaitingForBusyShards,
+    WaitingForSpecificBusyShards,
+)
+from charms.opensearch.v0.helper_charm import Status
+from charms.opensearch.v0.helper_cluster import ClusterState
+from charms.opensearch.v0.helper_databag import Scope
+from charms.opensearch.v0.opensearch_exceptions import OpenSearchHttpError
+from ops.model import BlockedStatus, WaitingStatus
+
+# The unique Charmhub library identifier, never change it
+LIBID = "93d2c27f38974a59b3bbe39fb27ac98d"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+
+logger = logging.getLogger(__name__)
+
+
+class HealthColors:
+    """Colors the clusters or a unit may have depending on their health."""
+
+    GREEN = "green"
+    YELLOW = "yellow"
+    YELLOW_TEMP = "yellow-temp"
+    RED = "red"
+
+
+class OpenSearchHealth:
+    """Class for managing OpenSearch statuses."""
+
+    def __init__(self, charm):
+        self._charm = charm
+        self._opensearch = self._charm.opensearch
+
+    def apply(
+        self,
+        wait_for_green_first: bool = False,
+        use_localhost: bool = True,
+        app: bool = True,
+    ) -> str:
+        """Fetch cluster health and set it on the app status."""
+        host = self._charm.unit_ip if use_localhost else None
+        status = self._fetch_status(host, wait_for_green_first)
+
+        if app:
+            self.apply_for_app(status)
+        else:
+            self.apply_for_unit(status)
+
+        return status
+
+    def apply_for_app(self, status: str):
+        """Cluster wide / app status."""
+        if not self._charm.unit.is_leader():
+            # this is needed in case the leader is in an error state and doesn't
+            # report the status itself
+            self._charm.peers_data.put(Scope.UNIT, "health", status)
+            return status
+
+        if status == HealthColors.GREEN:
+            # green: cluster healthy
+            self._charm.status.clear(ClusterHealthRed, app=True)
+            self._charm.status.clear(ClusterHealthYellow, app=True)
+            self._charm.status.clear(WaitingForBusyShards, app=True)
+        elif status == HealthColors.RED:
+            # health RED, some primary shards are unassigned
+            self._charm.app.status = BlockedStatus(ClusterHealthRed)
+            return
+        else:
+            # cluster health is yellow, either a temporary state where shards are moving
+            # around (relocating / initializing) - or a permanent state where some replica
+            # shards are unassigned.
+            self._charm.app.status = (
+                BlockedStatus(ClusterHealthYellow)
+                if status == HealthColors.YELLOW
+                else WaitingStatus(WaitingForBusyShards)
+            )
+
+        return status
+
+    def apply_for_unit(self, status: str, host: Optional[str] = None):
+        """Apply the health status on the current unit."""
+        if status != HealthColors.YELLOW_TEMP:
+            self._charm.status.clear(
+                WaitingForSpecificBusyShards, pattern=Status.CheckPattern.Interpolated
+            )
+            return
+
+        busy_shards = ClusterState.busy_shards_by_unit(
+            self._opensearch, host=host, alt_hosts=self._charm.alt_hosts
+        ).get(self._charm.unit_name)
+
+        if busy_shards:
+            self._charm.unit.status = WaitingStatus(
+                WaitingForSpecificBusyShards.format(", ".join(busy_shards))
+            )
+        else:
+            self._charm.status.clear(
+                WaitingForSpecificBusyShards, pattern=Status.CheckPattern.Interpolated
+            )
+
+    def _fetch_status(self, host: Optional[str] = None, wait_for_green_first: bool = False):
+        """Fetch the current cluster status."""
+        response: Optional[Dict[str, any]] = None
+        if wait_for_green_first:
+            try:
+                response = ClusterState.health(
+                    self._opensearch,
+                    True,
+                    host=host,
+                    alt_hosts=self._charm.alt_hosts,
+                )
+            except OpenSearchHttpError:
+                # it timed out, settle with current status, fetched next without the 1min wait
+                pass
+
+        if not response:
+            response = ClusterState.health(
+                self._opensearch,
+                False,
+                host=host,
+                alt_hosts=self._charm.alt_hosts,
+            )
+
+        status = response["status"].lower()
+        if status != HealthColors.YELLOW:
+            return status
+
+        # we differentiate between a temp yellow (moving shards) and perm one (missing replicas)
+        shards_by_state = ClusterState.shards_by_state(
+            self._opensearch, host=host, alt_hosts=self._charm.alt_hosts
+        )
+        busy_shards = shards_by_state.get("INITIALIZING", 0) + shards_by_state.get("RELOCATING", 0)
+        return HealthColors.YELLOW_TEMP if busy_shards > 0 else HealthColors.YELLOW

--- a/lib/charms/operator_libs_linux/v1/snap.py
+++ b/lib/charms/operator_libs_linux/v1/snap.py
@@ -83,7 +83,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 10
 
 
 # Regex to locate 7-bit C1 ANSI sequences
@@ -113,7 +113,7 @@ class SnapService:
         enabled: bool = False,
         active: bool = False,
         activators: List[str] = [],
-        **kwargs
+        **kwargs,
     ):
         self.daemon = daemon
         self.daemon_scope = kwargs.get("daemon-scope", None) or daemon_scope
@@ -122,7 +122,7 @@ class SnapService:
         self.activators = activators
 
     def as_dict(self) -> Dict:
-        """Returns instance representation as dict."""
+        """Return instance representation as dict."""
         return {
             "daemon": self.daemon,
             "daemon_scope": self.daemon_scope,
@@ -158,7 +158,7 @@ class Error(Exception):
     """Base class of most errors raised by this library."""
 
     def __repr__(self):
-        """String representation of the Error class."""
+        """Represent the Error class."""
         return "<{}.{} {}>".format(type(self).__module__, type(self).__name__, self.args)
 
     @property
@@ -176,7 +176,6 @@ class SnapAPIError(Error):
     """Raised when an HTTP API error occurs talking to the Snapd server."""
 
     def __init__(self, body: Dict, code: int, status: str, message: str):
-        """This shouldn't be instantiated directly."""
         super().__init__(message)  # Makes str(e) return message
         self.body = body
         self.code = code
@@ -184,7 +183,7 @@ class SnapAPIError(Error):
         self._message = message
 
     def __repr__(self):
-        """String representation of the SnapAPIError class."""
+        """Represent the SnapAPIError class."""
         return "APIError({!r}, {!r}, {!r}, {!r})".format(
             self.body, self.code, self.status, self._message
         )
@@ -245,15 +244,15 @@ class Snap(object):
         ) == (other._name, other._revision)
 
     def __hash__(self):
-        """A basic hash so this class can be used in Mappings and dicts."""
+        """Calculate a hash for this snap."""
         return hash((self._name, self._revision))
 
     def __repr__(self):
-        """A representation of the snap."""
+        """Represent the object such that it can be reconstructed."""
         return "<{}.{}: {}>".format(self.__module__, self.__class__.__name__, self.__dict__)
 
     def __str__(self):
-        """A human-readable representation of the snap."""
+        """Represent the snap object as a string."""
         return "<{}: {}-{}.{} -- {}>".format(
             self.__class__.__name__,
             self._name,
@@ -312,7 +311,7 @@ class Snap(object):
             raise SnapError("Could not {} for snap [{}]: {}".format(_cmd, self._name, e.stderr))
 
     def get(self, key) -> str:
-        """Gets a snap configuration value.
+        """Fetch a snap configuration value.
 
         Args:
             key: the key to retrieve
@@ -320,7 +319,7 @@ class Snap(object):
         return self._snap("get", [key]).strip()
 
     def set(self, config: Dict) -> str:
-        """Sets a snap configuration value.
+        """Set a snap configuration value.
 
         Args:
            config: a dictionary containing keys and values specifying the config to set.
@@ -330,7 +329,7 @@ class Snap(object):
         return self._snap("set", [*args])
 
     def unset(self, key) -> str:
-        """Unsets a snap configuration value.
+        """Unset a snap configuration value.
 
         Args:
             key: the key to unset
@@ -338,7 +337,7 @@ class Snap(object):
         return self._snap("unset", [key])
 
     def start(self, services: Optional[List[str]] = None, enable: Optional[bool] = False) -> None:
-        """Starts a snap's services.
+        """Start a snap's services.
 
         Args:
             services (list): (optional) list of individual snap services to start (otherwise all)
@@ -348,7 +347,7 @@ class Snap(object):
         self._snap_daemons(args, services)
 
     def stop(self, services: Optional[List[str]] = None, disable: Optional[bool] = False) -> None:
-        """Stops a snap's services.
+        """Stop a snap's services.
 
         Args:
             services (list): (optional) list of individual snap services to stop (otherwise all)
@@ -358,7 +357,7 @@ class Snap(object):
         self._snap_daemons(args, services)
 
     def logs(self, services: Optional[List[str]] = None, num_lines: Optional[int] = 10) -> str:
-        """Shows a snap services' logs.
+        """Fetch a snap services' logs.
 
         Args:
             services (list): (optional) list of individual snap services to show logs from
@@ -371,7 +370,7 @@ class Snap(object):
     def connect(
         self, plug: str, service: Optional[str] = None, slot: Optional[str] = None
     ) -> None:
-        """Connects a plug to a slot.
+        """Connect a plug to a slot.
 
         Args:
             plug (str): the plug to connect
@@ -440,8 +439,9 @@ class Snap(object):
           cohort: optionally, specify a cohort.
           leave_cohort: leave the current cohort.
         """
-        channel = '--channel="{}"'.format(channel) if channel else ""
-        args = [channel]
+        args = []
+        if channel:
+            args.append('--channel="{}"'.format(channel))
 
         if not cohort:
             cohort = self._cohort
@@ -455,7 +455,7 @@ class Snap(object):
         self._snap("refresh", args)
 
     def _remove(self) -> str:
-        """Removes a snap from the system."""
+        """Remove a snap from the system."""
         return self._snap("remove")
 
     @property
@@ -470,7 +470,7 @@ class Snap(object):
         channel: Optional[str] = "",
         cohort: Optional[str] = "",
     ):
-        """Ensures that a snap is in a given state.
+        """Ensure that a snap is in a given state.
 
         Args:
           state: a `SnapState` to reconcile to.
@@ -504,7 +504,7 @@ class Snap(object):
         self._state = state
 
     def _update_snap_apps(self) -> None:
-        """Updates a snap's apps after snap changes state."""
+        """Update a snap's apps after snap changes state."""
         try:
             self._apps = self._snap_client.get_installed_snap_apps(self._name)
         except SnapAPIError:
@@ -513,22 +513,22 @@ class Snap(object):
 
     @property
     def present(self) -> bool:
-        """Returns whether or not a snap is present."""
+        """Report whether or not a snap is present."""
         return self._state in (SnapState.Present, SnapState.Latest)
 
     @property
     def latest(self) -> bool:
-        """Returns whether the snap is the most recent version."""
+        """Report whether the snap is the most recent version."""
         return self._state is SnapState.Latest
 
     @property
     def state(self) -> SnapState:
-        """Returns the current snap state."""
+        """Report the current snap state."""
         return self._state
 
     @state.setter
     def state(self, state: SnapState) -> None:
-        """Sets the snap state to a given value.
+        """Set the snap state to a given value.
 
         Args:
           state: a `SnapState` to reconcile the snap to.
@@ -734,15 +734,15 @@ class SnapCache(Mapping):
             self._load_installed_snaps()
 
     def __contains__(self, key: str) -> bool:
-        """Magic method to ease checking if a given snap is in the cache."""
+        """Check if a given snap is in the cache."""
         return key in self._snap_map
 
     def __len__(self) -> int:
-        """Returns number of items in the snap cache."""
+        """Report number of items in the snap cache."""
         return len(self._snap_map)
 
     def __iter__(self) -> Iterable["Snap"]:
-        """Magic method to provide an iterator for the snap cache."""
+        """Provide iterator for the snap cache."""
         return iter(self._snap_map.values())
 
     def __getitem__(self, snap_name: str) -> Snap:
@@ -829,6 +829,7 @@ def add(
         channel: an (Optional) channel as a string. Defaults to 'latest'
         classic: an (Optional) boolean specifying whether it should be added with classic
             confinement. Default `False`
+        cohort: an (Optional) string specifying the snap cohort to use
 
     Raises:
         SnapError if some snaps failed to install or were not found.
@@ -845,7 +846,7 @@ def add(
 
 @_cache_init
 def remove(snap_names: Union[str, List[str]]) -> Union[Snap, List[Snap]]:
-    """Removes a snap from the system.
+    """Remove specified snap(s) from the system.
 
     Args:
         snap_names: the name or names of the snaps to install
@@ -868,14 +869,15 @@ def ensure(
     classic: Optional[bool] = False,
     cohort: Optional[str] = "",
 ) -> Union[Snap, List[Snap]]:
-    """Ensures a snap is in a given state to the system.
+    """Ensure specified snaps are in a given state on the system.
 
     Args:
-        name: the name(s) of the snaps to operate on
+        snap_names: the name(s) of the snaps to operate on
         state: a string representation of the desired state, from `SnapState`
         channel: an (Optional) channel as a string. Defaults to 'latest'
         classic: an (Optional) boolean specifying whether it should be added with classic
             confinement. Default `False`
+        cohort: an (Optional) string specifying the snap cohort to use
 
     Raises:
         SnapError if the snap is not in the cache.
@@ -915,9 +917,7 @@ def _wrap_snap_operations(
 
     if len(snaps["failed"]):
         raise SnapError(
-            "Failed to install or refresh snap(s): {}".format(
-                ", ".join([s for s in snaps["failed"]])
-            )
+            "Failed to install or refresh snap(s): {}".format(", ".join(list(snaps["failed"])))
         )
 
     return snaps["success"] if len(snaps["success"]) > 1 else snaps["success"][0]
@@ -964,7 +964,7 @@ def install_local(
 
 
 def _system_set(config_item: str, value: str) -> None:
-    """Helper for setting snap system config values.
+    """Set system snapd config values.
 
     Args:
         config_item: name of snap system setting. E.g. 'refresh.hold'
@@ -977,19 +977,27 @@ def _system_set(config_item: str, value: str) -> None:
         raise SnapError("Failed setting system config '{}' to '{}'".format(config_item, value))
 
 
-def hold_refresh(days: int = 90) -> bool:
+def hold_refresh(days: int = 90, forever: bool = False) -> bool:
     """Set the system-wide snap refresh hold.
 
     Args:
         days: number of days to hold system refreshes for. Maximum 90. Set to zero to remove hold.
+        forever: if True, will set a hold forever.
     """
-    # Currently the snap daemon can only hold for a maximum of 90 days
-    if not isinstance(days, int) or days > 90:
-        raise ValueError("days must be an int between 1 and 90")
+    if not isinstance(forever, bool):
+        raise TypeError("forever must be a bool")
+    if not isinstance(days, int):
+        raise TypeError("days must be an int")
+    if forever:
+        _system_set("refresh.hold", "forever")
+        logger.info("Set system-wide snap refresh hold to: forever")
     elif days == 0:
         _system_set("refresh.hold", "")
         logger.info("Removed system-wide snap refresh hold")
     else:
+        # Currently the snap daemon can only hold for a maximum of 90 days
+        if not 1 <= days <= 90:
+            raise ValueError("days must be between 1 and 90")
         # Add the number of days to current time
         target_date = datetime.now(timezone.utc).astimezone() + timedelta(days=days)
         # Format for the correct datetime format

--- a/lib/charms/operator_libs_linux/v1/systemd.py
+++ b/lib/charms/operator_libs_linux/v1/systemd.py
@@ -60,21 +60,23 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 3
 
 
 class SystemdError(Exception):
+    """Custom exception for SystemD related errors."""
+
     pass
 
 
 def _popen_kwargs():
-    return dict(
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        bufsize=1,
-        universal_newlines=True,
-        encoding="utf-8",
-    )
+    return {
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.STDOUT,
+        "bufsize": 1,
+        "universal_newlines": True,
+        "encoding": "utf-8",
+    }
 
 
 def _systemctl(
@@ -114,7 +116,7 @@ def _systemctl(
 
     # If we are just checking whether a service is running, return True/False, rather
     # than raising an error.
-    if sub_cmd == "is-active" and proc.returncode == 3:  # Code returned when service is not active.
+    if sub_cmd == "is-active" and proc.returncode == 3:  # Code returned when service not active.
         return False
 
     if sub_cmd == "is-failed":

--- a/lib/charms/operator_libs_linux/v1/systemd.py
+++ b/lib/charms/operator_libs_linux/v1/systemd.py
@@ -109,16 +109,16 @@ def _systemctl(
 
     proc.wait()
 
-    if sub_cmd == "is-active":
-        # If we are just checking whether a service is running, return True/False, rather
-        # than raising an error.
-        if proc.returncode < 1:
-            return True
-        if proc.returncode == 3:  # Code returned when service is not active.
-            return False
-
     if proc.returncode < 1:
         return True
+
+    # If we are just checking whether a service is running, return True/False, rather
+    # than raising an error.
+    if sub_cmd == "is-active" and proc.returncode == 3:  # Code returned when service is not active.
+        return False
+
+    if sub_cmd == "is-failed":
+        return False
 
     raise SystemdError(
         "Could not {}{}: systemd output: {}".format(
@@ -134,6 +134,15 @@ def service_running(service_name: str) -> bool:
         service_name: the name of the service to check
     """
     return _systemctl("is-active", service_name, quiet=True)
+
+
+def service_failed(service_name: str) -> bool:
+    """Determine whether a system service has failed.
+
+    Args:
+        service_name: the name of the service to check
+    """
+    return _systemctl("is-failed", service_name, quiet=True)
 
 
 def service_start(service_name: str) -> bool:

--- a/lib/charms/rolling_ops/v0/rollingops.py
+++ b/lib/charms/rolling_ops/v0/rollingops.py
@@ -380,7 +380,8 @@ class RollingOpsManager(Object):
                 self.charm.on[self.name].run_with_lock.emit()
             return
 
-        self.model.app.status = ActiveStatus()
+        if self.model.app.status.message == f"Beginning rolling {self.name}":
+            self.model.app.status = ActiveStatus()
 
     def _on_acquire_lock(self: CharmBase, event: ActionEvent):
         """Request a lock."""
@@ -414,4 +415,5 @@ class RollingOpsManager(Object):
 
         # cleanup old callback overrides
         relation.data[self.charm.unit].update({"callback_override": ""})
-        self.model.unit.status = ActiveStatus()
+        if self.model.unit.status.message == f"Executing {self.name} operation":
+            self.model.unit.status = ActiveStatus()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ overrides==7.3.1
 requests==2.28.2
 ruamel.yaml==0.17.21
 tenacity==8.2.2
+urllib3==1.26.15

--- a/src/opensearch.py
+++ b/src/opensearch.py
@@ -25,7 +25,7 @@ from charms.opensearch.v0.opensearch_exceptions import (
 )
 from charms.operator_libs_linux.v1 import snap
 from charms.operator_libs_linux.v1.snap import SnapError
-from charms.operator_libs_linux.v1.systemd import _systemctl, service_failed
+from charms.operator_libs_linux.v1.systemd import service_failed
 from overrides import override
 from tenacity import retry, stop_after_attempt, wait_exponential
 
@@ -183,8 +183,7 @@ class OpenSearchTarball(OpenSearchDistribution):
     @override
     def is_failed(self) -> bool:
         """Check if the opensearch daemon has failed."""
-        # TODO: replace with is_failed from lib once PR made to the lib upstream.
-        return _systemctl("is-failed", "opensearch.service", quiet=True)
+        return service_failed("opensearch.service")
 
     @override
     def _build_paths(self) -> Paths:

--- a/src/opensearch.py
+++ b/src/opensearch.py
@@ -25,7 +25,7 @@ from charms.opensearch.v0.opensearch_exceptions import (
 )
 from charms.operator_libs_linux.v1 import snap
 from charms.operator_libs_linux.v1.snap import SnapError
-from charms.operator_libs_linux.v1.systemd import _systemctl
+from charms.operator_libs_linux.v1.systemd import _systemctl, service_failed
 from overrides import override
 from tenacity import retry, stop_after_attempt, wait_exponential
 
@@ -98,8 +98,7 @@ class OpenSearchSnap(OpenSearchDistribution):
         if not self._opensearch.present:
             raise OpenSearchMissingError()
 
-        # TODO: replace with is_failed from lib once PR made to the lib upstream.
-        return _systemctl("is-failed", "snap.opensearch.daemon.service", quiet=True)
+        return service_failed("snap.opensearch.daemon.service")
 
     @override
     def _build_paths(self) -> Paths:

--- a/tests/integration/ha/continuous_writes.py
+++ b/tests/integration/ha/continuous_writes.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import multiprocessing
+
+from integration.helpers import client
+from opensearchpy import OpenSearch, TransportError
+from opensearchpy.helpers import BulkIndexError, streaming_bulk
+from pytest_operator.plugin import OpsTest
+
+
+class ContinuousWrites:
+    """Utility class for managing continuous writes."""
+
+    INDEX_NAME = "my_index"
+
+    @staticmethod
+    def start(ops_test: OpsTest, starting_number: int) -> None:
+        # run continuous writes in the background.
+        process = multiprocessing.Process(
+            target=ContinuousWrites._start_writes,
+            name="continuous_writes",
+            args=(
+                ops_test,
+                starting_number,
+                True,
+            ),
+        )
+        process.start()
+
+    @staticmethod
+    async def stop(ops_test: OpsTest) -> int:
+        """Stop the continuous writes process and return max id."""
+        for process in multiprocessing.active_children():
+            if process.name == "continuous_writes":
+                process.terminate()
+
+        opensearch_client = await client(ops_test)
+        try:
+            # refresh the index so that all writes are visible on search
+            opensearch_client.indices.refresh(index=ContinuousWrites.INDEX_NAME)
+
+            resp = opensearch_client.search(
+                index=ContinuousWrites.INDEX_NAME,
+                body={
+                    "size": 0,
+                    "aggs": {"max_id": {"max": {"field": "id"}}},
+                },
+            )
+            return int(resp["aggregations"]["max_id"]["value"])
+        finally:
+            opensearch_client.close()
+
+    @staticmethod
+    async def clear(ops_test: OpsTest) -> None:
+        """Stop writes and Delete the index."""
+        await ContinuousWrites.stop(ops_test)
+
+        opensearch_client = await client(ops_test)
+        try:
+            opensearch_client.indices.delete(index=ContinuousWrites.INDEX_NAME)
+        finally:
+            opensearch_client.close()
+
+    @staticmethod
+    async def count(ops_test: OpsTest) -> int:
+        """Count the number of documents in the index."""
+        opensearch_client = await client(ops_test)
+        try:
+            # refresh the index so that all writes are visible on search
+            opensearch_client.indices.refresh(index=ContinuousWrites.INDEX_NAME)
+
+            resp = opensearch_client.count(index=ContinuousWrites.INDEX_NAME)
+            return int(resp["count"])
+        finally:
+            opensearch_client.close()
+
+    @staticmethod
+    async def _start_writes(ops_test: OpsTest, starting_number: int, is_bulk: bool = True) -> None:
+        write_value = starting_number
+
+        while True:
+            opensearch_client = await client(ops_test)
+            try:
+                if is_bulk:
+                    ContinuousWrites._bulk(opensearch_client, write_value)
+                else:
+                    ContinuousWrites._index(opensearch_client, write_value)
+            except (BulkIndexError, TransportError):
+                continue
+            finally:
+                opensearch_client.close()
+
+        write_value += 1
+
+    @staticmethod
+    def _bulk(opensearch_client: OpenSearch, write_value: int) -> None:
+        """Bulk Index group of docs."""
+        data = []
+        for i in range(100):
+            val = write_value + i
+            data.append(
+                {
+                    "_index": ContinuousWrites.INDEX_NAME,
+                    "_id": val,
+                    "_source": {
+                        "title": f"title_{val}",
+                        "val": val,
+                    },
+                }
+            )
+
+        streaming_bulk(opensearch_client, actions=data)
+
+    @staticmethod
+    def _index(opensearch_client: OpenSearch, write_value: int) -> None:
+        """Index single document."""
+        opensearch_client.index(
+            index=ContinuousWrites.INDEX_NAME,
+            id=write_value,
+            body={"title": f"title_{write_value}", "val": write_value},
+        )

--- a/tests/integration/ha/continuous_writes.py
+++ b/tests/integration/ha/continuous_writes.py
@@ -1,47 +1,93 @@
 #!/usr/bin/env python3
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
+import asyncio
+import logging
+from multiprocessing import Process, Queue
+from types import SimpleNamespace
 
-import multiprocessing
-
-from tests.integration.helpers import client
 from opensearchpy import OpenSearch, TransportError
-from opensearchpy.helpers import BulkIndexError, streaming_bulk
+from opensearchpy.helpers import BulkIndexError, bulk
 from pytest_operator.plugin import OpsTest
+
+from tests.integration.helpers import (
+    get_admin_secrets,
+    get_application_unit_ids,
+    get_application_unit_ips,
+    opensearch_client,
+)
+
+logging.getLogger("opensearch").setLevel(logging.ERROR)
+logging.getLogger("opensearchpy.helpers").setLevel(logging.ERROR)
 
 
 class ContinuousWrites:
     """Utility class for managing continuous writes."""
 
-    INDEX_NAME = "my_index"
+    INDEX_NAME = "series_index"
+    CERT_PATH = "/tmp/ca_chain.cert"
 
-    @staticmethod
-    def start(ops_test: OpsTest, starting_number: int) -> None:
-        # run continuous writes in the background.
-        process = multiprocessing.Process(
-            target=ContinuousWrites._start_writes,
-            name="continuous_writes",
-            args=(
-                ops_test,
-                starting_number,
-                True,
-            ),
+    def __init__(self, ops_test: OpsTest):
+        self._ops_test = ops_test
+        self._is_stopped = True
+        self._queue = None
+        self._process = None
+
+    async def start(self) -> None:
+        """Run continuous writes in the background."""
+        if not self._is_stopped:
+            await self.clear()
+
+        # create process
+        self._create_process()
+
+        # put data (hosts, password) in the process queue
+        await self.update()
+
+        # start writes
+        self._process.start()
+
+    async def update(self):
+        """Update cluster related conf. Useful in cases such as scaling, pwd change etc."""
+        password = await self._secrets()
+        self._queue.put(
+            SimpleNamespace(hosts=get_application_unit_ips(self._ops_test), password=password)
         )
-        process.start()
 
-    @staticmethod
-    async def stop(ops_test: OpsTest) -> int:
-        """Stop the continuous writes process and return max id."""
-        for process in multiprocessing.active_children():
-            if process.name == "continuous_writes":
-                process.terminate()
+    async def clear(self) -> None:
+        """Stop writes and Delete the index."""
+        if not self._is_stopped:
+            await self.stop()
 
-        opensearch_client = await client(ops_test)
+        client = await self._client()
+        try:
+            client.indices.delete(index=ContinuousWrites.INDEX_NAME)
+        finally:
+            client.close()
+
+    async def count(self) -> int:
+        """Count the number of documents in the index."""
+        client = await self._client()
         try:
             # refresh the index so that all writes are visible on search
-            opensearch_client.indices.refresh(index=ContinuousWrites.INDEX_NAME)
+            client.indices.refresh(index=ContinuousWrites.INDEX_NAME)
 
-            resp = opensearch_client.search(
+            resp = client.count(index=ContinuousWrites.INDEX_NAME)
+            return int(resp["count"])
+        finally:
+            client.close()
+
+    async def stop(self) -> int:
+        """Stop the continuous writes process and return max inserted ID."""
+        if not self._is_stopped:
+            self._stop_process()
+
+        client = await self._client()
+        try:
+            # refresh the index so that all writes are visible on search
+            client.indices.refresh(index=ContinuousWrites.INDEX_NAME)
+
+            resp = client.search(
                 index=ContinuousWrites.INDEX_NAME,
                 body={
                     "size": 0,
@@ -50,52 +96,67 @@ class ContinuousWrites:
             )
             return int(resp["aggregations"]["max_id"]["value"])
         finally:
-            opensearch_client.close()
+            client.close()
+
+    def _create_process(self):
+        self._is_stopped = False
+        self._queue = Queue()
+        self._process = Process(
+            target=ContinuousWrites._run_async,
+            name="continuous_writes",
+            args=(self._queue, 1, True),
+        )
+
+    def _stop_process(self):
+        self._process.terminate()
+        self._queue.close()
+        self._is_stopped = True
+
+    async def _secrets(self) -> str:
+        """Fetch secrets and return the password."""
+        secrets = await get_admin_secrets(
+            self._ops_test, get_application_unit_ids(self._ops_test)[0]
+        )
+        with open(ContinuousWrites.CERT_PATH, "w") as chain:
+            chain.write(secrets["ca-chain"])
+
+        return secrets["password"]
+
+    async def _client(self):
+        """Build an opensearch client."""
+        return opensearch_client(
+            get_application_unit_ips(self._ops_test),
+            "admin",
+            await self._secrets(),
+            ContinuousWrites.CERT_PATH,
+        )
 
     @staticmethod
-    async def clear(ops_test: OpsTest) -> None:
-        """Stop writes and Delete the index."""
-        await ContinuousWrites.stop(ops_test)
-
-        opensearch_client = await client(ops_test)
-        try:
-            opensearch_client.indices.delete(index=ContinuousWrites.INDEX_NAME)
-        finally:
-            opensearch_client.close()
-
-    @staticmethod
-    async def count(ops_test: OpsTest) -> int:
-        """Count the number of documents in the index."""
-        opensearch_client = await client(ops_test)
-        try:
-            # refresh the index so that all writes are visible on search
-            opensearch_client.indices.refresh(index=ContinuousWrites.INDEX_NAME)
-
-            resp = opensearch_client.count(index=ContinuousWrites.INDEX_NAME)
-            return int(resp["count"])
-        finally:
-            opensearch_client.close()
-
-    @staticmethod
-    async def _start_writes(ops_test: OpsTest, starting_number: int, is_bulk: bool = True) -> None:
+    async def _run(data_queue: Queue, starting_number: int, is_bulk: bool) -> None:
         write_value = starting_number
 
+        data = data_queue.get(True)
         while True:
-            opensearch_client = await client(ops_test)
+            if not data_queue.empty():
+                data = data_queue.get(False)
+
+            client = opensearch_client(
+                data.hosts, "admin", data.password, ContinuousWrites.CERT_PATH
+            )
             try:
                 if is_bulk:
-                    ContinuousWrites._bulk(opensearch_client, write_value)
+                    ContinuousWrites._bulk(client, write_value)
                 else:
-                    ContinuousWrites._index(opensearch_client, write_value)
+                    ContinuousWrites._index(client, write_value)
             except (BulkIndexError, TransportError):
                 continue
             finally:
-                opensearch_client.close()
+                client.close()
 
-        write_value += 1
+            write_value += 1
 
     @staticmethod
-    def _bulk(opensearch_client: OpenSearch, write_value: int) -> None:
+    def _bulk(client: OpenSearch, write_value: int) -> None:
         """Bulk Index group of docs."""
         data = []
         for i in range(100):
@@ -105,19 +166,24 @@ class ContinuousWrites:
                     "_index": ContinuousWrites.INDEX_NAME,
                     "_id": val,
                     "_source": {
+                        "id": val,
                         "title": f"title_{val}",
-                        "val": val,
                     },
                 }
             )
 
-        streaming_bulk(opensearch_client, actions=data)
+        bulk(client, actions=data)
 
     @staticmethod
-    def _index(opensearch_client: OpenSearch, write_value: int) -> None:
+    def _index(client: OpenSearch, write_value: int) -> None:
         """Index single document."""
-        opensearch_client.index(
+        client.index(
             index=ContinuousWrites.INDEX_NAME,
             id=write_value,
-            body={"title": f"title_{write_value}", "val": write_value},
+            body={"id": write_value, "title": f"title_{write_value}"},
         )
+
+    @staticmethod
+    def _run_async(data_queue: Queue, starting_number: int, is_bulk: bool):
+        """Run async code."""
+        asyncio.run(ContinuousWrites._run(data_queue, starting_number, is_bulk))

--- a/tests/integration/ha/continuous_writes.py
+++ b/tests/integration/ha/continuous_writes.py
@@ -4,7 +4,7 @@
 
 import multiprocessing
 
-from integration.helpers import client
+from tests.integration.helpers import client
 from opensearchpy import OpenSearch, TransportError
 from opensearchpy.helpers import BulkIndexError, streaming_bulk
 from pytest_operator.plugin import OpsTest

--- a/tests/integration/ha/test_horizontal_scaling.py
+++ b/tests/integration/ha/test_horizontal_scaling.py
@@ -245,7 +245,7 @@ async def test_safe_scale_down_roles_reassigning(
     # scale-down: remove a cm unit
     await ops_test.model.applications[APP_NAME].destroy_unit(f"{APP_NAME}/{unit_id_to_stop}")
     await ops_test.model.wait_for_idle(
-        apps=[APP_NAME], timeout=1000, wait_for_exact_units=4, idle_period=60
+        apps=[APP_NAME], status="active", timeout=1000, wait_for_exact_units=4, idle_period=60
     )
 
     # update hosts used in continuous writes
@@ -264,7 +264,7 @@ async def test_safe_scale_down_roles_reassigning(
     ][0]
     await ops_test.model.applications[APP_NAME].destroy_unit(f"{APP_NAME}/{unit_id_to_stop}")
     await ops_test.model.wait_for_idle(
-        apps=[APP_NAME], timeout=1000, wait_for_exact_units=3, idle_period=60
+        apps=[APP_NAME], status="active", timeout=1000, wait_for_exact_units=3, idle_period=60
     )
 
     # update hosts used in continuous writes

--- a/tests/integration/ha/test_horizontal_scaling.py
+++ b/tests/integration/ha/test_horizontal_scaling.py
@@ -6,9 +6,9 @@ import logging
 
 import pytest
 from charms.opensearch.v0.helper_cluster import ClusterTopology
-from integration.ha.continuous_writes import ContinuousWrites
 from pytest_operator.plugin import OpsTest
 
+from tests.integration.ha.continuous_writes import ContinuousWrites
 from tests.integration.ha.helpers import (
     all_nodes,
     cluster_allocation,

--- a/tox.ini
+++ b/tox.ini
@@ -97,7 +97,7 @@ deps =
 commands =
     pytest -v --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/tls/test_tls.py
 
-[testenv:ha-integration]
+[testenv:h-scaling-integration]
 description = Run HA integration tests
 pass_env =
     {[testenv]pass_env}

--- a/tox.ini
+++ b/tox.ini
@@ -72,6 +72,7 @@ pass_env =
     CI
     CI_PACKED_CHARMS
 deps =
+    opensearch-py
     pytest
     pytest-asyncio
     juju==2.9.38.1 # juju 3.0.0 has issues with retrieving action results
@@ -87,6 +88,7 @@ pass_env =
     CI
     CI_PACKED_CHARMS
 deps =
+    opensearch-py
     pytest
     pytest-asyncio
     juju==2.9.38.1 # juju 3.0.0 has issues with retrieving action results
@@ -102,6 +104,7 @@ pass_env =
     CI
     CI_PACKED_CHARMS
 deps =
+    opensearch-py
     pytest
     pytest-asyncio
     juju==2.9.38.1 # juju 3.0.0 has issues with retrieving action results
@@ -117,6 +120,7 @@ pass_env =
     CI
     CI_PACKED_CHARMS
 deps =
+    opensearch-py
     pytest
     pytest-asyncio
     juju==2.9.38.1 # juju 3.0.0 has issues with retrieving action results
@@ -132,6 +136,7 @@ pass_env =
     CI
     CI_PACKED_CHARMS
 deps =
+    opensearch-py
     pytest
     pytest-asyncio
     juju==2.9.38.1 # juju 3.0.0 has issues with retrieving action results


### PR DESCRIPTION
### Issue:
This PR implements [DPE-1262](https://warthogs.atlassian.net/browse/DPE-1262) & [DPE-1265](https://warthogs.atlassian.net/browse/DPE-1265), namely this PR implements:

- continuous writes for the integration tests:
    - bulk inserts 
    - single doc inserts
- Fixed bug in scale-up raised by this routine
- Fixed bug in scale-down where leader unit does not receive a peer rel data update
- Externalized health management of the cluster to its own class 
- Added the `opensearch-py` client in tests, for hosts rotation when performing requests 
- Updated `operator_libs_linux` libraries

[DPE-1262]: https://warthogs.atlassian.net/browse/DPE-1262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DPE-1265]: https://warthogs.atlassian.net/browse/DPE-1265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ