### PR TITLE
[DPE-1266] HA test: Added test of primary shard reelection

### DIFF
--- a/tests/integration/ha/test_horizontal_scaling.py
+++ b/tests/integration/ha/test_horizontal_scaling.py
@@ -403,11 +403,13 @@ async def test_safe_scale_down_remove_leaders(
     unit_with_primary_shard = [shard.unit_id for shard in shards if shard.is_prim][0]
     await ops_test.model.applications[app].destroy_unit(f"{app}/{unit_with_primary_shard}")
 
+    leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
     shards = await get_shards_by_index(ops_test, leader_unit_ip, ContinuousWrites.INDEX_NAME)
-    p_shards = [shard.unit_id for shard in shards if shard.is_prim]
-    assert len(p_shards) > 0
-    new_unit_with_primary_shard = p_shards[0]
-    assert new_unit_with_primary_shard != unit_with_primary_shard
+    units_with_p_shards = [shard.unit_id for shard in shards if shard.is_prim]
+    assert len(units_with_p_shards) == 1
+
+    for unit_id in units_with_p_shards:
+        assert unit_id != unit_with_primary_shard
 
     # continuous writes checks
     await assert_continuous_writes_consistency(c_writes)

--- a/tests/integration/ha/test_horizontal_scaling.py
+++ b/tests/integration/ha/test_horizontal_scaling.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import logging
+import time
 
 import pytest
 from charms.opensearch.v0.helper_cluster import ClusterTopology
@@ -403,13 +404,23 @@ async def test_safe_scale_down_remove_leaders(
     unit_with_primary_shard = [shard.unit_id for shard in shards if shard.is_prim][0]
     await ops_test.model.applications[app].destroy_unit(f"{app}/{unit_with_primary_shard}")
 
+    writes = await c_writes.count()
+
+    # check that the primary shard reelection happened
     leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
     shards = await get_shards_by_index(ops_test, leader_unit_ip, ContinuousWrites.INDEX_NAME)
     units_with_p_shards = [shard.unit_id for shard in shards if shard.is_prim]
     assert len(units_with_p_shards) == 1
 
     for unit_id in units_with_p_shards:
-        assert unit_id != unit_with_primary_shard
+        assert (
+            unit_id != unit_with_primary_shard
+        ), "Primary shard still assigned to destroyed unit."
+
+    # check that writes are still going after the removal / p_shard reelection
+    time.sleep(3)
+    new_writes = await c_writes.count()
+    assert new_writes > writes
 
     # continuous writes checks
     await assert_continuous_writes_consistency(c_writes)


### PR DESCRIPTION
### Issue
This PR enriches the test about primary removals:
- Removal of Elected CM node ==> previous PR 
- Removal of Juju leader node ==> previous PR
- **Removal of Node hosting the Primary shard of an index ==> this PR**