### PR TITLE
[DPE-1962] Continuous writing in tests

### DIFF
--- a/tests/integration/ha/continuous_writes.py
+++ b/tests/integration/ha/continuous_writes.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+import asyncio
+import logging
+import os
+from multiprocessing import Event, Process, Queue
+from types import SimpleNamespace
+
+from opensearchpy import OpenSearch, TransportError
+from opensearchpy.helpers import BulkIndexError, bulk
+from pytest_operator.plugin import OpsTest
+from tenacity import (
+    RetryError,
+    Retrying,
+    retry,
+    stop_after_attempt,
+    stop_after_delay,
+    wait_fixed,
+    wait_random,
+)
+
+from tests.integration.helpers import (
+    get_admin_secrets,
+    get_application_unit_ids,
+    get_application_unit_ips,
+    opensearch_client,
+)
+
+logging.getLogger("opensearch").setLevel(logging.ERROR)
+logging.getLogger("opensearchpy.helpers").setLevel(logging.ERROR)
+
+
+class ContinuousWrites:
+    """Utility class for managing continuous writes."""
+
+    INDEX_NAME = "series_index"
+    LAST_WRITTEN_VAL_PATH = "last_written_value"
+    CERT_PATH = "/tmp/ca_chain.cert"
+
+    def __init__(self, ops_test: OpsTest):
+        self._ops_test = ops_test
+        self._is_stopped = True
+        self._event = None
+        self._queue = None
+        self._process = None
+
+    async def start(self) -> None:
+        """Run continuous writes in the background."""
+        if not self._is_stopped:
+            await self.clear()
+
+        # create process
+        self._create_process()
+
+        # put data (hosts, password) in the process queue
+        await self.update()
+
+        # start writes
+        self._process.start()
+
+    async def update(self):
+        """Update cluster related conf. Useful in cases such as scaling, pwd change etc."""
+        password = await self._secrets()
+        self._queue.put(
+            SimpleNamespace(hosts=get_application_unit_ips(self._ops_test), password=password)
+        )
+
+    async def clear(self) -> None:
+        """Stop writes and Delete the index."""
+        if not self._is_stopped:
+            await self.stop()
+
+        client = await self._client()
+        try:
+            client.indices.delete(index=ContinuousWrites.INDEX_NAME)
+        finally:
+            client.close()
+
+    async def count(self) -> int:
+        """Count the number of documents in the index."""
+        client = await self._client()
+        try:
+            # refresh the index so that all writes are visible on search
+            client.indices.refresh(index=ContinuousWrites.INDEX_NAME)
+
+            resp = client.count(index=ContinuousWrites.INDEX_NAME)
+            return int(resp["count"])
+        finally:
+            client.close()
+
+    async def stop(self) -> SimpleNamespace:
+        """Stop the continuous writes process and return max inserted ID."""
+        if not self._is_stopped:
+            self._stop_process()
+
+        result = SimpleNamespace()
+
+        client = await self._client()
+        try:
+            # refresh the index so that all writes are visible on search
+            client.indices.refresh(index=ContinuousWrites.INDEX_NAME)
+
+            resp = client.search(
+                index=ContinuousWrites.INDEX_NAME,
+                body={
+                    "size": 0,
+                    "aggs": {"max_id": {"max": {"field": "id"}}},
+                },
+            )
+
+            # max stored document id
+            result.max_stored_id = int(resp["aggregations"]["max_id"]["value"])
+        finally:
+            client.close()
+
+        # documents count
+        result.count = await self.count()
+
+        # last expected document id stored on disk
+        try:
+            for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(5)):
+                with attempt:
+                    with open(ContinuousWrites.LAST_WRITTEN_VAL_PATH, "r") as f:
+                        result.last_expected_id = int(f.read().rstrip())
+        except RetryError:
+            result.last_expected_id = -1
+
+        return result
+
+    def _create_process(self):
+        self._is_stopped = False
+        self._event = Event()
+        self._queue = Queue()
+        self._process = Process(
+            target=ContinuousWrites._run_async,
+            name="continuous_writes",
+            args=(self._event, self._queue, 0, True),
+        )
+
+    def _stop_process(self):
+        self._event.set()
+        self._process.join()
+        self._queue.close()
+        self._is_stopped = True
+
+    async def _secrets(self) -> str:
+        """Fetch secrets and return the password."""
+        secrets = await get_admin_secrets(
+            self._ops_test, get_application_unit_ids(self._ops_test)[0]
+        )
+        with open(ContinuousWrites.CERT_PATH, "w") as chain:
+            chain.write(secrets["ca-chain"])
+
+        return secrets["password"]
+
+    async def _client(self):
+        """Build an opensearch client."""
+        return opensearch_client(
+            get_application_unit_ips(self._ops_test),
+            "admin",
+            await self._secrets(),
+            ContinuousWrites.CERT_PATH,
+        )
+
+    @staticmethod
+    async def _run(event: Event, data_queue: Queue, starting_number: int, is_bulk: bool) -> None:
+        """Continuous writing."""
+
+        def _client(_data) -> OpenSearch:
+            return opensearch_client(
+                _data.hosts, "admin", _data.password, ContinuousWrites.CERT_PATH
+            )
+
+        write_value = starting_number
+
+        data = data_queue.get(True)
+        client = _client(data)
+
+        while True:
+            if not data_queue.empty():  # currently evaluates to false as we don't make updates
+                data = data_queue.get(False)
+                client.close()
+                client = _client(data)
+
+            try:
+                if is_bulk:
+                    ContinuousWrites._bulk(client, write_value)
+                else:
+                    ContinuousWrites._index(client, write_value)
+            except BulkIndexError:
+                continue
+            except TransportError:
+                client.close()
+                client = _client(data)
+                continue
+            finally:
+                # process termination requested
+                if event.is_set():
+                    break
+
+            write_value += 1
+
+        # write last expected written value on disk
+        with open(ContinuousWrites.LAST_WRITTEN_VAL_PATH, "w") as f:
+            if is_bulk:
+                write_value = (100 * write_value) + 99
+
+            f.write(str(write_value))
+            os.fsync(f)
+
+        client.close()
+
+    @staticmethod
+    @retry(reraise=True, stop=stop_after_attempt(3), wait=wait_random(min=1, max=2))
+    def _bulk(client: OpenSearch, write_value: int) -> None:
+        """Bulk Index group of docs."""
+        data = []
+        for i in range(100):
+            val = (100 * write_value) + i
+            data.append(
+                {
+                    "_index": ContinuousWrites.INDEX_NAME,
+                    "_id": val,
+                    "_source": {
+                        "id": val,
+                        "title": f"title_{val}",
+                    },
+                }
+            )
+
+        success, errors = bulk(client, actions=data)
+        if errors:
+            raise BulkIndexError()
+
+    @staticmethod
+    @retry(reraise=True, stop=stop_after_attempt(3), wait=wait_random(min=1, max=2))
+    def _index(client: OpenSearch, write_value: int) -> None:
+        """Index single document."""
+        client.index(
+            index=ContinuousWrites.INDEX_NAME,
+            id=write_value,
+            body={"id": write_value, "title": f"title_{write_value}"},
+        )
+
+    @staticmethod
+    def _run_async(event: Event, data_queue: Queue, starting_number: int, is_bulk: bool):
+        """Run async code."""
+        asyncio.run(ContinuousWrites._run(event, data_queue, starting_number, is_bulk))

--- a/tests/integration/ha/test_horizontal_scaling.py
+++ b/tests/integration/ha/test_horizontal_scaling.py
@@ -90,10 +90,6 @@ async def test_horizontal_scale_up(
     num_units = len(ops_test.model.applications[APP_NAME].units)
     assert num_units == 3
 
-    # update hosts used in continuous writes, so that if we remove a node
-    # we still have working HTTP endpoints
-    # await c_writes.update()
-
     unit_names = get_application_unit_names(ops_test)
     leader_unit_ip = await get_leader_unit_ip(ops_test)
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -10,6 +10,8 @@ from typing import Dict, List, Optional, Union
 
 import requests
 import yaml
+from charms.opensearch.v0.helper_networking import is_reachable, reachable_hosts
+from opensearchpy import OpenSearch
 from pytest_operator.plugin import OpsTest
 from tenacity import retry, stop_after_attempt, wait_fixed, wait_random
 
@@ -154,6 +156,24 @@ async def get_leader_unit_id(ops_test: OpsTest) -> int:
     return int(leader_unit.name.split("/")[1])
 
 
+def get_reachable_unit_ips(ops_test: OpsTest) -> List[str]:
+    """Helper function to retrieve the IP addresses of all online units."""
+    return reachable_hosts(get_application_unit_ips(ops_test))
+
+
+def get_reachable_units(ops_test: OpsTest) -> Dict[int, str]:
+    """Helper function to retrieve a dict of id/IP addresses of all online units."""
+    result = {}
+    for unit in ops_test.model.applications[APP_NAME].units:
+        if not is_reachable(unit.public_address, 9200):
+            continue
+
+        u_id = int(unit.name.split("/")[1])
+        result[u_id] = unit.public_address
+
+    return result
+
+
 async def http_request(
     ops_test: OpsTest,
     method: str,
@@ -171,6 +191,7 @@ async def http_request(
         endpoint: the url to be called.
         payload: the body of the request if any.
         resp_status_code: whether to only return the http response code.
+        verify: whether verify certificate chain or not
         user_password: use alternative password than the admin one in the secrets.
 
     Returns:
@@ -204,12 +225,44 @@ async def http_request(
         return resp.json()
 
 
+def opensearch_client(
+    hosts: List[str], user_name: str, password: str, cert_path: str
+) -> OpenSearch:
+    """Build an opensearch client."""
+    return OpenSearch(
+        hosts=[{"host": ip, "port": 9200} for ip in hosts],
+        http_auth=(user_name, password),
+        http_compress=True,
+        sniff_on_start=True,  # sniff before doing anything
+        sniff_on_connection_fail=True,  # refresh nodes after a node fails to respond
+        sniffer_timeout=60,  # and also every 60 seconds
+        use_ssl=True,  # turn on ssl
+        verify_certs=True,  # make sure we verify SSL certificates
+        ssl_assert_hostname=False,
+        ssl_show_warn=False,
+        ca_certs=cert_path,  # cert path on disk
+    )
+
+
 @retry(
     wait=wait_fixed(wait=5) + wait_random(0, 5),
     stop=stop_after_attempt(15),
 )
-async def cluster_health(ops_test: OpsTest, unit_ip: str) -> Dict[str, any]:
+async def cluster_health(
+    ops_test: OpsTest, unit_ip: str, wait_for_green_first: bool = False
+) -> Dict[str, any]:
     """Fetch the cluster health."""
+    if wait_for_green_first:
+        try:
+            return await http_request(
+                ops_test,
+                "GET",
+                f"https://{unit_ip}:9200/_cluster/health?wait_for_status=green&timeout=1m",
+            )
+        except requests.HTTPError:
+            # it timed out, settle with current status, fetched next without the 1min wait
+            pass
+
     return await http_request(
         ops_test,
         "GET",

--- a/tox.ini
+++ b/tox.ini
@@ -72,6 +72,7 @@ pass_env =
     CI
     CI_PACKED_CHARMS
 deps =
+    opensearch-py
     pytest
     pytest-asyncio
     juju==2.9.38.1 # juju 3.0.0 has issues with retrieving action results
@@ -87,6 +88,7 @@ pass_env =
     CI
     CI_PACKED_CHARMS
 deps =
+    opensearch-py
     pytest
     pytest-asyncio
     juju==2.9.38.1 # juju 3.0.0 has issues with retrieving action results
@@ -102,6 +104,7 @@ pass_env =
     CI
     CI_PACKED_CHARMS
 deps =
+    opensearch-py
     pytest
     pytest-asyncio
     juju==2.9.38.1 # juju 3.0.0 has issues with retrieving action results
@@ -117,6 +120,7 @@ pass_env =
     CI
     CI_PACKED_CHARMS
 deps =
+    opensearch-py
     pytest
     pytest-asyncio
     juju==2.9.38.1 # juju 3.0.0 has issues with retrieving action results
@@ -132,6 +136,7 @@ pass_env =
     CI
     CI_PACKED_CHARMS
 deps =
+    opensearch-py
     pytest
     pytest-asyncio
     juju==2.9.38.1 # juju 3.0.0 has issues with retrieving action results


### PR DESCRIPTION
### Issue:
This PR implements [DPE-1262](https://warthogs.atlassian.net/browse/DPE-1262) & [DPE-1265](https://warthogs.atlassian.net/browse/DPE-1265), namely this PR implements:

- continuous writes for the integration tests:
    - bulk inserts 
    - single doc inserts
- Added the `opensearch-py` client in tests, for hosts rotation when performing requests 
- Updated `operator_libs_linux` libraries


[DPE-1262]: https://warthogs.atlassian.net/browse/DPE-1262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DPE-1265]: https://warthogs.atlassian.net/browse/DPE-1265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ