### PR TITLE
Update the seed_hosts regularly 

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -768,6 +768,13 @@ class OpenSearchBaseCharm(CharmBase):
         if not nodes_config:
             return
 
+        nodes_config = {name: Node.from_dict(node) for name, node in nodes_config.items()}
+
+        # update CM IPs
+        self.opensearch_config.append_seed_hosts(
+            [node.ip for node in list(nodes_config.values()) if node.is_cm_eligible()]
+        )
+
         new_node_conf = nodes_config.get(self.unit_name)
         if not new_node_conf and not self.opensearch.is_node_up():
             # the conf could not be computed / broadcasted, because this node is
@@ -776,7 +783,6 @@ class OpenSearchBaseCharm(CharmBase):
             return
 
         if new_node_conf:
-            new_node_conf = Node.from_dict(new_node_conf)
             current_conf = self.opensearch_config.load_node()
             if sorted(current_conf["node.roles"]) == sorted(new_node_conf.roles):
                 # no conf change (roles for now)

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -770,8 +770,8 @@ class OpenSearchBaseCharm(CharmBase):
 
         nodes_config = {name: Node.from_dict(node) for name, node in nodes_config.items()}
 
-        # update CM IPs
-        self.opensearch_config.append_seed_hosts(
+        # update (append) CM IPs
+        self.opensearch_config.add_seed_hosts(
             [node.ip for node in list(nodes_config.values()) if node.is_cm_eligible()]
         )
 

--- a/lib/charms/opensearch/v0/opensearch_config.py
+++ b/lib/charms/opensearch/v0/opensearch_config.py
@@ -181,9 +181,7 @@ class OpenSearchConfig:
             cm_ips_hostnames.extend([name] + aliases + addresses)
 
         with open(self._opensearch.paths.seed_hosts, "w+") as f:
-            existing = [line.strip() for line in f.readlines()]
-            full_list = set(existing + cm_ips_hostnames)
-            lines = "\n".join(full_list)
+            lines = "\n".join(cm_ips_hostnames)
             f.write(f"{lines}\n")
 
     def cleanup_bootstrap_conf(self):

--- a/lib/charms/opensearch/v0/opensearch_config.py
+++ b/lib/charms/opensearch/v0/opensearch_config.py
@@ -140,7 +140,7 @@ class OpenSearchConfig:
 
         # This allows the new CMs to be discovered automatically (hot reload of unicast_hosts.txt)
         self._opensearch.config.put(self.CONFIG_YML, "discovery.seed_providers", "file")
-        self.append_seed_hosts(cm_ips)
+        self.add_seed_hosts(cm_ips)
 
         if "cluster_manager" in roles and contribute_to_bootstrap:  # cluster NOT bootstrapped yet
             self._opensearch.config.put(
@@ -173,7 +173,7 @@ class OpenSearchConfig:
             True,
         )
 
-    def append_seed_hosts(self, cm_ips: List[str]):
+    def add_seed_hosts(self, cm_ips: List[str]):
         """Add CM nodes ips / host names to the seed host list of this unit."""
         cm_ips_hostnames = cm_ips.copy()
         for ip in cm_ips:

--- a/lib/charms/opensearch/v0/opensearch_config.py
+++ b/lib/charms/opensearch/v0/opensearch_config.py
@@ -177,7 +177,8 @@ class OpenSearchConfig:
         """Add CM nodes ips / host names to the seed host list of this unit."""
         cm_ips_hostnames = cm_ips.copy()
         for ip in cm_ips:
-            cm_ips_hostnames.append(socket.getfqdn(ip))
+            name, aliases, addresses = socket.gethostbyaddr(ip)
+            cm_ips_hostnames.extend([name] + aliases + addresses)
 
         with open(self._opensearch.paths.seed_hosts, "w+") as f:
             existing = [line.strip() for line in f.readlines()]

--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -69,6 +69,7 @@ class Paths:
         self.tmp = tmp
         self.certs = f"{conf}/certificates"  # must be under config
         self.certs_relative = "certificates"
+        self.seed_hosts = f"{conf}/unicast_hosts.txt"
 
 
 class OpenSearchDistribution(ABC):


### PR DESCRIPTION
## Issue
The kill db process HA test raised a bug that occurs for the first unit, which only contains 1 seed_host (itself - since no other node was up in the cluster). If the process on this unit restarts, this node will not be able to join the rest of the cluster as the discovery cannot happen.

## Solution
- we now update all the nodes with newly joined `cluster_manager` eligible nodes addresses
- to avoid having to restart each node upon newly discovered cluster manager eligible:
    - we no longer  rely on `discovery.seed_hosts` as it cannot be changed later without a restart
    - we use `discovery.seed_providers: file`
    - we use `unicast_hosts.txt` for storing: ips + aliases + hostnames ==> hot reloaded

## Notes:
The Snap was updated with this change