### PR TITLE
Horizontal scaling and status related bug fixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,51 +93,50 @@ jobs:
         env:
           CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}
 
-
   # These tests currently compete for access to the 4-core runner amongst individual test runs in
   # this repo, and with other charms. Therefore, this runner should be used sparingly until we can
   # access more runners.
-  # heavy-integration-test:
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       tox-environments:
-  #         - ha-integration
-  #   name: ${{ matrix.tox-environments }}
-  #   needs:
-  #     - lint
-  #     - unit-test
-  #     - build
-  #   runs-on: Ubuntu_4C_16M
-  #   timeout-minutes: 120
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #     - name: Setup operator environment
-  #       # TODO: Replace with custom image on self-hosted runner
-  #       uses: charmed-kubernetes/actions-operator@main
-  #       with:
-  #         provider: lxd
-  #     - name: Download packed charm(s)
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: ${{ needs.build.outputs.artifact-name }}
-  #     - name: Select tests
-  #       id: select-tests
-  #       run: |
-  #         if [ "${{ github.event_name }}" == "schedule" ]
-  #         then
-  #           echo Running unstable and stable tests
-  #           echo "mark_expression=" >> $GITHUB_OUTPUT
-  #         else
-  #           echo Skipping unstable tests
-  #           echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
-  #         fi
-  #     - name: Run integration tests
-  #       run: |
-  #         # set sysctl values in case the cloudinit-userdata not applied
-  #         sudo sysctl -w vm.max_map_count=262144 vm.swappiness=0 net.ipv4.tcp_retries2=5
-
-  #         tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}'
-  #       env:
-  #         CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}
+  heavy-integration-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        tox-environments:
+          - h-scaling-integration
+    name: ${{ matrix.tox-environments }}
+    needs:
+      - lint
+      - unit-test
+      - build
+    runs-on: Ubuntu_4C_16G
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup operator environment
+        # TODO: Replace with custom image on self-hosted runner
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: lxd
+      - name: Download packed charm(s)
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.build.outputs.artifact-name }}
+      - name: Select tests
+        id: select-tests
+        run: |
+          if [ "${{ github.event_name }}" == "schedule" ]
+          then
+            echo Running unstable and stable tests
+            echo "mark_expression=" >> $GITHUB_OUTPUT
+          else
+            echo Skipping unstable tests
+            echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
+          fi
+      - name: Run integration tests
+        run: |
+          # set sysctl values in case the cloudinit-userdata not applied
+          sudo sysctl -w vm.max_map_count=262144 vm.swappiness=0 net.ipv4.tcp_retries2=5
+          
+          tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}'
+        env:
+          CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}

--- a/lib/charms/opensearch/v0/helper_cluster.py
+++ b/lib/charms/opensearch/v0/helper_cluster.py
@@ -183,15 +183,21 @@ class ClusterState:
         reraise=True,
     )
     def shards(
-        opensearch: OpenSearchDistribution, host: Optional[str] = None
+        opensearch: OpenSearchDistribution,
+        host: Optional[str] = None,
+        alt_hosts: Optional[List[str]] = None,
     ) -> List[Dict[str, str]]:
         """Get all shards of all indexes in the cluster."""
-        return opensearch.request("GET", "/_cat/shards", host=host)
+        return opensearch.request("GET", "/_cat/shards", host=host, alt_hosts=alt_hosts)
 
     @staticmethod
-    def shards_by_state(opensearch: OpenSearchDistribution) -> Dict[str, List[str]]:
+    def shards_by_state(
+        opensearch: OpenSearchDistribution,
+        host: Optional[str] = None,
+        alt_hosts: Optional[List[str]] = None,
+    ) -> Dict[str, List[str]]:
         """Get the shards count by state."""
-        shards = ClusterState.shards(opensearch)
+        shards = ClusterState.shards(opensearch, host=host, alt_hosts=alt_hosts)
 
         shards_state_map = {}
         for shard in shards:
@@ -203,10 +209,12 @@ class ClusterState:
 
     @staticmethod
     def busy_shards_by_unit(
-        opensearch: OpenSearchDistribution, host: Optional[str] = None
+        opensearch: OpenSearchDistribution,
+        host: Optional[str] = None,
+        alt_hosts: Optional[List[str]] = None,
     ) -> Dict[str, List[str]]:
         """Get the busy shards of each index in the cluster."""
-        shards = ClusterState.shards(opensearch, host)
+        shards = ClusterState.shards(opensearch, host=host, alt_hosts=alt_hosts)
 
         busy_shards = {}
         for shard in shards:

--- a/lib/charms/opensearch/v0/opensearch_health.py
+++ b/lib/charms/opensearch/v0/opensearch_health.py
@@ -1,0 +1,149 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Base class for the OpenSearch Health management."""
+import logging
+from typing import Dict, Optional
+
+from charms.opensearch.v0.constants_charm import (
+    ClusterHealthRed,
+    ClusterHealthYellow,
+    WaitingForBusyShards,
+    WaitingForSpecificBusyShards,
+)
+from charms.opensearch.v0.helper_charm import Status
+from charms.opensearch.v0.helper_cluster import ClusterState
+from charms.opensearch.v0.helper_databag import Scope
+from charms.opensearch.v0.opensearch_exceptions import OpenSearchHttpError
+from ops.model import BlockedStatus, WaitingStatus
+
+# The unique Charmhub library identifier, never change it
+LIBID = "93d2c27f38974a59b3bbe39fb27ac98d"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+
+logger = logging.getLogger(__name__)
+
+
+class HealthColors:
+    """Colors the clusters or a unit may have depending on their health."""
+
+    GREEN = "green"
+    YELLOW = "yellow"
+    YELLOW_TEMP = "yellow-temp"
+    RED = "red"
+
+
+class OpenSearchHealth:
+    """Class for managing OpenSearch statuses."""
+
+    def __init__(self, charm):
+        self._charm = charm
+        self._opensearch = self._charm.opensearch
+
+    def apply(
+        self,
+        wait_for_green_first: bool = False,
+        use_localhost: bool = True,
+        app: bool = True,
+    ) -> str:
+        """Fetch cluster health and set it on the app status."""
+        host = self._charm.unit_ip if use_localhost else None
+        status = self._fetch_status(host, wait_for_green_first)
+
+        if app:
+            self.apply_for_app(status)
+        else:
+            self.apply_for_unit(status)
+
+        return status
+
+    def apply_for_app(self, status: str):
+        """Cluster wide / app status."""
+        if not self._charm.unit.is_leader():
+            # this is needed in case the leader is in an error state and doesn't
+            # report the status itself
+            self._charm.peers_data.put(Scope.UNIT, "health", status)
+            return status
+
+        if status == HealthColors.GREEN:
+            # green: cluster healthy
+            self._charm.status.clear(ClusterHealthRed, app=True)
+            self._charm.status.clear(ClusterHealthYellow, app=True)
+            self._charm.status.clear(WaitingForBusyShards, app=True)
+        elif status == HealthColors.RED:
+            # health RED, some primary shards are unassigned
+            self._charm.app.status = BlockedStatus(ClusterHealthRed)
+            return
+        else:
+            # cluster health is yellow, either a temporary state where shards are moving
+            # around (relocating / initializing) - or a permanent state where some replica
+            # shards are unassigned.
+            self._charm.app.status = (
+                BlockedStatus(ClusterHealthYellow)
+                if status == HealthColors.YELLOW
+                else WaitingStatus(WaitingForBusyShards)
+            )
+
+        return status
+
+    def apply_for_unit(self, status: str, host: Optional[str] = None):
+        """Apply the health status on the current unit."""
+        if status != HealthColors.YELLOW_TEMP:
+            self._charm.status.clear(
+                WaitingForSpecificBusyShards, pattern=Status.CheckPattern.Interpolated
+            )
+            return
+
+        busy_shards = ClusterState.busy_shards_by_unit(
+            self._opensearch, host=host, alt_hosts=self._charm.alt_hosts
+        ).get(self._charm.unit_name)
+
+        if busy_shards:
+            self._charm.unit.status = WaitingStatus(
+                WaitingForSpecificBusyShards.format(", ".join(busy_shards))
+            )
+        else:
+            self._charm.status.clear(
+                WaitingForSpecificBusyShards, pattern=Status.CheckPattern.Interpolated
+            )
+
+    def _fetch_status(self, host: Optional[str] = None, wait_for_green_first: bool = False):
+        """Fetch the current cluster status."""
+        response: Optional[Dict[str, any]] = None
+        if wait_for_green_first:
+            try:
+                response = ClusterState.health(
+                    self._opensearch,
+                    True,
+                    host=host,
+                    alt_hosts=self._charm.alt_hosts,
+                )
+            except OpenSearchHttpError:
+                # it timed out, settle with current status, fetched next without the 1min wait
+                pass
+
+        if not response:
+            response = ClusterState.health(
+                self._opensearch,
+                False,
+                host=host,
+                alt_hosts=self._charm.alt_hosts,
+            )
+
+        status = response["status"].lower()
+        if status != HealthColors.YELLOW:
+            return status
+
+        # we differentiate between a temp yellow (moving shards) and perm one (missing replicas)
+        shards_by_state = ClusterState.shards_by_state(
+            self._opensearch, host=host, alt_hosts=self._charm.alt_hosts
+        )
+        busy_shards = shards_by_state.get("INITIALIZING", 0) + shards_by_state.get("RELOCATING", 0)
+        return HealthColors.YELLOW_TEMP if busy_shards > 0 else HealthColors.YELLOW

--- a/lib/charms/operator_libs_linux/v1/snap.py
+++ b/lib/charms/operator_libs_linux/v1/snap.py
@@ -83,7 +83,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 10
 
 
 # Regex to locate 7-bit C1 ANSI sequences
@@ -113,7 +113,7 @@ class SnapService:
         enabled: bool = False,
         active: bool = False,
         activators: List[str] = [],
-        **kwargs
+        **kwargs,
     ):
         self.daemon = daemon
         self.daemon_scope = kwargs.get("daemon-scope", None) or daemon_scope
@@ -122,7 +122,7 @@ class SnapService:
         self.activators = activators
 
     def as_dict(self) -> Dict:
-        """Returns instance representation as dict."""
+        """Return instance representation as dict."""
         return {
             "daemon": self.daemon,
             "daemon_scope": self.daemon_scope,
@@ -158,7 +158,7 @@ class Error(Exception):
     """Base class of most errors raised by this library."""
 
     def __repr__(self):
-        """String representation of the Error class."""
+        """Represent the Error class."""
         return "<{}.{} {}>".format(type(self).__module__, type(self).__name__, self.args)
 
     @property
@@ -176,7 +176,6 @@ class SnapAPIError(Error):
     """Raised when an HTTP API error occurs talking to the Snapd server."""
 
     def __init__(self, body: Dict, code: int, status: str, message: str):
-        """This shouldn't be instantiated directly."""
         super().__init__(message)  # Makes str(e) return message
         self.body = body
         self.code = code
@@ -184,7 +183,7 @@ class SnapAPIError(Error):
         self._message = message
 
     def __repr__(self):
-        """String representation of the SnapAPIError class."""
+        """Represent the SnapAPIError class."""
         return "APIError({!r}, {!r}, {!r}, {!r})".format(
             self.body, self.code, self.status, self._message
         )
@@ -245,15 +244,15 @@ class Snap(object):
         ) == (other._name, other._revision)
 
     def __hash__(self):
-        """A basic hash so this class can be used in Mappings and dicts."""
+        """Calculate a hash for this snap."""
         return hash((self._name, self._revision))
 
     def __repr__(self):
-        """A representation of the snap."""
+        """Represent the object such that it can be reconstructed."""
         return "<{}.{}: {}>".format(self.__module__, self.__class__.__name__, self.__dict__)
 
     def __str__(self):
-        """A human-readable representation of the snap."""
+        """Represent the snap object as a string."""
         return "<{}: {}-{}.{} -- {}>".format(
             self.__class__.__name__,
             self._name,
@@ -312,7 +311,7 @@ class Snap(object):
             raise SnapError("Could not {} for snap [{}]: {}".format(_cmd, self._name, e.stderr))
 
     def get(self, key) -> str:
-        """Gets a snap configuration value.
+        """Fetch a snap configuration value.
 
         Args:
             key: the key to retrieve
@@ -320,7 +319,7 @@ class Snap(object):
         return self._snap("get", [key]).strip()
 
     def set(self, config: Dict) -> str:
-        """Sets a snap configuration value.
+        """Set a snap configuration value.
 
         Args:
            config: a dictionary containing keys and values specifying the config to set.
@@ -330,7 +329,7 @@ class Snap(object):
         return self._snap("set", [*args])
 
     def unset(self, key) -> str:
-        """Unsets a snap configuration value.
+        """Unset a snap configuration value.
 
         Args:
             key: the key to unset
@@ -338,7 +337,7 @@ class Snap(object):
         return self._snap("unset", [key])
 
     def start(self, services: Optional[List[str]] = None, enable: Optional[bool] = False) -> None:
-        """Starts a snap's services.
+        """Start a snap's services.
 
         Args:
             services (list): (optional) list of individual snap services to start (otherwise all)
@@ -348,7 +347,7 @@ class Snap(object):
         self._snap_daemons(args, services)
 
     def stop(self, services: Optional[List[str]] = None, disable: Optional[bool] = False) -> None:
-        """Stops a snap's services.
+        """Stop a snap's services.
 
         Args:
             services (list): (optional) list of individual snap services to stop (otherwise all)
@@ -358,7 +357,7 @@ class Snap(object):
         self._snap_daemons(args, services)
 
     def logs(self, services: Optional[List[str]] = None, num_lines: Optional[int] = 10) -> str:
-        """Shows a snap services' logs.
+        """Fetch a snap services' logs.
 
         Args:
             services (list): (optional) list of individual snap services to show logs from
@@ -371,7 +370,7 @@ class Snap(object):
     def connect(
         self, plug: str, service: Optional[str] = None, slot: Optional[str] = None
     ) -> None:
-        """Connects a plug to a slot.
+        """Connect a plug to a slot.
 
         Args:
             plug (str): the plug to connect
@@ -440,8 +439,9 @@ class Snap(object):
           cohort: optionally, specify a cohort.
           leave_cohort: leave the current cohort.
         """
-        channel = '--channel="{}"'.format(channel) if channel else ""
-        args = [channel]
+        args = []
+        if channel:
+            args.append('--channel="{}"'.format(channel))
 
         if not cohort:
             cohort = self._cohort
@@ -455,7 +455,7 @@ class Snap(object):
         self._snap("refresh", args)
 
     def _remove(self) -> str:
-        """Removes a snap from the system."""
+        """Remove a snap from the system."""
         return self._snap("remove")
 
     @property
@@ -470,7 +470,7 @@ class Snap(object):
         channel: Optional[str] = "",
         cohort: Optional[str] = "",
     ):
-        """Ensures that a snap is in a given state.
+        """Ensure that a snap is in a given state.
 
         Args:
           state: a `SnapState` to reconcile to.
@@ -504,7 +504,7 @@ class Snap(object):
         self._state = state
 
     def _update_snap_apps(self) -> None:
-        """Updates a snap's apps after snap changes state."""
+        """Update a snap's apps after snap changes state."""
         try:
             self._apps = self._snap_client.get_installed_snap_apps(self._name)
         except SnapAPIError:
@@ -513,22 +513,22 @@ class Snap(object):
 
     @property
     def present(self) -> bool:
-        """Returns whether or not a snap is present."""
+        """Report whether or not a snap is present."""
         return self._state in (SnapState.Present, SnapState.Latest)
 
     @property
     def latest(self) -> bool:
-        """Returns whether the snap is the most recent version."""
+        """Report whether the snap is the most recent version."""
         return self._state is SnapState.Latest
 
     @property
     def state(self) -> SnapState:
-        """Returns the current snap state."""
+        """Report the current snap state."""
         return self._state
 
     @state.setter
     def state(self, state: SnapState) -> None:
-        """Sets the snap state to a given value.
+        """Set the snap state to a given value.
 
         Args:
           state: a `SnapState` to reconcile the snap to.
@@ -734,15 +734,15 @@ class SnapCache(Mapping):
             self._load_installed_snaps()
 
     def __contains__(self, key: str) -> bool:
-        """Magic method to ease checking if a given snap is in the cache."""
+        """Check if a given snap is in the cache."""
         return key in self._snap_map
 
     def __len__(self) -> int:
-        """Returns number of items in the snap cache."""
+        """Report number of items in the snap cache."""
         return len(self._snap_map)
 
     def __iter__(self) -> Iterable["Snap"]:
-        """Magic method to provide an iterator for the snap cache."""
+        """Provide iterator for the snap cache."""
         return iter(self._snap_map.values())
 
     def __getitem__(self, snap_name: str) -> Snap:
@@ -829,6 +829,7 @@ def add(
         channel: an (Optional) channel as a string. Defaults to 'latest'
         classic: an (Optional) boolean specifying whether it should be added with classic
             confinement. Default `False`
+        cohort: an (Optional) string specifying the snap cohort to use
 
     Raises:
         SnapError if some snaps failed to install or were not found.
@@ -845,7 +846,7 @@ def add(
 
 @_cache_init
 def remove(snap_names: Union[str, List[str]]) -> Union[Snap, List[Snap]]:
-    """Removes a snap from the system.
+    """Remove specified snap(s) from the system.
 
     Args:
         snap_names: the name or names of the snaps to install
@@ -868,14 +869,15 @@ def ensure(
     classic: Optional[bool] = False,
     cohort: Optional[str] = "",
 ) -> Union[Snap, List[Snap]]:
-    """Ensures a snap is in a given state to the system.
+    """Ensure specified snaps are in a given state on the system.
 
     Args:
-        name: the name(s) of the snaps to operate on
+        snap_names: the name(s) of the snaps to operate on
         state: a string representation of the desired state, from `SnapState`
         channel: an (Optional) channel as a string. Defaults to 'latest'
         classic: an (Optional) boolean specifying whether it should be added with classic
             confinement. Default `False`
+        cohort: an (Optional) string specifying the snap cohort to use
 
     Raises:
         SnapError if the snap is not in the cache.
@@ -915,9 +917,7 @@ def _wrap_snap_operations(
 
     if len(snaps["failed"]):
         raise SnapError(
-            "Failed to install or refresh snap(s): {}".format(
-                ", ".join([s for s in snaps["failed"]])
-            )
+            "Failed to install or refresh snap(s): {}".format(", ".join(list(snaps["failed"])))
         )
 
     return snaps["success"] if len(snaps["success"]) > 1 else snaps["success"][0]
@@ -964,7 +964,7 @@ def install_local(
 
 
 def _system_set(config_item: str, value: str) -> None:
-    """Helper for setting snap system config values.
+    """Set system snapd config values.
 
     Args:
         config_item: name of snap system setting. E.g. 'refresh.hold'
@@ -977,19 +977,27 @@ def _system_set(config_item: str, value: str) -> None:
         raise SnapError("Failed setting system config '{}' to '{}'".format(config_item, value))
 
 
-def hold_refresh(days: int = 90) -> bool:
+def hold_refresh(days: int = 90, forever: bool = False) -> bool:
     """Set the system-wide snap refresh hold.
 
     Args:
         days: number of days to hold system refreshes for. Maximum 90. Set to zero to remove hold.
+        forever: if True, will set a hold forever.
     """
-    # Currently the snap daemon can only hold for a maximum of 90 days
-    if not isinstance(days, int) or days > 90:
-        raise ValueError("days must be an int between 1 and 90")
+    if not isinstance(forever, bool):
+        raise TypeError("forever must be a bool")
+    if not isinstance(days, int):
+        raise TypeError("days must be an int")
+    if forever:
+        _system_set("refresh.hold", "forever")
+        logger.info("Set system-wide snap refresh hold to: forever")
     elif days == 0:
         _system_set("refresh.hold", "")
         logger.info("Removed system-wide snap refresh hold")
     else:
+        # Currently the snap daemon can only hold for a maximum of 90 days
+        if not 1 <= days <= 90:
+            raise ValueError("days must be between 1 and 90")
         # Add the number of days to current time
         target_date = datetime.now(timezone.utc).astimezone() + timedelta(days=days)
         # Format for the correct datetime format

--- a/lib/charms/operator_libs_linux/v1/systemd.py
+++ b/lib/charms/operator_libs_linux/v1/systemd.py
@@ -60,21 +60,23 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 3
 
 
 class SystemdError(Exception):
+    """Custom exception for SystemD related errors."""
+
     pass
 
 
 def _popen_kwargs():
-    return dict(
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        bufsize=1,
-        universal_newlines=True,
-        encoding="utf-8",
-    )
+    return {
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.STDOUT,
+        "bufsize": 1,
+        "universal_newlines": True,
+        "encoding": "utf-8",
+    }
 
 
 def _systemctl(
@@ -109,16 +111,16 @@ def _systemctl(
 
     proc.wait()
 
-    if sub_cmd == "is-active":
-        # If we are just checking whether a service is running, return True/False, rather
-        # than raising an error.
-        if proc.returncode < 1:
-            return True
-        if proc.returncode == 3:  # Code returned when service is not active.
-            return False
-
     if proc.returncode < 1:
         return True
+
+    # If we are just checking whether a service is running, return True/False, rather
+    # than raising an error.
+    if sub_cmd == "is-active" and proc.returncode == 3:  # Code returned when service not active.
+        return False
+
+    if sub_cmd == "is-failed":
+        return False
 
     raise SystemdError(
         "Could not {}{}: systemd output: {}".format(
@@ -134,6 +136,15 @@ def service_running(service_name: str) -> bool:
         service_name: the name of the service to check
     """
     return _systemctl("is-active", service_name, quiet=True)
+
+
+def service_failed(service_name: str) -> bool:
+    """Determine whether a system service has failed.
+
+    Args:
+        service_name: the name of the service to check
+    """
+    return _systemctl("is-failed", service_name, quiet=True)
 
 
 def service_start(service_name: str) -> bool:

--- a/lib/charms/rolling_ops/v0/rollingops.py
+++ b/lib/charms/rolling_ops/v0/rollingops.py
@@ -380,7 +380,8 @@ class RollingOpsManager(Object):
                 self.charm.on[self.name].run_with_lock.emit()
             return
 
-        self.model.app.status = ActiveStatus()
+        if self.model.app.status.message == f"Beginning rolling {self.name}":
+            self.model.app.status = ActiveStatus()
 
     def _on_acquire_lock(self: CharmBase, event: ActionEvent):
         """Request a lock."""
@@ -414,4 +415,5 @@ class RollingOpsManager(Object):
 
         # cleanup old callback overrides
         relation.data[self.charm.unit].update({"callback_override": ""})
-        self.model.unit.status = ActiveStatus()
+        if self.model.unit.status.message == f"Executing {self.name} operation":
+            self.model.unit.status = ActiveStatus()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ overrides==7.3.1
 requests==2.28.2
 ruamel.yaml==0.17.21
 tenacity==8.2.2
+urllib3==1.26.15

--- a/src/opensearch.py
+++ b/src/opensearch.py
@@ -25,7 +25,7 @@ from charms.opensearch.v0.opensearch_exceptions import (
 )
 from charms.operator_libs_linux.v1 import snap
 from charms.operator_libs_linux.v1.snap import SnapError
-from charms.operator_libs_linux.v1.systemd import _systemctl
+from charms.operator_libs_linux.v1.systemd import service_failed
 from overrides import override
 from tenacity import retry, stop_after_attempt, wait_exponential
 
@@ -98,8 +98,7 @@ class OpenSearchSnap(OpenSearchDistribution):
         if not self._opensearch.present:
             raise OpenSearchMissingError()
 
-        # TODO: replace with is_failed from lib once PR made to the lib upstream.
-        return _systemctl("is-failed", "snap.opensearch.daemon.service", quiet=True)
+        return service_failed("snap.opensearch.daemon.service")
 
     @override
     def _build_paths(self) -> Paths:
@@ -184,8 +183,7 @@ class OpenSearchTarball(OpenSearchDistribution):
     @override
     def is_failed(self) -> bool:
         """Check if the opensearch daemon has failed."""
-        # TODO: replace with is_failed from lib once PR made to the lib upstream.
-        return _systemctl("is-failed", "opensearch.service", quiet=True)
+        return service_failed("opensearch.service")
 
     @override
     def _build_paths(self) -> Paths:

--- a/tox.ini
+++ b/tox.ini
@@ -95,7 +95,7 @@ deps =
 commands =
     pytest -v --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/tls/test_tls.py
 
-[testenv:ha-integration]
+[testenv:h-scaling-integration]
 description = Run HA integration tests
 pass_env =
     {[testenv]pass_env}


### PR DESCRIPTION
### Issue:

This PR fixes some issues that arose by running the `continuous writes` routines:
- during scale up, only recompute the roles once the last unit joins 
- make sure the leader unit's roles can be updated
- for the first unit on the cluster, only wait for the `opensearch service` to start, no need to check the host:port
- better health management
- externalized the health management into separate file/class
- updated charm libs


### Notes:
- Do NOT merge before [this PR](https://github.com/canonical/opensearch-operator/pull/57) 