### PR TITLE
Fix client integration bug when adding two relations that access the same index

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
     needs:
       - lint
       - unit-test
-    uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v2
+    uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v2.3.9
 
   lite-integration-test:
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,10 +54,10 @@ jobs:
       fail-fast: false
       matrix:
         tox-environments:
-          # - charm-integration
-          # - tls-integration
+          - charm-integration
+          - tls-integration
           - client-integration
-          # - ha-integration
+          - ha-integration
     name: ${{ matrix.tox-environments }}
     needs:
       - lint
@@ -100,47 +100,47 @@ jobs:
   # These tests currently compete for access to the 4-core runner amongst individual test runs in
   # this repo, and with other charms. Therefore, this runner should be used sparingly until we can
   # access more runners.
-  # heavy-integration-test:
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       tox-environments:
-  #         - h-scaling-integration
-  #   name: ${{ matrix.tox-environments }}
-  #   needs:
-  #     - lint
-  #     - unit-test
-  #     - build
-  #   runs-on: Ubuntu_4C_16G
-  #   timeout-minutes: 120
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-  #     - name: Setup operator environment
-  #       # TODO: Replace with custom image on self-hosted runner
-  #       uses: charmed-kubernetes/actions-operator@main
-  #       with:
-  #         provider: lxd
-  #     - name: Download packed charm(s)
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: ${{ needs.build.outputs.artifact-name }}
-  #     - name: Select tests
-  #       id: select-tests
-  #       run: |
-  #         if [ "${{ github.event_name }}" == "schedule" ]
-  #         then
-  #           echo Running unstable and stable tests
-  #           echo "mark_expression=" >> $GITHUB_OUTPUT
-  #         else
-  #           echo Skipping unstable tests
-  #           echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
-  #         fi
-  #     - name: Run integration tests
-  #       run: |
-  #         # set sysctl values in case the cloudinit-userdata not applied
-  #         sudo sysctl -w vm.max_map_count=262144 vm.swappiness=0 net.ipv4.tcp_retries2=5
+  heavy-integration-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        tox-environments:
+          - h-scaling-integration
+    name: ${{ matrix.tox-environments }}
+    needs:
+      - lint
+      - unit-test
+      - build
+    runs-on: Ubuntu_4C_16G
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup operator environment
+        # TODO: Replace with custom image on self-hosted runner
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: lxd
+      - name: Download packed charm(s)
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.build.outputs.artifact-name }}
+      - name: Select tests
+        id: select-tests
+        run: |
+          if [ "${{ github.event_name }}" == "schedule" ]
+          then
+            echo Running unstable and stable tests
+            echo "mark_expression=" >> $GITHUB_OUTPUT
+          else
+            echo Skipping unstable tests
+            echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
+          fi
+      - name: Run integration tests
+        run: |
+          # set sysctl values in case the cloudinit-userdata not applied
+          sudo sysctl -w vm.max_map_count=262144 vm.swappiness=0 net.ipv4.tcp_retries2=5
 
-  #         tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}'
-  #       env:
-  #         CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}
+          tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}'
+        env:
+          CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,10 +54,10 @@ jobs:
       fail-fast: false
       matrix:
         tox-environments:
-          - charm-integration
-          - tls-integration
+          # - charm-integration
+          # - tls-integration
           - client-integration
-          - ha-integration
+          # - ha-integration
     name: ${{ matrix.tox-environments }}
     needs:
       - lint
@@ -100,47 +100,47 @@ jobs:
   # These tests currently compete for access to the 4-core runner amongst individual test runs in
   # this repo, and with other charms. Therefore, this runner should be used sparingly until we can
   # access more runners.
-  heavy-integration-test:
-    strategy:
-      fail-fast: false
-      matrix:
-        tox-environments:
-          - h-scaling-integration
-    name: ${{ matrix.tox-environments }}
-    needs:
-      - lint
-      - unit-test
-      - build
-    runs-on: Ubuntu_4C_16G
-    timeout-minutes: 120
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Setup operator environment
-        # TODO: Replace with custom image on self-hosted runner
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          provider: lxd
-      - name: Download packed charm(s)
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ needs.build.outputs.artifact-name }}
-      - name: Select tests
-        id: select-tests
-        run: |
-          if [ "${{ github.event_name }}" == "schedule" ]
-          then
-            echo Running unstable and stable tests
-            echo "mark_expression=" >> $GITHUB_OUTPUT
-          else
-            echo Skipping unstable tests
-            echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
-          fi
-      - name: Run integration tests
-        run: |
-          # set sysctl values in case the cloudinit-userdata not applied
-          sudo sysctl -w vm.max_map_count=262144 vm.swappiness=0 net.ipv4.tcp_retries2=5
+  # heavy-integration-test:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       tox-environments:
+  #         - h-scaling-integration
+  #   name: ${{ matrix.tox-environments }}
+  #   needs:
+  #     - lint
+  #     - unit-test
+  #     - build
+  #   runs-on: Ubuntu_4C_16G
+  #   timeout-minutes: 120
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #     - name: Setup operator environment
+  #       # TODO: Replace with custom image on self-hosted runner
+  #       uses: charmed-kubernetes/actions-operator@main
+  #       with:
+  #         provider: lxd
+  #     - name: Download packed charm(s)
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: ${{ needs.build.outputs.artifact-name }}
+  #     - name: Select tests
+  #       id: select-tests
+  #       run: |
+  #         if [ "${{ github.event_name }}" == "schedule" ]
+  #         then
+  #           echo Running unstable and stable tests
+  #           echo "mark_expression=" >> $GITHUB_OUTPUT
+  #         else
+  #           echo Skipping unstable tests
+  #           echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
+  #         fi
+  #     - name: Run integration tests
+  #       run: |
+  #         # set sysctl values in case the cloudinit-userdata not applied
+  #         sudo sysctl -w vm.max_map_count=262144 vm.swappiness=0 net.ipv4.tcp_retries2=5
 
-          tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}'
-        env:
-          CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}
+  #         tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}'
+  #       env:
+  #         CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -257,6 +257,9 @@ class OpenSearchBaseCharm(CharmBase):
             # we defer because we want the temporary status to be updated
             event.defer()
 
+        for relation in self.model.relations.get(ClientRelationName, []):
+            self.opensearch_provider.update_endpoints(relation)
+
         data = event.relation.data.get(event.unit if self.unit.is_leader() else event.app)
         if not data:
             return
@@ -269,9 +272,6 @@ class OpenSearchBaseCharm(CharmBase):
                 self.peers_data.put(
                     Scope.APP, "bootstrap_contributors_count", contributor_count + 1
                 )
-
-            for relation in self.model.relations.get(ClientRelationName, []):
-                self.opensearch_provider.update_endpoints(relation)
 
             if data.get(VOTING_TO_DELETE) or data.get(ALLOCS_TO_DELETE):
                 self.opensearch_exclusions.cleanup()

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -94,7 +94,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 
 SERVICE_MANAGER = "service"

--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -226,6 +226,8 @@ class OpenSearchDistribution(ABC):
         ) -> requests.Response:
             """Performs an HTTP request."""
             if remaining_retries < 0:
+                # Can't check `if not error_response`, because Response objects evaluate to False
+                # when the request fails.
                 if error_response is None:
                     raise OpenSearchHttpError()
 

--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -268,7 +268,7 @@ class OpenSearchDistribution(ABC):
 
             except (requests.exceptions.RequestException, urllib3.exceptions.HTTPError) as e:
                 logger.error(
-                    f"Request {method} to {urls[0]} with payload: {payload} failed."
+                    f"Request {method} to {urls[0]} with payload: {payload} failed. "
                     f"(Attempts left: {remaining_retries})\n{e}"
                 )
                 time.sleep(1)

--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -227,8 +227,9 @@ class OpenSearchDistribution(ABC):
             """Performs an HTTP request."""
             if remaining_retries < 0:
                 logger.error(error_response)
+                logger.error(error_response.text)
                 logger.error(return_failed_resp)
-                if not error_response:
+                if error_response is None:
                     logger.error("not error response")
                     raise OpenSearchHttpError()
 

--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -40,7 +40,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 
 logger = logging.getLogger(__name__)

--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -289,7 +289,8 @@ class OpenSearchDistribution(ABC):
                 return call(
                     remaining_retries - 1,
                     return_failed_resp,
-                    # TODO we're getting RequestException instead of HTTPError when we create a new index for the client relation.
+                    # TODO we're getting RequestException instead of HTTPError when we create a new
+                    # index for the client relation.
                     # TODO pass response codes into OpenSearchHttpError
                     error_response=e.response if isinstance(e, requests.HTTPError) else None,
                     err_text=err_text,

--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -227,13 +227,18 @@ class OpenSearchDistribution(ABC):
             """Performs an HTTP request."""
             if remaining_retries < 0:
                 logger.error(error_response)
+                logger.error(return_failed_resp)
                 if not error_response:
+                    logger.error("not error response")
                     raise OpenSearchHttpError()
 
                 if return_failed_resp:
+                    logger.error("error resp and return failed resp")
                     return error_response
 
                 # For some reason this isn't being fired. why?
+                logger.error(error_response.text)
+                logger.error(error_response.status_code)
                 raise OpenSearchHttpError(
                     response_body=error_response.text, response_code=error_response.status_code
                 )
@@ -266,15 +271,14 @@ class OpenSearchDistribution(ABC):
 
                     response = s.request(**request_kwargs)
                     logger.error(response.status_code)
-                    logger.error(response.text)
 
-                    # TODO this is making it really hard to figure out what our responses are. re implement
+                    # TODO this is making it really hard to figure out what our responses are.
                     response.raise_for_status()
 
                     return response
             except (requests.exceptions.RequestException, urllib3.exceptions.HTTPError) as e:
                 logger.error(
-                    f"Request {method} to {urls[0]} with payload: {payload} failed. "
+                    f"Request {method} to {urls[0]} with payload: {payload} failed."
                     f"(Attempts left: {remaining_retries})\n{e}"
                 )
                 time.sleep(1)

--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -224,12 +224,14 @@ class OpenSearchDistribution(ABC):
             return_failed_resp: bool,
             error_response: Optional[requests.Response] = None,
             err_text: Optional[str] = None,
-            err_response_code: Optional[int] = None
+            err_response_code: Optional[int] = None,
         ) -> requests.Response:
             """Performs an HTTP request."""
             if remaining_retries < 0:
                 if not error_response:
-                    raise OpenSearchHttpError(response_body=err_text, response_code=err_response_code)
+                    raise OpenSearchHttpError(
+                        response_body=err_text, response_code=err_response_code
+                    )
 
                 if return_failed_resp:
                     return error_response
@@ -268,7 +270,7 @@ class OpenSearchDistribution(ABC):
                     logger.error(response.status_code)
                     logger.error(response.text)
 
-                    # TODO this is making it really hard to figure out what our responses are. 
+                    # TODO this is making it really hard to figure out what our responses are.
                     response.raise_for_status()
 
                     return response
@@ -287,11 +289,11 @@ class OpenSearchDistribution(ABC):
                 return call(
                     remaining_retries - 1,
                     return_failed_resp,
-                    # TODO we're getting RequestException instead of HTTPError when we create a new index for the client relation. 
+                    # TODO we're getting RequestException instead of HTTPError when we create a new index for the client relation.
                     # TODO pass response codes into OpenSearchHttpError
-                    error_response = e.response if isinstance(e, requests.HTTPError) else None,
-                    err_text = err_text,
-                    err_response_code =err_response_code,
+                    error_response=e.response if isinstance(e, requests.HTTPError) else None,
+                    err_text=err_text,
+                    err_response_code=err_response_code,
                 )
 
         if None in [endpoint, method]:

--- a/lib/charms/opensearch/v0/opensearch_relation_provider.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_provider.py
@@ -189,7 +189,9 @@ class OpenSearchProvider(Object):
                 and e.response_body.get("error", {}).get("type")
                 == "resource_already_exists_exception"
             ):
-                failed_to_create = f"failed to create {event.index} index - deferring index-requested event..."
+                failed_to_create = (
+                    f"failed to create {event.index} index - deferring index-requested event..."
+                )
                 logger.error(failed_to_create)
                 self.unit.status = BlockedStatus(failed_to_create)
                 event.defer()

--- a/lib/charms/opensearch/v0/opensearch_relation_provider.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_provider.py
@@ -182,25 +182,16 @@ class OpenSearchProvider(Object):
         self.unit.status = MaintenanceStatus(f"new index {event.index} requested")
 
         try:
-            create_index_request = self.opensearch.request("PUT", f"/{event.index}")
-            logger.error(create_index_request)
+            self.opensearch.request("PUT", f"/{event.index}")
         except OpenSearchHttpError as e:
-            logger.error(e)
-            logger.error(f"logger e.response_code {e.response_code}")
-            logger.error(f"logger e.response_body {e.response_body}")
-            logger.error(f"error response = {e.response_body.get('error')}")
-            logger.error(f"error response = {e.response_body.get('error', {}).get('type')}")
             if not (
                 e.response_code == 400
                 and e.response_body.get("error", {}).get("type")
                 == "resource_already_exists_exception"
             ):
-                logger.error(
-                    f"failed to create {event.index} index - deferring index-requested event..."
-                )
-                self.unit.status = BlockedStatus(
-                    f"failed to create {event.index} index - deferring index-requested event..."
-                )
+                failed_to_create = f"failed to create {event.index} index - deferring index-requested event..."
+                logger.error(failed_to_create)
+                self.unit.status = BlockedStatus(failed_to_create)
                 event.defer()
                 return
 

--- a/lib/charms/opensearch/v0/opensearch_relation_provider.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_provider.py
@@ -189,6 +189,7 @@ class OpenSearchProvider(Object):
                 and e.response_body.get("error", {}).get("type")
                 == "resource_already_exists_exception"
             ):
+                logger.error(e)
                 failed_to_create = (
                     f"failed to create {event.index} index - deferring index-requested event..."
                 )

--- a/lib/charms/opensearch/v0/opensearch_relation_provider.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_provider.py
@@ -183,33 +183,12 @@ class OpenSearchProvider(Object):
         self.unit.status = MaintenanceStatus(f"new index {event.index} requested")
 
         try:
-            create_index_request = self.opensearch.request(
-                "PUT", f"/{event.index}", raise_for_status=False, return_json = False
-            )
+            create_index_request = self.opensearch.request("PUT", f"/{event.index}")
             logger.error(create_index_request)
-            # Skip checking for errors if it's due to the index already existing - we know this is 
-            # an error, but it's irrelevant to this function because we can grant the second 
-            # relation access to the original index.
-            if not (
-                create_index_request.status_code == 400
-                and create_index_request.response_body.get("error", {}).get("type")
-                == "resource_already_exists_exception"
-            ):
-                create_index_request.raise_for_status()
-                logger.error(
-                    f"failed to create {event.index} index - deferring index-requested event..."
-                )
-                self.unit.status = BlockedStatus(
-                    f"failed to create {event.index} index - deferring index-requested event..."
-                )
-                event.defer()
-                return
-
         except OpenSearchHttpError as e:
-            logger.error(e.response_code)
-            logger.error(e.response_body)
+            logger.error(f"logger e.response_code {e.response_code}")
+            logger.error(f"logger e.response_body {e.response_body}")
             if not (
-                # TODO is this still relevant?
                 e.response_code == 400
                 and e.response_body.get("error", {}).get("type")
                 == "resource_already_exists_exception"

--- a/lib/charms/opensearch/v0/opensearch_relation_provider.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_provider.py
@@ -190,6 +190,8 @@ class OpenSearchProvider(Object):
                 index_exists = False
             else:
                 logger.error(e)
+                logger.error(e.response_code)
+                logger.error(f"failed to check if {event.index} index exists")
                 event.defer()
                 return
 
@@ -204,6 +206,8 @@ class OpenSearchProvider(Object):
                 == "resource_already_exists_exception"
             ):
                 logger.error(e)
+                logger.error(e.response_code)
+                logger.error(f"failed to create {event.index} index")
                 event.defer()
                 return
 

--- a/lib/charms/opensearch/v0/opensearch_relation_provider.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_provider.py
@@ -189,9 +189,8 @@ class OpenSearchProvider(Object):
                 and e.response_body.get("error", {}).get("type")
                 == "resource_already_exists_exception"
             ):
-                logger.error(e)
                 failed_to_create = (
-                    f"failed to create {event.index} index - deferring index-requested event..."
+                    f"failed to create {event.index} index due to {e} - deferring index-requested event..."
                 )
                 logger.error(failed_to_create)
                 self.unit.status = BlockedStatus(failed_to_create)

--- a/lib/charms/opensearch/v0/opensearch_relation_provider.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_provider.py
@@ -192,6 +192,9 @@ class OpenSearchProvider(Object):
                 logger.error(e)
                 logger.error(e.response_code)
                 logger.error(f"failed to check if {event.index} index exists")
+                self.unit.status = BlockedStatus(
+                    f"failed to check if {event.index} index exists - deferring index-requested event..."
+                )
                 event.defer()
                 return
 
@@ -207,7 +210,12 @@ class OpenSearchProvider(Object):
             ):
                 logger.error(e)
                 logger.error(e.response_code)
-                logger.error(f"failed to create {event.index} index")
+                logger.error(
+                    f"failed to create {event.index} index - deferring index-requested event..."
+                )
+                self.unit.status = BlockedStatus(
+                    f"failed to create {event.index} index - deferring index-requested event..."
+                )
                 event.defer()
                 return
 

--- a/lib/charms/opensearch/v0/opensearch_relation_provider.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_provider.py
@@ -41,7 +41,7 @@ from ops.charm import (
     RelationDepartedEvent,
 )
 from ops.framework import Object
-from ops.model import BlockedStatus, MaintenanceStatus, Relation, ActiveStatus
+from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, Relation
 
 # The unique Charmhub library identifier, never change it
 LIBID = "c0f1d8f94bdd41a781fe2871e1922480"

--- a/lib/charms/opensearch/v0/opensearch_relation_provider.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_provider.py
@@ -182,25 +182,8 @@ class OpenSearchProvider(Object):
         prev_status = self.unit.status
         self.unit.status = MaintenanceStatus(f"new index {event.index} requested")
 
-        # TODO this could be MUCH cleaner
         try:
-            index_exists = self.opensearch.request("HEAD", f"/{event.index}") == 200
-        except OpenSearchHttpError as e:
-            if e.response_code == 404:
-                index_exists = False
-            else:
-                logger.error(e)
-                logger.error(e.response_code)
-                logger.error(f"failed to check if {event.index} index exists")
-                self.unit.status = BlockedStatus(
-                    f"failed to check if {event.index} index exists - deferring index-requested event..."
-                )
-                event.defer()
-                return
-
-        try:
-            if not index_exists:
-                self.opensearch.request("PUT", f"/{event.index}")
+            self.opensearch.request("PUT", f"/{event.index}")
         except OpenSearchHttpError as e:
             if not (
                 # TODO is this still relevant?

--- a/lib/charms/opensearch/v0/opensearch_relation_provider.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_provider.py
@@ -189,9 +189,7 @@ class OpenSearchProvider(Object):
                 and e.response_body.get("error", {}).get("type")
                 == "resource_already_exists_exception"
             ):
-                failed_to_create = (
-                    f"failed to create {event.index} index due to {e} - deferring index-requested event..."
-                )
+                failed_to_create = f"failed to create {event.index} index due to {e} - deferring index-requested event..."
                 logger.error(failed_to_create)
                 self.unit.status = BlockedStatus(failed_to_create)
                 event.defer()

--- a/lib/charms/opensearch/v0/opensearch_relation_provider.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_provider.py
@@ -183,8 +183,31 @@ class OpenSearchProvider(Object):
         self.unit.status = MaintenanceStatus(f"new index {event.index} requested")
 
         try:
-            self.opensearch.request("PUT", f"/{event.index}")
+            create_index_request = self.opensearch.request(
+                "PUT", f"/{event.index}", raise_for_status=False, return_json = False
+            )
+            logger.error(create_index_request)
+            # Skip checking for errors if it's due to the index already existing - we know this is 
+            # an error, but it's irrelevant to this function because we can grant the second 
+            # relation access to the original index.
+            if not (
+                create_index_request.status_code == 400
+                and create_index_request.response_body.get("error", {}).get("type")
+                == "resource_already_exists_exception"
+            ):
+                create_index_request.raise_for_status()
+                logger.error(
+                    f"failed to create {event.index} index - deferring index-requested event..."
+                )
+                self.unit.status = BlockedStatus(
+                    f"failed to create {event.index} index - deferring index-requested event..."
+                )
+                event.defer()
+                return
+
         except OpenSearchHttpError as e:
+            logger.error(e.response_code)
+            logger.error(e.response_body)
             if not (
                 # TODO is this still relevant?
                 e.response_code == 400

--- a/lib/charms/opensearch/v0/opensearch_relation_provider.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_provider.py
@@ -51,7 +51,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 logger = logging.getLogger(__name__)
 

--- a/tests/integration/relations/opensearch_provider/test_opensearch_provider.py
+++ b/tests/integration/relations/opensearch_provider/test_opensearch_provider.py
@@ -181,7 +181,7 @@ async def test_version(ops_test: OpsTest):
     results = json.loads(run_version_request["results"])
     assert version == results.get("version", {}).get("number"), results
 
-
+@pytest.mark.skip
 @pytest.mark.abort_on_fail
 async def test_scaling(ops_test: OpsTest):
     """Test that scaling correctly updates endpoints in databag.

--- a/tests/integration/relations/opensearch_provider/test_opensearch_provider.py
+++ b/tests/integration/relations/opensearch_provider/test_opensearch_provider.py
@@ -181,6 +181,7 @@ async def test_version(ops_test: OpsTest):
     results = json.loads(run_version_request["results"])
     assert version == results.get("version", {}).get("number"), results
 
+
 @pytest.mark.skip
 @pytest.mark.abort_on_fail
 async def test_scaling(ops_test: OpsTest):

--- a/tests/integration/relations/opensearch_provider/test_opensearch_provider.py
+++ b/tests/integration/relations/opensearch_provider/test_opensearch_provider.py
@@ -182,7 +182,6 @@ async def test_version(ops_test: OpsTest):
     assert version == results.get("version", {}).get("number"), results
 
 
-@pytest.mark.skip
 @pytest.mark.abort_on_fail
 async def test_scaling(ops_test: OpsTest):
     """Test that scaling correctly updates endpoints in databag.


### PR DESCRIPTION
## Issue
When adding a second relation with the same index, we fail to create the index and enter a fail/defer/retry loop. This means the user is never created, so the new relation is never accessible. 

## Solution
This PR updates the error response check in `call()` to verify that `error_response is None`. This fixes the issue because we were getting false negatives when evaluating `not error_response` in this function, since a failed response is falsy. 
