### PR TITLE
Helpers for ha tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,6 +57,7 @@ jobs:
           - charm-integration
           - tls-integration
           - client-integration
+          # - ha-integration
     name: ${{ matrix.tox-environments }}
     needs:
       - lint

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
-from random import randint
 from typing import Dict, List, Optional
 
 from charms.opensearch.v0.models import Node
@@ -10,6 +9,17 @@ from tenacity import retry, stop_after_attempt, wait_fixed, wait_random
 
 from tests.integration.ha.continuous_writes import ContinuousWrites
 from tests.integration.helpers import http_request
+
+
+class Shard:
+    """Class for holding a shard."""
+
+    def __init__(self, index: str, num: int, is_prim: bool, node_id: str, unit_id: int):
+        self.index = index
+        self.num = num
+        self.is_prim = is_prim
+        self.node_id = node_id
+        self.unit_id = unit_id
 
 
 async def app_name(ops_test: OpsTest) -> Optional[str]:
@@ -79,56 +89,40 @@ async def get_shards_by_state(ops_test: OpsTest, unit_ip: str) -> Dict[str, List
     wait=wait_fixed(wait=5) + wait_random(0, 5),
     stop=stop_after_attempt(15),
 )
-async def create_dummy_indexes(ops_test: OpsTest, unit_ip: str, count: int = 5) -> None:
-    """Create indexes."""
-    for index_id in range(count):
-        p_shards = index_id % 2 + 2
-        r_shards = 3 if p_shards == 2 else 2
-        await http_request(
-            ops_test,
-            "PUT",
-            f"https://{unit_ip}:9200/index_{index_id}",
-            {
-                "settings": {
-                    "index": {"number_of_shards": p_shards, "number_of_replicas": r_shards}
-                }
-            },
-        )
+async def get_shards_by_index(ops_test: OpsTest, unit_ip: str, index_name: str) -> List[Shard]:
+    """Returns the list of shards and their location in cluster for an index.
 
+    Args:
+        ops_test: The ops test framework instance.
+        unit_ip: The ip of the OpenSearch unit.
+        index_name: the name of the index.
 
-@retry(
-    wait=wait_fixed(wait=5) + wait_random(0, 5),
-    stop=stop_after_attempt(15),
-)
-async def delete_dummy_indexes(ops_test: OpsTest, unit_ip: str, count: int = 5) -> None:
-    """Delete dummy indexes."""
-    for index_id in range(count):
-        await http_request(
-            ops_test,
-            "DELETE",
-            f"https://{unit_ip}:9200/index_{index_id}",
-        )
+    Returns:
+        List of shards.
+    """
+    response = await http_request(
+        ops_test,
+        "GET",
+        f"https://{unit_ip}:9200/{index_name}/_search_shards",
+    )
 
+    nodes = response["nodes"]
 
-@retry(
-    wait=wait_fixed(wait=5) + wait_random(0, 5),
-    stop=stop_after_attempt(15),
-)
-async def create_dummy_docs(ops_test: OpsTest, unit_ip: str, count: int = 5) -> None:
-    """Store documents in the dummy indexes."""
-    all_docs = ""
-    for index_id in range(count):
-        for doc_id in range(count * 1000):
-            all_docs = (
-                f"{all_docs}"
-                f'{{"create":{{"_index":"index_{index_id}", "_id":"{doc_id}"}}}}\n'
-                f'{{"ProductId": "{1000 + doc_id}", '
-                f'"Amount": "{randint(10, 1000)}", '
-                f'"Quantity": "{randint(0, 50)}", '
-                f'Store_Id": "{randint(1, 250)}"}}\n'
+    result = []
+    for shards_collection in response["shards"]:
+        for shard in shards_collection:
+            unit_id = int(nodes[shard["node"]]["name"].split("-")[1])
+            result.append(
+                Shard(
+                    index=index_name,
+                    num=shard["shard"],
+                    is_prim=shard["primary"],
+                    node_id=shard["node"],
+                    unit_id=unit_id,
+                )
             )
 
-    await http_request(ops_test, "PUT", f"https://{unit_ip}:9200/_bulk", payload=all_docs)
+    return result
 
 
 @retry(

--- a/tests/integration/ha/helpers_data.py
+++ b/tests/integration/ha/helpers_data.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Helper functions for data related tests, such as indexing, searching etc.."""
+from random import randint
+from typing import Any, Dict, Optional
+
+from pytest_operator.plugin import OpsTest
+from tenacity import retry, stop_after_attempt, wait_fixed, wait_random
+
+from tests.integration.helpers import http_request
+
+
+@retry(
+    wait=wait_fixed(wait=5) + wait_random(0, 5),
+    stop=stop_after_attempt(15),
+)
+async def create_dummy_indexes(ops_test: OpsTest, unit_ip: str, count: int = 5) -> None:
+    """Create indexes."""
+    for index_id in range(count):
+        p_shards = index_id % 2 + 2
+        r_shards = 3 if p_shards == 2 else 2
+        await http_request(
+            ops_test,
+            "PUT",
+            f"https://{unit_ip}:9200/index_{index_id}",
+            {
+                "settings": {
+                    "index": {"number_of_shards": p_shards, "number_of_replicas": r_shards}
+                }
+            },
+        )
+
+
+@retry(
+    wait=wait_fixed(wait=5) + wait_random(0, 5),
+    stop=stop_after_attempt(15),
+)
+async def delete_dummy_indexes(ops_test: OpsTest, unit_ip: str, count: int = 5) -> None:
+    """Delete dummy indexes."""
+    for index_id in range(count):
+        await http_request(
+            ops_test,
+            "DELETE",
+            f"https://{unit_ip}:9200/index_{index_id}",
+        )
+
+
+@retry(
+    wait=wait_fixed(wait=5) + wait_random(0, 5),
+    stop=stop_after_attempt(15),
+)
+async def create_dummy_docs(ops_test: OpsTest, unit_ip: str, count: int = 5) -> None:
+    """Store documents in the dummy indexes."""
+    all_docs = ""
+    for index_id in range(count):
+        for doc_id in range(count * 1000):
+            all_docs = (
+                f"{all_docs}"
+                f'{{"create":{{"_index":"index_{index_id}", "_id":"{doc_id}"}}}}\n'
+                f'{{"ProductId": "{1000 + doc_id}", '
+                f'"Amount": "{randint(10, 1000)}", '
+                f'"Quantity": "{randint(0, 50)}", '
+                f'Store_Id": "{randint(1, 250)}"}}\n'
+            )
+
+    await http_request(ops_test, "PUT", f"https://{unit_ip}:9200/_bulk", payload=all_docs)
+
+
+@retry(
+    wait=wait_fixed(wait=5) + wait_random(0, 5),
+    stop=stop_after_attempt(15),
+)
+async def create_index(
+    ops_test: OpsTest, unit_ip: str, index_name: str, p_shards: int = 1, r_shards: int = 1
+) -> None:
+    """Create an index with a set number of primary and replica shards."""
+    await http_request(
+        ops_test,
+        "PUT",
+        f"https://{unit_ip}:9200/{index_name}",
+        {"settings": {"index": {"number_of_shards": p_shards, "number_of_replicas": r_shards}}},
+    )
+
+
+@retry(
+    wait=wait_fixed(wait=5) + wait_random(0, 5),
+    stop=stop_after_attempt(15),
+)
+async def index_doc(
+    ops_test: OpsTest,
+    unit_ip: str,
+    index_name: str,
+    doc_id: int,
+    doc: Optional[Dict[str, any]] = None,
+    refresh: bool = True,
+) -> None:
+    """Index a simple document."""
+    if not doc:
+        doc = default_doc(index_name, doc_id)
+
+    await http_request(
+        ops_test, "PUT", f"https://{unit_ip}:9200/{index_name}/{doc_id}", payload=doc
+    )
+
+    # a refresh makes the indexed data available for search, runs by default every 30 sec,
+    # but we can manually trigger it like below
+    if refresh:
+        await http_request(ops_test, "POST", f"https://{unit_ip}:9200/{index_name}/_refresh")
+
+
+@retry(
+    wait=wait_fixed(wait=5) + wait_random(0, 5),
+    stop=stop_after_attempt(15),
+)
+async def get_doc(ops_test: OpsTest, unit_ip: str, index_name: str, doc_id: int) -> Dict[str, Any]:
+    """Index a simple document."""
+    return await http_request(
+        ops_test, "GET", f"https://{unit_ip}:9200/{index_name}/_doc/{doc_id}"
+    )
+
+
+@retry(
+    wait=wait_fixed(wait=5) + wait_random(0, 5),
+    stop=stop_after_attempt(15),
+)
+async def delete_doc(ops_test: OpsTest, unit_ip: str, index_name: str, doc_id: int) -> None:
+    """Index a simple document."""
+    await http_request(
+        ops_test,
+        "DELETE",
+        f"https://{unit_ip}:9200/{index_name}/_doc/{doc_id}",
+    )
+
+
+@retry(
+    wait=wait_fixed(wait=5) + wait_random(0, 5),
+    stop=stop_after_attempt(15),
+)
+async def delete_index(ops_test: OpsTest, unit_ip: str, index_name: str) -> None:
+    """Index a simple document."""
+    await http_request(
+        ops_test,
+        "DELETE",
+        f"https://{unit_ip}:9200/{index_name}/",
+    )
+
+
+def default_doc(index_name: str, doc_id: int) -> Dict[str, Any]:
+    """Return a default document used in the tests."""
+    return {"title": f"title_{doc_id}", "val": doc_id, "path": f"{index_name}/{doc_id}"}

--- a/tests/integration/ha/helpers_data.py
+++ b/tests/integration/ha/helpers_data.py
@@ -115,7 +115,7 @@ async def index_doc(
     stop=stop_after_attempt(15),
 )
 async def get_doc(ops_test: OpsTest, unit_ip: str, index_name: str, doc_id: int) -> Dict[str, Any]:
-    """Index a simple document."""
+    """Fetch a document by id."""
     return await http_request(
         ops_test, "GET", f"https://{unit_ip}:9200/{index_name}/_doc/{doc_id}"
     )
@@ -126,7 +126,7 @@ async def get_doc(ops_test: OpsTest, unit_ip: str, index_name: str, doc_id: int)
     stop=stop_after_attempt(15),
 )
 async def delete_doc(ops_test: OpsTest, unit_ip: str, index_name: str, doc_id: int) -> None:
-    """Index a simple document."""
+    """Delete a document by id."""
     await http_request(
         ops_test,
         "DELETE",
@@ -139,7 +139,7 @@ async def delete_doc(ops_test: OpsTest, unit_ip: str, index_name: str, doc_id: i
     stop=stop_after_attempt(15),
 )
 async def delete_index(ops_test: OpsTest, unit_ip: str, index_name: str) -> None:
-    """Index a simple document."""
+    """Delete an index."""
     await http_request(
         ops_test,
         "DELETE",

--- a/tests/integration/ha/test_ha.py
+++ b/tests/integration/ha/test_ha.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+
+import pytest
+from pytest_operator.plugin import OpsTest
+
+from tests.integration.ha.continuous_writes import ContinuousWrites
+from tests.integration.ha.helpers import app_name
+from tests.integration.helpers import APP_NAME, MODEL_CONFIG, SERIES
+from tests.integration.tls.test_tls import TLS_CERTIFICATES_APP_NAME
+
+logger = logging.getLogger(__name__)
+
+IDLE_PERIOD = 120
+
+
+@pytest.fixture()
+def c_writes(ops_test: OpsTest):
+    """Creates instance of the ContinuousWrites."""
+    return ContinuousWrites(ops_test)
+
+
+@pytest.fixture()
+async def c_writes_runner(ops_test: OpsTest, c_writes: ContinuousWrites):
+    """Starts continuous write operations and clears writes at the end of the test."""
+    await c_writes.start()
+    yield
+    await c_writes.clear()
+
+
+@pytest.mark.abort_on_fail
+@pytest.mark.skip_if_deployed
+async def test_build_and_deploy(ops_test: OpsTest) -> None:
+    """Build and deploy one unit of OpenSearch."""
+    # it is possible for users to provide their own cluster for HA testing.
+    # Hence, check if there is a pre-existing cluster.
+    if await app_name(ops_test):
+        return
+
+    my_charm = await ops_test.build_charm(".")
+    await ops_test.model.set_config(MODEL_CONFIG)
+
+    # Deploy TLS Certificates operator.
+    config = {"generate-self-signed-certificates": "true", "ca-common-name": "CN_CA"}
+    await asyncio.gather(
+        ops_test.model.deploy(TLS_CERTIFICATES_APP_NAME, channel="edge", config=config),
+        ops_test.model.deploy(my_charm, num_units=3, series=SERIES),
+    )
+
+    # Relate it to OpenSearch to set up TLS.
+    await ops_test.model.relate(APP_NAME, TLS_CERTIFICATES_APP_NAME)
+    await ops_test.model.wait_for_idle(
+        apps=[TLS_CERTIFICATES_APP_NAME, APP_NAME], status="active", timeout=1000
+    )
+    assert len(ops_test.model.applications[APP_NAME].units) == 3

--- a/tests/integration/ha/test_horizontal_scaling.py
+++ b/tests/integration/ha/test_horizontal_scaling.py
@@ -15,12 +15,14 @@ from tests.integration.ha.helpers import (
     app_name,
     assert_continuous_writes_consistency,
     cluster_allocation,
-    create_dummy_docs,
-    create_dummy_indexes,
-    delete_dummy_indexes,
     get_elected_cm_unit_id,
     get_number_of_shards_by_node,
     get_shards_by_state,
+)
+from tests.integration.ha.helpers_data import (
+    create_dummy_docs,
+    create_dummy_indexes,
+    delete_dummy_indexes,
 )
 from tests.integration.helpers import (
     APP_NAME,

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -134,6 +134,22 @@ def get_application_unit_ips_names(ops_test: OpsTest) -> Dict[str, str]:
     return result
 
 
+def get_application_unit_ids_ips(ops_test: OpsTest) -> Dict[int, str]:
+    """List the units of an application by id and corresponding IP.
+
+    Args:
+        ops_test: The ops test framework instance
+
+    Returns:
+        Dictionary unit_id / unit_ip, of the application
+    """
+    result = {}
+    for unit in ops_test.model.applications[APP_NAME].units:
+        result[int(unit.name.split("/")[1])] = unit.public_address
+
+    return result
+
+
 async def get_leader_unit_ip(ops_test: OpsTest) -> str:
     """Helper function that retrieves the leader unit."""
     leader_unit = None

--- a/tox.ini
+++ b/tox.ini
@@ -98,7 +98,7 @@ commands =
     pytest -v --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/tls/test_tls.py
 
 [testenv:h-scaling-integration]
-description = Run HA integration tests
+description = Run horizontal-scaling integration tests
 pass_env =
     {[testenv]pass_env}
     CI
@@ -112,6 +112,22 @@ deps =
     -r {tox_root}/requirements.txt
 commands =
     pytest -v --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/ha/test_horizontal_scaling.py
+
+[testenv:ha-integration]
+description = Run HA integration tests
+pass_env =
+    {[testenv]pass_env}
+    CI
+    CI_PACKED_CHARMS
+deps =
+    opensearch-py
+    pytest
+    pytest-asyncio
+    juju==2.9.38.1 # juju 3.0.0 has issues with retrieving action results
+    pytest-operator
+    -r {tox_root}/requirements.txt
+commands =
+    pytest -v --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/ha/test_ha.py
 
 [testenv:client-integration]
 description = Run client relation integration tests


### PR DESCRIPTION
## Proposal
This PR adds helpers useful and used in HA tests. Namely, this PR adds:
- `helper_data.py`, helper for data related operations
- Shards collection / operations
- added the `ha-integration` in ci and tox.ini 