### PR TITLE
Updating CI to only use heavy runner when necessary

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,15 +46,63 @@ jobs:
     name: Build charms
     uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v2
 
-  integration-test:
+  lite-integration-test:
     strategy:
       fail-fast: false
       matrix:
         tox-environments:
           - charm-integration
           - tls-integration
-          - ha-integration
           - client-integration
+    name: ${{ matrix.tox-environments }}
+    needs:
+      - lint
+      - unit-test
+      - build
+    runs-on: ubuntu-22.04
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup operator environment
+        # TODO: Replace with custom image on self-hosted runner
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: lxd
+      - name: Download packed charm(s)
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.build.outputs.artifact-name }}
+      - name: Select tests
+        id: select-tests
+        run: |
+          if [ "${{ github.event_name }}" == "schedule" ]
+          then
+            echo Running unstable and stable tests
+            echo "mark_expression=" >> $GITHUB_OUTPUT
+          else
+            echo Skipping unstable tests
+            echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
+          fi
+      - name: Run integration tests
+        run: |
+          # set sysctl values in case the cloudinit-userdata not applied
+          sudo sysctl -w vm.max_map_count=262144 vm.swappiness=0 net.ipv4.tcp_retries2=5
+
+          tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}'
+        env:
+          CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}
+
+
+  # These tests currently compete for access to the 4-core runner amongst individual test runs in
+  # this repo, and with other charms. Therefore, this runner should be used sparingly until we can
+  # access more runners.
+  heavy-integration-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        tox-environments:
+          - ha-integration
     name: ${{ matrix.tox-environments }}
     needs:
       - lint


### PR DESCRIPTION
## Proposal
Currently the CI uses the heavy runner for all tests, meaning the tests all run in series rather than in parallel. Furthermore, not all tests need the heavy runner, so this PR makes use of the light runners where possible, and only uses the heavy runner where necessary

## Context
client-relation tests are intermittently failing. These have a fix in a separate PR, and aren't affected by this PR.