### PR TITLE
[DPE-1266] HA test: kill cluster_manager and juju leader nodes 

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -304,17 +304,17 @@ class OpenSearchBaseCharm(CharmBase):
             self.unit.status = BlockedStatus(TooManyNodesRemoved)
             raise OpenSearchScaleDownError(TooManyNodesRemoved)
 
-        # attempt lock acquisition through index creation, should crash if index already created
-        # meaning another unit is holding the lock
         if self.opensearch.is_node_up() and self.alt_hosts:
-            self.opensearch.request("PUT", "/.ops_stop", retries=3)
-
             # TODO query if current is CM + is_leader
             if self.unit.is_leader():
                 remaining_nodes = [
                     node for node in self._get_nodes(True) if node.name != self.unit_name
                 ]
                 self._compute_and_broadcast_updated_topology(remaining_nodes)
+
+            # attempt lock acquisition through index creation, should crash if index
+            # already created, meaning another unit is holding the lock
+            self.opensearch.request("PUT", "/.ops_stop", retries=3)
 
         try:
             self._stop_opensearch()

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -101,7 +101,7 @@ async def create_dummy_indexes(ops_test: OpsTest, unit_ip: str, count: int = 5) 
     stop=stop_after_attempt(15),
 )
 async def delete_dummy_indexes(ops_test: OpsTest, unit_ip: str, count: int = 5) -> None:
-    """Create indexes."""
+    """Delete dummy indexes."""
     for index_id in range(count):
         await http_request(
             ops_test,

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -2,7 +2,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 from random import randint
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from charms.opensearch.v0.models import Node
 from pytest_operator.plugin import OpsTest
@@ -10,6 +10,38 @@ from tenacity import retry, stop_after_attempt, wait_fixed, wait_random
 
 from tests.integration.ha.continuous_writes import ContinuousWrites
 from tests.integration.helpers import http_request
+
+
+async def app_name(ops_test: OpsTest) -> Optional[str]:
+    """Returns the name of the cluster running OpenSearch.
+
+    This is important since not all deployments of the OpenSearch charm have the
+    application name "opensearch".
+    Note: if multiple clusters are running OpenSearch this will return the one first found.
+    """
+    status = await ops_test.model.get_status()
+    for app in ops_test.model.applications:
+        if "opensearch" in status["applications"][app]["charm"]:
+            return app
+
+    return None
+
+
+async def get_elected_cm_unit_id(ops_test: OpsTest, unit_ip: str) -> int:
+    """Returns the unit id of the current elected cm node."""
+    # get current elected cm node
+    resp = await http_request(
+        ops_test,
+        "GET",
+        f"https://{unit_ip}:9200/_cluster/state/cluster_manager_node",
+    )
+    cm_node_id = resp.get("cluster_manager_node")
+    if not cm_node_id:
+        return -1
+
+    # get all nodes
+    resp = await http_request(ops_test, "GET", f"https://{unit_ip}:9200/_nodes")
+    return int(resp["nodes"][cm_node_id]["name"].split("-")[1])
 
 
 @retry(
@@ -61,6 +93,20 @@ async def create_dummy_indexes(ops_test: OpsTest, unit_ip: str, count: int = 5) 
                     "index": {"number_of_shards": p_shards, "number_of_replicas": r_shards}
                 }
             },
+        )
+
+
+@retry(
+    wait=wait_fixed(wait=5) + wait_random(0, 5),
+    stop=stop_after_attempt(15),
+)
+async def delete_dummy_indexes(ops_test: OpsTest, unit_ip: str, count: int = 5) -> None:
+    """Create indexes."""
+    for index_id in range(count):
+        await http_request(
+            ops_test,
+            "DELETE",
+            f"https://{unit_ip}:9200/index_{index_id}",
         )
 
 

--- a/tests/integration/ha/test_horizontal_scaling.py
+++ b/tests/integration/ha/test_horizontal_scaling.py
@@ -288,8 +288,8 @@ async def test_safe_scale_down_remove_leaders(
     """
     app = await app_name(ops_test)
 
-    # scale up by 1 unit
-    await ops_test.model.applications[app].add_unit(count=1)
+    # scale up by 2 units
+    await ops_test.model.applications[app].add_unit(count=2)
     await ops_test.model.wait_for_idle(
         apps=[app], status="active", timeout=1000, wait_for_exact_units=5, idle_period=60
     )
@@ -299,7 +299,7 @@ async def test_safe_scale_down_remove_leaders(
 
     await ops_test.model.applications[app].destroy_unit(f"{app}/{leader_unit_id}")
     await ops_test.model.wait_for_idle(
-        apps=[app], status="active", timeout=1000, wait_for_exact_units=4, idle_period=90
+        apps=[app], status="active", timeout=1000, wait_for_exact_units=4, idle_period=120
     )
 
     # make sure the duties supposed to be done by the departing leader are done

--- a/tests/integration/ha/test_horizontal_scaling.py
+++ b/tests/integration/ha/test_horizontal_scaling.py
@@ -303,7 +303,8 @@ async def test_safe_scale_down_remove_leaders(
     )
 
     # make sure the duties supposed to be done by the departing leader are done
-    # we expect to have 3 cm-eligible and 1 data-only nodes
+    # we expect to have 3 cm-eligible+data (one of which will be elected) and
+    # 1 data-only nodes as per the roles-reassigning logic
     leader_unit_ip = await get_leader_unit_ip(ops_test)
     nodes = await all_nodes(ops_test, leader_unit_ip)
     assert ClusterTopology.nodes_count_by_role(nodes)["cluster_manager"] == 3
@@ -312,8 +313,6 @@ async def test_safe_scale_down_remove_leaders(
     # scale-down: remove the current elected CM
     first_elected_cm_unit_id = await get_elected_cm_unit_id(ops_test, leader_unit_ip)
     assert first_elected_cm_unit_id != -1
-
-    # scale-down: remove the elected cm
     await ops_test.model.applications[app].destroy_unit(f"{app}/{first_elected_cm_unit_id}")
     await ops_test.model.wait_for_idle(
         apps=[app], status="active", timeout=1000, wait_for_exact_units=3, idle_period=90

--- a/tests/integration/ha/test_horizontal_scaling.py
+++ b/tests/integration/ha/test_horizontal_scaling.py
@@ -38,6 +38,8 @@ from tests.integration.tls.test_tls import TLS_CERTIFICATES_APP_NAME
 
 logger = logging.getLogger(__name__)
 
+IDLE_PERIOD = 120
+
 
 @pytest.fixture()
 def c_writes(ops_test: OpsTest):
@@ -90,7 +92,7 @@ async def test_horizontal_scale_up(
     # scale up
     await ops_test.model.applications[app].add_unit(count=2)
     await ops_test.model.wait_for_idle(
-        apps=[app], status="active", timeout=1000, wait_for_exact_units=3, idle_period=60
+        apps=[app], status="active", timeout=1000, wait_for_exact_units=3, idle_period=IDLE_PERIOD
     )
     num_units = len(ops_test.model.applications[app].units)
     assert num_units == 3
@@ -130,7 +132,7 @@ async def test_safe_scale_down_shards_realloc(
     # scale up
     await ops_test.model.applications[app].add_unit(count=1)
     await ops_test.model.wait_for_idle(
-        apps=[app], status="active", timeout=1000, wait_for_exact_units=4, idle_period=60
+        apps=[app], status="active", timeout=1000, wait_for_exact_units=4, idle_period=IDLE_PERIOD
     )
 
     leader_unit_ip = await get_leader_unit_ip(ops_test)
@@ -158,7 +160,7 @@ async def test_safe_scale_down_shards_realloc(
     # remove the service in the chosen unit
     await ops_test.model.applications[app].destroy_unit(f"{app}/{unit_id_to_stop}")
     await ops_test.model.wait_for_idle(
-        apps=[app], status="active", timeout=1000, wait_for_exact_units=3, idle_period=60
+        apps=[app], status="active", timeout=1000, wait_for_exact_units=3, idle_period=IDLE_PERIOD
     )
 
     # check if at least partial shard re-allocation happened
@@ -184,7 +186,7 @@ async def test_safe_scale_down_shards_realloc(
     # scale up by 1 unit
     await ops_test.model.applications[app].add_unit(count=1)
     await ops_test.model.wait_for_idle(
-        apps=[app], status="active", timeout=1000, wait_for_exact_units=4, idle_period=60
+        apps=[app], status="active", timeout=1000, wait_for_exact_units=4, idle_period=IDLE_PERIOD
     )
 
     new_unit_id = [
@@ -229,7 +231,7 @@ async def test_safe_scale_down_roles_reassigning(
     # scale up by 1 unit
     await ops_test.model.applications[app].add_unit(count=1)
     await ops_test.model.wait_for_idle(
-        apps=[app], status="active", timeout=1000, wait_for_exact_units=5, idle_period=60
+        apps=[app], status="active", timeout=1000, wait_for_exact_units=5, idle_period=IDLE_PERIOD
     )
 
     leader_unit_ip = await get_leader_unit_ip(ops_test)
@@ -248,7 +250,7 @@ async def test_safe_scale_down_roles_reassigning(
     # scale-down: remove a cm unit
     await ops_test.model.applications[app].destroy_unit(f"{app}/{unit_id_to_stop}")
     await ops_test.model.wait_for_idle(
-        apps=[app], status="active", timeout=1000, wait_for_exact_units=4, idle_period=60
+        apps=[app], status="active", timeout=1000, wait_for_exact_units=4, idle_period=IDLE_PERIOD
     )
 
     # fetch nodes, we expect to have a "cm" node, reconfigured to be "data only" to keep the quorum
@@ -264,7 +266,7 @@ async def test_safe_scale_down_roles_reassigning(
     ][0]
     await ops_test.model.applications[app].destroy_unit(f"{app}/{unit_id_to_stop}")
     await ops_test.model.wait_for_idle(
-        apps=[app], status="active", timeout=1000, wait_for_exact_units=3, idle_period=90
+        apps=[app], status="active", timeout=1000, wait_for_exact_units=3, idle_period=IDLE_PERIOD
     )
 
     # fetch nodes, we expect to have all nodes "cluster_manager" to keep the quorum
@@ -291,7 +293,7 @@ async def test_safe_scale_down_remove_leaders(
     # scale up by 2 units
     await ops_test.model.applications[app].add_unit(count=2)
     await ops_test.model.wait_for_idle(
-        apps=[app], status="active", timeout=1000, wait_for_exact_units=5, idle_period=60
+        apps=[app], status="active", timeout=1000, wait_for_exact_units=5, idle_period=IDLE_PERIOD
     )
 
     # scale down: remove the juju leader
@@ -299,7 +301,7 @@ async def test_safe_scale_down_remove_leaders(
 
     await ops_test.model.applications[app].destroy_unit(f"{app}/{leader_unit_id}")
     await ops_test.model.wait_for_idle(
-        apps=[app], status="active", timeout=1000, wait_for_exact_units=4, idle_period=120
+        apps=[app], status="active", timeout=1000, wait_for_exact_units=4, idle_period=IDLE_PERIOD
     )
 
     # make sure the duties supposed to be done by the departing leader are done
@@ -315,7 +317,7 @@ async def test_safe_scale_down_remove_leaders(
     assert first_elected_cm_unit_id != -1
     await ops_test.model.applications[app].destroy_unit(f"{app}/{first_elected_cm_unit_id}")
     await ops_test.model.wait_for_idle(
-        apps=[app], status="active", timeout=1000, wait_for_exact_units=3, idle_period=90
+        apps=[app], status="active", timeout=1000, wait_for_exact_units=3, idle_period=IDLE_PERIOD
     )
 
     # check if CM re-election happened


### PR DESCRIPTION
### Issue:
This PR implements [DPE-1266](https://warthogs.atlassian.net/browse/DPE-1266), namely this PR implements:
- targeted removal of:
   - elected cluster manager node 
   - elected juju leader node
- externalization of the `app name` for running integration tests against existing running deployments.


[DPE-1266]: https://warthogs.atlassian.net/browse/DPE-1266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ