### PR TITLE
[DPE-1638] - HA tests - full cluster crash

### DIFF
--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -8,7 +8,13 @@ from pytest_operator.plugin import OpsTest
 from tenacity import retry, stop_after_attempt, wait_fixed, wait_random
 
 from tests.integration.ha.continuous_writes import ContinuousWrites
-from tests.integration.helpers import get_application_unit_ids_ips, http_request
+from tests.integration.helpers import (
+    get_application_unit_ids,
+    get_application_unit_ids_ips,
+    http_request,
+)
+
+OPENSEARCH_SERVICE_PATH = "/etc/systemd/system/snap.opensearch.daemon.service"
 
 
 class Shard:
@@ -221,3 +227,32 @@ async def send_kill_signal_to_process(
         raise Exception(f"{kill_cmd} failed -- rc: {return_code} - out: {stdout} - err: {stderr}")
 
     return opensearch_pid
+
+
+async def update_restart_delay(ops_test: OpsTest, app: str, unit_id: int, delay: int):
+    """Updates the restart delay in the DB service file."""
+    unit_name = f"{app}/{unit_id}"
+
+    # load the service file from the unit and update it with the new delay
+    replace_delay_cmd = (
+        f"run --unit {unit_name} -- "
+        f"sudo sed -i -e  's/^RestartSec=[0-9]\\+/RestartSec={delay}/g' "
+        f"{OPENSEARCH_SERVICE_PATH}"
+    )
+    await ops_test.juju(*replace_delay_cmd.split(), check=True)
+
+    # reload the daemon for systemd to reflect changes
+    reload_cmd = f"run --unit {unit_name} -- sudo systemctl daemon-reload"
+    await ops_test.juju(*reload_cmd.split(), check=True)
+
+
+async def all_processes_down(ops_test: OpsTest, app: str) -> bool:
+    """Check if all processes are down."""
+    for unit_id in get_application_unit_ids(ops_test, app):
+        unit_name = f"{app}/{unit_id}"
+        get_pid_cmd = f"run --unit {unit_name} -- sudo lsof -ti:9200"
+        _, opensearch_pid, _ = await ops_test.juju(*get_pid_cmd.split(), check=True)
+        if opensearch_pid:
+            return False
+
+    return True

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -43,6 +43,10 @@ async def app_name(ops_test: OpsTest) -> Optional[str]:
     return None
 
 
+@retry(
+    wait=wait_fixed(wait=5) + wait_random(0, 5),
+    stop=stop_after_attempt(15),
+)
 async def get_elected_cm_unit_id(ops_test: OpsTest, unit_ip: str) -> int:
     """Returns the unit id of the current elected cm node."""
     # get current elected cm node

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -216,9 +216,9 @@ async def send_kill_signal_to_process(
 
     if opensearch_pid is None:
         get_pid_cmd = f"run --unit {unit_name} -- sudo lsof -ti:9200"
-        _, opensearch_pid, _ = await ops_test.juju(*get_pid_cmd.split(), check=True)
+        _, opensearch_pid, _ = await ops_test.juju(*get_pid_cmd.split(), check=False)
 
-    if not opensearch_pid:
+    if not opensearch_pid.strip():
         raise Exception("Could not fetch PID for process listening on port 9200.")
 
     kill_cmd = f"ssh {unit_name} -- sudo kill -{signal.upper()} {opensearch_pid}"
@@ -251,8 +251,8 @@ async def all_processes_down(ops_test: OpsTest, app: str) -> bool:
     for unit_id in get_application_unit_ids(ops_test, app):
         unit_name = f"{app}/{unit_id}"
         get_pid_cmd = f"run --unit {unit_name} -- sudo lsof -ti:9200"
-        _, opensearch_pid, _ = await ops_test.juju(*get_pid_cmd.split(), check=True)
-        if opensearch_pid:
+        _, opensearch_pid, _ = await ops_test.juju(*get_pid_cmd.split(), check=False)
+        if opensearch_pid.strip():
             return False
 
     return True

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -236,7 +236,7 @@ async def update_restart_delay(ops_test: OpsTest, app: str, unit_id: int, delay:
     # load the service file from the unit and update it with the new delay
     replace_delay_cmd = (
         f"run --unit {unit_name} -- "
-        f"sudo sed -i -e  's/^RestartSec=[0-9]\\+/RestartSec={delay}/g' "
+        f"sudo sed -i -e s/^RestartSec=[0-9]\\+/RestartSec={delay}/g "
         f"{OPENSEARCH_SERVICE_PATH}"
     )
     await ops_test.juju(*replace_delay_cmd.split(), check=True)

--- a/tests/integration/ha/test_ha.py
+++ b/tests/integration/ha/test_ha.py
@@ -441,7 +441,7 @@ async def test_full_cluster_crash(
 
     # Reset restart delay
     for unit_id in get_application_unit_ids(ops_test, app):
-        await update_restart_delay(ops_test,app,  unit_id, ORIGINAL_RESTART_DELAY)
+        await update_restart_delay(ops_test, app, unit_id, ORIGINAL_RESTART_DELAY)
 
     # sleep for restart delay + 10 secs max for the election time + node start
     time.sleep(ORIGINAL_RESTART_DELAY + 10)

--- a/tests/integration/ha/test_ha.py
+++ b/tests/integration/ha/test_ha.py
@@ -443,11 +443,11 @@ async def test_full_cluster_crash(
     for unit_id in get_application_unit_ids(ops_test, app):
         await update_restart_delay(ops_test, app, unit_id, ORIGINAL_RESTART_DELAY)
 
-    # sleep for restart delay + 10 secs max for the election time + node start
-    time.sleep(ORIGINAL_RESTART_DELAY + 10)
+    # sleep for restart delay + 30 secs max for the election time + node start + cluster formation
+    time.sleep(ORIGINAL_RESTART_DELAY + 30)
 
     # verify all units are up and running
-    for unit_id, unit_ip in get_application_unit_ids_ips(ops_test, app):
+    for unit_id, unit_ip in get_application_unit_ids_ips(ops_test, app).items():
         assert await is_up(ops_test, unit_ip), f"Unit {unit_id} not restarted after cluster crash."
 
     # verify new writes are continuing by counting the number of writes before and after 5 seconds

--- a/tests/integration/ha/test_ha.py
+++ b/tests/integration/ha/test_ha.py
@@ -11,11 +11,13 @@ from pytest_operator.plugin import OpsTest
 
 from tests.integration.ha.continuous_writes import ContinuousWrites
 from tests.integration.ha.helpers import (
+    all_processes_down,
     app_name,
     assert_continuous_writes_consistency,
     get_elected_cm_unit_id,
     get_shards_by_index,
     send_kill_signal_to_process,
+    update_restart_delay,
 )
 from tests.integration.ha.helpers_data import (
     create_index,
@@ -30,6 +32,7 @@ from tests.integration.helpers import (
     MODEL_CONFIG,
     SERIES,
     check_cluster_formation_successful,
+    cluster_health,
     get_application_unit_ids,
     get_application_unit_ids_ips,
     get_application_unit_names,
@@ -43,6 +46,9 @@ logger = logging.getLogger(__name__)
 
 
 SECOND_APP_NAME = "second-opensearch"
+
+ORIGINAL_RESTART_DELAY = 20
+RESTART_DELAY = 360
 
 
 @pytest.fixture()
@@ -66,6 +72,15 @@ async def c_balanced_writes_runner(ops_test: OpsTest, c_writes: ContinuousWrites
     await c_writes.start(repl_on_all_nodes=True)
     yield
     await c_writes.clear()
+
+
+@pytest.fixture()
+async def reset_service_restart_delay(ops_test: OpsTest):
+    """Resets service file restart delay on all units."""
+    yield
+    app = (await app_name(ops_test)) or APP_NAME
+    for unit_id in get_application_unit_ids(ops_test, app=app):
+        await update_restart_delay(ops_test, app, unit_id, ORIGINAL_RESTART_DELAY)
 
 
 @pytest.mark.abort_on_fail
@@ -406,6 +421,54 @@ async def test_freeze_db_process_node_with_elected_cm(
     assert await check_cluster_formation_successful(
         ops_test, leader_unit_ip, get_application_unit_names(ops_test, app=app)
     )
+
+    # continuous writes checks
+    await assert_continuous_writes_consistency(ops_test, c_writes, app)
+
+
+@pytest.mark.abort_on_fail
+async def test_full_cluster_crash(
+    ops_test: OpsTest,
+    c_writes: ContinuousWrites,
+    c_balanced_writes_runner,
+    reset_service_restart_delay,
+) -> None:
+    """Check cluster can operate normally after all nodes down at same time and come back up."""
+    app = (await app_name(ops_test)) or APP_NAME
+
+    # update all units to have a new RESTART_DELAY. Modifying the Restart delay to 3 minutes
+    # should ensure enough time for all replicas to be down at the same time.
+    for unit_id in get_application_unit_ids(ops_test, app):
+        await update_restart_delay(ops_test, unit_id, RESTART_DELAY)
+
+    # kill all units simultaneously
+    await asyncio.gather(
+        *[
+            send_kill_signal_to_process(ops_test, app, unit_id, signal="SIGKILL")
+            for unit_id in get_application_unit_ids(ops_test, app)
+        ]
+    )
+
+    # check that all units being down at the same time.
+    assert await all_processes_down(ops_test, app), "Not all units down at the same time."
+
+    # sleep for restart delay + 10 secs max for the election time + node start
+    time.sleep(RESTART_DELAY + 10)
+
+    # verify all units are up and running
+    for unit_id, unit_ip in get_application_unit_ids_ips(ops_test, app):
+        assert await is_up(ops_test, unit_ip), f"Unit {unit_id} not restarted after cluster crash."
+
+    # verify new writes are continuing by counting the number of writes before and after 5 seconds
+    writes = await c_writes.count()
+    time.sleep(5)
+    more_writes = await c_writes.count()
+    assert more_writes > writes, "Writes not continuing to DB"
+
+    # check that cluster health is green (all primary and replica shards allocated)
+    leader_ip = await get_leader_unit_ip(ops_test, app)
+    health_resp = await cluster_health(ops_test, leader_ip)
+    assert health_resp["status"] == "green"
 
     # continuous writes checks
     await assert_continuous_writes_consistency(ops_test, c_writes, app)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -4,6 +4,7 @@
 import json
 import logging
 import tempfile
+from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Dict, List, Optional, Union
@@ -394,6 +395,7 @@ async def is_up(ops_test: OpsTest, unit_ip: str, retries: int = 15) -> bool:
             stop=stop_after_attempt(retries), wait=wait_fixed(wait=10) + wait_random(0, 5)
         ):
             with attempt:
+                logger.info(f"is_up attempt for {unit_ip}: {datetime.now().strftime('%H:%M:%S')}")
                 http_resp_code = await http_request(
                     ops_test, "GET", f"https://{unit_ip}:9200/", resp_status_code=True
                 )

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -4,7 +4,6 @@
 import json
 import logging
 import tempfile
-from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Dict, List, Optional, Union
@@ -391,15 +390,10 @@ async def check_cluster_formation_successful(
 async def is_up(ops_test: OpsTest, unit_ip: str, retries: int = 15) -> bool:
     """Return if node up."""
     try:
-        for attempt in Retrying(
-            stop=stop_after_attempt(retries), wait=wait_fixed(wait=10) + wait_random(0, 5)
-        ):
+        for attempt in Retrying(stop=stop_after_attempt(retries), wait=wait_fixed(wait=5)):
             with attempt:
-                logger.info(f"is_up attempt for {unit_ip}: {datetime.now().strftime('%H:%M:%S')}")
-                http_resp_code = await http_request(
-                    ops_test, "GET", f"https://{unit_ip}:9200/", resp_status_code=True
-                )
-                return http_resp_code == 200
+                await http_request(ops_test, "GET", f"https://{unit_ip}:9200/")
+                return True
     except RetryError:
         return False
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -390,7 +390,7 @@ async def check_cluster_formation_successful(
 async def is_up(ops_test: OpsTest, unit_ip: str, retries: int = 15) -> bool:
     """Return if node up."""
     try:
-        for attempt in Retrying(stop=stop_after_attempt(retries), wait=wait_fixed(wait=5)):
+        for attempt in Retrying(stop=stop_after_attempt(retries), wait=wait_fixed(wait=10)):
             with attempt:
                 await http_request(ops_test, "GET", f"https://{unit_ip}:9200/")
                 return True

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -390,7 +390,7 @@ async def check_cluster_formation_successful(
 async def is_up(ops_test: OpsTest, unit_ip: str, retries: int = 15) -> bool:
     """Return if node up."""
     try:
-        for attempt in Retrying(stop=stop_after_attempt(retries), wait=wait_fixed(wait=10)):
+        for attempt in Retrying(stop=stop_after_attempt(retries), wait=wait_fixed(wait=15)):
             with attempt:
                 await http_request(ops_test, "GET", f"https://{unit_ip}:9200/")
                 return True


### PR DESCRIPTION
## Issue
This PR implements [DPE-1638](https://warthogs.atlassian.net/browse/DPE-1638), namely this PR implements:
- integration test for killing the opensearch process on all the nodes of the cluster - for 3 minutes
- verify the nodes restart automatically after 3 minutes 
- verify the writes continue when the nodes are up 

[DPE-1638]: https://warthogs.atlassian.net/browse/DPE-1638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ