### PR TITLE
[DPE-1635] - HA tests - Full cluster restart

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,4 +42,4 @@ jobs:
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          channel: "${{ steps.channel.outputs.name }}"
+          channel: "2/edge"

--- a/tests/integration/ha/test_ha.py
+++ b/tests/integration/ha/test_ha.py
@@ -51,6 +51,15 @@ RESTART_DELAY = 360
 
 
 @pytest.fixture()
+async def reset_restart_delay(ops_test: OpsTest):
+    """Resets service file delay on all units."""
+    yield
+    app = (await app_name(ops_test)) or APP_NAME
+    for unit_id in get_application_unit_ids(ops_test, app):
+        await update_restart_delay(ops_test, app, unit_id, ORIGINAL_RESTART_DELAY)
+
+
+@pytest.fixture()
 async def c_writes(ops_test: OpsTest):
     """Creates instance of the ContinuousWrites."""
     app = (await app_name(ops_test)) or APP_NAME
@@ -418,7 +427,7 @@ async def test_freeze_db_process_node_with_elected_cm(
 
 @pytest.mark.abort_on_fail
 async def test_full_cluster_crash(
-    ops_test: OpsTest, c_writes: ContinuousWrites, c_balanced_writes_runner
+    ops_test: OpsTest, c_writes: ContinuousWrites, c_balanced_writes_runner, reset_restart_delay
 ) -> None:
     """Check cluster can operate normally after all nodes SIGKILL at same time and come back up."""
     app = (await app_name(ops_test)) or APP_NAME
@@ -474,7 +483,7 @@ async def test_full_cluster_crash(
 
 @pytest.mark.abort_on_fail
 async def test_full_cluster_restart(
-    ops_test: OpsTest, c_writes: ContinuousWrites, c_balanced_writes_runner
+    ops_test: OpsTest, c_writes: ContinuousWrites, c_balanced_writes_runner, reset_restart_delay
 ) -> None:
     """Check cluster can operate normally after all nodes SIGTERM at same time and come back up."""
     app = (await app_name(ops_test)) or APP_NAME

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -387,7 +387,7 @@ async def check_cluster_formation_successful(
     return set(unit_names) == set(registered_nodes)
 
 
-async def is_up(ops_test: OpsTest, unit_ip: str, retries: int = 15) -> bool:
+async def is_up(ops_test: OpsTest, unit_ip: str, retries: int = 25) -> bool:
     """Return if node up."""
     try:
         for attempt in Retrying(stop=stop_after_attempt(retries), wait=wait_fixed(wait=15)):


### PR DESCRIPTION
## Issue
This PR implements [DPE-1635](https://warthogs.atlassian.net/browse/DPE-1635) - namely, this PR implements:
- integration test for killing (`SIGTERM`) the opensearch process on all the nodes of the cluster - for 3 minutes
- verify the nodes restart automatically after 3 minutes
- verify the cluster formation is intact
- verify the writes continue when the nodes are up

[DPE-1635]: https://warthogs.atlassian.net/browse/DPE-1635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ