### PR TITLE
[DPE-1557] - HA tests - network cut - with IP change

### DIFF
--- a/lib/charms/opensearch/v0/constants_charm.py
+++ b/lib/charms/opensearch/v0/constants_charm.py
@@ -47,6 +47,7 @@ RequestUnitServiceOps = "Requesting lock on operation: {}"
 InstallProgress = "Installing OpenSearch..."
 SecurityIndexInitProgress = "Initializing the security index..."
 AdminUserInitProgress = "Configuring admin user..."
+TLSNewCertsRequested = "Requesting new TLS certificates..."
 HorizontalScaleUpSuggest = "Horizontal scale up advised: {} shards unassigned."
 WaitingForOtherUnitServiceOps = "Waiting for other units to complete the ops on their service."
 

--- a/lib/charms/opensearch/v0/helper_conf_setter.py
+++ b/lib/charms/opensearch/v0/helper_conf_setter.py
@@ -261,6 +261,7 @@ class YamlConfigSetter(ConfigSetter):
 
             if output_type in [OutputType.file, OutputType.all]:
                 if output_file is None or output_file == config_file:
+                    f.seek(0)
                     f.write(data)
                 else:
                     with open(output_file, "w") as g:

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -370,6 +370,9 @@ class OpenSearchBaseCharm(CharmBase):
         # if there are exclusions to be removed
         if self.unit.is_leader():
             self.opensearch_exclusions.cleanup()
+
+            self._compute_and_broadcast_updated_topology(self._get_nodes(True))
+
             if self.health.apply() == HealthColors.YELLOW_TEMP:
                 event.defer()
                 return

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -398,7 +398,7 @@ class OpenSearchBaseCharm(CharmBase):
             # since when an IP change happens, "_on_peer_relation_joined" won't be called,
             # we need to alert the leader that it must recompute the node roles for any unit whose
             # roles were changed while the current unit was cut-off from the rest of the network
-            self.on[PeerRelationName].relation_changed.emit(
+            self.on[PeerRelationName].relation_joined.emit(
                 self.model.get_relation(PeerRelationName)
             )
 
@@ -546,6 +546,7 @@ class OpenSearchBaseCharm(CharmBase):
         except OpenSearchHttpError:
             self.peers_data.delete(Scope.UNIT, "starting")
             event.defer()
+            self._post_start_init()
             return
 
         try:

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -21,6 +21,7 @@ from charms.opensearch.v0.constants_charm import (
     ServiceIsStopping,
     ServiceStartError,
     ServiceStopped,
+    TLSNewCertsRequested,
     TLSNotFullyConfigured,
     TLSRelationBrokenError,
     TooManyNodesRemoved,
@@ -386,6 +387,7 @@ class OpenSearchBaseCharm(CharmBase):
     def _on_config_changed(self, _: ConfigChangedEvent):
         """On update status event. Useful for IP changes or for user provided config changes."""
         if self.opensearch_config.update_host_if_needed():
+            self.unit.status = MaintenanceStatus(TLSNewCertsRequested)
             self._delete_stored_tls_resources()
             self.tls.request_new_unit_certificates()
 

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -398,7 +398,9 @@ class OpenSearchBaseCharm(CharmBase):
             # since when an IP change happens, "_on_peer_relation_joined" won't be called,
             # we need to alert the leader that it must recompute the node roles for any unit whose
             # roles were changed while the current unit was cut-off from the rest of the network
-            self.on[PeerRelationName].relation_changed.emit(self.model.get_relation(PeerRelationName))
+            self.on[PeerRelationName].relation_changed.emit(
+                self.model.get_relation(PeerRelationName)
+            )
 
     def _on_set_password_action(self, event: ActionEvent):
         """Set new admin password from user input or generate if not passed."""

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -277,9 +277,6 @@ class OpenSearchBaseCharm(CharmBase):
                     Scope.APP, "bootstrap_contributors_count", contributor_count + 1
                 )
 
-            for relation in self.model.relations.get(ClientRelationName, []):
-                self.opensearch_provider.update_endpoints(relation)
-
             if unit_data.get(VOTING_TO_DELETE) or unit_data.get(ALLOCS_TO_DELETE):
                 self.opensearch_exclusions.cleanup()
 

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -396,8 +396,8 @@ class OpenSearchBaseCharm(CharmBase):
             self.tls.request_new_unit_certificates()
 
             # since when an IP change happens, "_on_peer_relation_joined" won't be called,
-            # we need to alert the leader that it must recompute the node roles for any unit whose roles
-            # were changed while the current unit was cut-off from the rest of the network
+            # we need to alert the leader that it must recompute the node roles for any unit whose
+            # roles were changed while the current unit was cut-off from the rest of the network
             self.on[PeerRelationName].relation_changed.emit(self.model.get_relation(PeerRelationName))
 
     def _on_set_password_action(self, event: ActionEvent):

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -577,7 +577,7 @@ class OpenSearchBaseCharm(CharmBase):
             self.peers_data.put(Scope.APP, "security_index_initialised", True)
 
         # it sometimes takes a few seconds before the node is fully "up" otherwise a 503 error
-        # may be thrown when calling a node - we want to unsure this node is perfectly ready
+        # may be thrown when calling a node - we want to ensure this node is perfectly ready
         # before marking it as ready
         if not self.opensearch.is_node_up():
             raise OpenSearchNotFullyReadyError("Node started but not full ready yet.")

--- a/lib/charms/opensearch/v0/opensearch_config.py
+++ b/lib/charms/opensearch/v0/opensearch_config.py
@@ -73,7 +73,6 @@ class OpenSearchConfig:
 
     def set_node_tls_conf(self, cert_type: CertType, secrets: Dict[str, any]):
         """Configures TLS for nodes."""
-        logger.debug(f"set_node_tls_conf: {cert_type}")
         target_conf_layer = "http" if cert_type == CertType.UNIT_HTTP else "transport"
 
         self._opensearch.config.put(

--- a/lib/charms/opensearch/v0/opensearch_config.py
+++ b/lib/charms/opensearch/v0/opensearch_config.py
@@ -180,7 +180,7 @@ class OpenSearchConfig:
             cm_ips_hostnames.extend([name] + aliases + addresses)
 
         with open(self._opensearch.paths.seed_hosts, "w+") as f:
-            lines = "\n".join(cm_ips_hostnames)
+            lines = "\n".join(set(cm_ips_hostnames))
             f.write(f"{lines}\n")
 
     def cleanup_bootstrap_conf(self):

--- a/lib/charms/opensearch/v0/opensearch_config.py
+++ b/lib/charms/opensearch/v0/opensearch_config.py
@@ -192,7 +192,6 @@ class OpenSearchConfig:
 
         Returns: True if host updated, False otherwise.
         """
-        logger.info("checking if old hosts are to be updated")
         old_hosts = set(self.load_node().get("network.host", []))
         if not old_hosts:
             # Unit not configured yet
@@ -200,7 +199,7 @@ class OpenSearchConfig:
 
         hosts = set(["_site_"] + self._opensearch.network_hosts)
         if old_hosts != hosts:
-            logger.info(f"updating hosts from {old_hosts} to {hosts}")
+            logger.info(f"Updating network.host from: {old_hosts} - to: {hosts}")
             self._opensearch.config.put(self.CONFIG_YML, "network.host", hosts)
             return True
 

--- a/lib/charms/opensearch/v0/opensearch_config.py
+++ b/lib/charms/opensearch/v0/opensearch_config.py
@@ -176,8 +176,12 @@ class OpenSearchConfig:
         """Add CM nodes ips / host names to the seed host list of this unit."""
         cm_ips_hostnames = cm_ips.copy()
         for ip in cm_ips:
-            name, aliases, addresses = socket.gethostbyaddr(ip)
-            cm_ips_hostnames.extend([name] + aliases + addresses)
+            try:
+                name, aliases, addresses = socket.gethostbyaddr(ip)
+                cm_ips_hostnames.extend([name] + aliases + addresses)
+            except socket.herror:
+                # no ptr record - the IP is enough and the only thing we have
+                pass
 
         with open(self._opensearch.paths.seed_hosts, "w+") as f:
             lines = "\n".join(set(cm_ips_hostnames))

--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -264,8 +264,6 @@ class OpenSearchDistribution(ABC):
 
                     response = s.request(**request_kwargs)
 
-                    response.raise_for_status()
-
                     return response
             except (requests.exceptions.RequestException, urllib3.exceptions.HTTPError) as e:
                 logger.error(
@@ -276,7 +274,7 @@ class OpenSearchDistribution(ABC):
                 return call(
                     remaining_retries - 1,
                     return_failed_resp,
-                    e.response if isinstance(e, requests.HTTPError) else None,
+                    e.response if isinstance(e, requests.exceptions.HTTPError) else None,
                 )
 
         if None in [endpoint, method]:
@@ -362,8 +360,11 @@ class OpenSearchDistribution(ABC):
     @property
     def roles(self) -> List[str]:
         """Get the list of the roles assigned to this node."""
-        nodes = self.request("GET", f"/_nodes/{self.node_id}")
-        return nodes["nodes"][self.node_id]["roles"]
+        try:
+            nodes = self.request("GET", f"/_nodes/{self.node_id}", alt_hosts=self._charm.alt_hosts)
+            return nodes["nodes"][self.node_id]["roles"]
+        except OpenSearchHttpError:
+            return self.config.load("opensearch.yml")["node.roles"]
 
     @property
     def host(self) -> str:

--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -274,7 +274,7 @@ class OpenSearchDistribution(ABC):
                 return call(
                     remaining_retries - 1,
                     return_failed_resp,
-                    error_response=e.response if isinstance(e, requests.exceptions.HTTPError) else None,
+                    e.response if isinstance(e, requests.exceptions.HTTPError) else None,
                 )
 
         if None in [endpoint, method]:

--- a/lib/charms/opensearch/v0/opensearch_exceptions.py
+++ b/lib/charms/opensearch/v0/opensearch_exceptions.py
@@ -59,6 +59,10 @@ class OpenSearchNotStartedError(OpenSearchError):
     """Exception thrown when attempting an operation when the OpenSearch service is stopped."""
 
 
+class OpenSearchNotFullyReadyError(OpenSearchError):
+    """Exception thrown when a node is started but not full ready to take on requests."""
+
+
 class OpenSearchCmdError(OpenSearchError):
     """Exception thrown when an OpenSearch bin command fails."""
 

--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -117,8 +117,9 @@ class OpenSearchTLS(Object):
         """
         try:
             scope, cert_type, secrets = self._find_secret(event.certificate_signing_request, "csr")
+            logger.debug(f"{scope.val}.{cert_type.val} TLS certificate available.")
         except TypeError:
-            logger.error("Unknown certificate available.")
+            logger.debug("Unknown certificate available.")
             return
 
         # seems like the admin certificate is also broadcast to non leader units on refresh request
@@ -152,8 +153,9 @@ class OpenSearchTLS(Object):
         """Request the new certificate when old certificate is expiring."""
         try:
             scope, cert_type, secrets = self._find_secret(event.certificate, "cert")
+            logger.debug(f"{scope.val}.{cert_type.val} TLS certificate expiring.")
         except TypeError:
-            logger.error("Unknown certificate expiring.")
+            logger.debug("Unknown certificate expiring.")
             return
 
         self._request_certificate_renewal(scope, cert_type, secrets)

--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -118,7 +118,7 @@ class OpenSearchTLS(Object):
         try:
             scope, cert_type, secrets = self._find_secret(event.certificate_signing_request, "csr")
         except TypeError:
-            logger.debug("Unknown certificate available.")
+            logger.error("Unknown certificate available.")
             return
 
         # seems like the admin certificate is also broadcast to non leader units on refresh request
@@ -152,9 +152,8 @@ class OpenSearchTLS(Object):
         """Request the new certificate when old certificate is expiring."""
         try:
             scope, cert_type, secrets = self._find_secret(event.certificate, "cert")
-            logger.debug(f"{scope.val}.{cert_type.val} TLS certificate expiring.")
         except TypeError:
-            logger.debug("Unknown certificate expiring.")
+            logger.error("Unknown certificate expiring.")
             return
 
         self._request_certificate_renewal(scope, cert_type, secrets)
@@ -200,9 +199,7 @@ class OpenSearchTLS(Object):
         if self.charm.model.get_relation(TLS_RELATION):
             self.certs.request_certificate_creation(certificate_signing_request=csr)
 
-    def _request_certificate_renewal(
-        self, scope: Scope, cert_type: CertType, secrets: Dict[str, str]
-    ):
+    def _request_certificate_renewal(self, scope: Scope, cert_type: CertType, secrets: Dict[str, str]):
         """Request new certificate and store the key/key-password/csr in the scope's data bag."""
         key = secrets["key"].encode("utf-8")
         key_password = secrets.get("key-password", None)

--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -88,10 +88,14 @@ class OpenSearchTLS(Object):
     def request_new_unit_certificates(self) -> None:
         """Requests a new certificate with the given scope and type from the tls operator."""
         for cert_type in [CertType.UNIT_HTTP, CertType.UNIT_TRANSPORT]:
+            csr = self.charm.secrets.get_object(Scope.UNIT, cert_type.val)["csr"].encode("utf-8")
+            self.certs.request_certificate_revocation(csr)
+
+        # doing this sequentially (revoking -> requesting new ones), to avoid triggering
+        # the "certificate available" callback with old certificates
+        for cert_type in [CertType.UNIT_HTTP, CertType.UNIT_TRANSPORT]:
             secrets = self.charm.secrets.get_object(Scope.UNIT, cert_type.val)
-            self._request_certificate(
-                Scope.UNIT, cert_type, secrets.get("key", None), secrets.get("key-password", None)
-            )
+            self._request_certificate_renewal(Scope.UNIT, cert_type, secrets)
 
     def _on_tls_relation_joined(self, _: RelationJoinedEvent) -> None:
         """Request certificate when TLS relation joined."""
@@ -113,9 +117,12 @@ class OpenSearchTLS(Object):
         """
         try:
             scope, cert_type, secrets = self._find_secret(event.certificate_signing_request, "csr")
-            logger.debug(f"{scope.val}.{cert_type.val} TLS certificate available.")
         except TypeError:
             logger.debug("Unknown certificate available.")
+            return
+
+        # seems like the admin certificate is also broadcast to non leader units on refresh request
+        if not self.charm.unit.is_leader() and scope == Scope.APP:
             return
 
         old_cert = secrets.get("cert", None)
@@ -150,27 +157,7 @@ class OpenSearchTLS(Object):
             logger.debug("Unknown certificate expiring.")
             return
 
-        key = secrets["key"].encode("utf-8")
-        key_password = secrets.get("key-password", None)
-        old_csr = secrets["csr"].encode("utf-8")
-
-        subject = self._get_subject(cert_type)
-        new_csr = generate_csr(
-            private_key=key,
-            private_key_password=(None if key_password is None else key_password.encode("utf-8")),
-            subject=subject,
-            organization=self.charm.app.name,
-            **self._get_sans(cert_type),
-        )
-
-        self.charm.secrets.put_object(
-            scope, cert_type.val, {"csr": new_csr.decode("utf-8"), "subject": subject}, merge=True
-        )
-
-        self.certs.request_certificate_renewal(
-            old_certificate_signing_request=old_csr,
-            new_certificate_signing_request=new_csr,
-        )
+        self._request_certificate_renewal(scope, cert_type, secrets)
 
     def _request_certificate(
         self,
@@ -212,6 +199,32 @@ class OpenSearchTLS(Object):
 
         if self.charm.model.get_relation(TLS_RELATION):
             self.certs.request_certificate_creation(certificate_signing_request=csr)
+
+    def _request_certificate_renewal(
+        self, scope: Scope, cert_type: CertType, secrets: Dict[str, str]
+    ):
+        """Request new certificate and store the key/key-password/csr in the scope's data bag."""
+        key = secrets["key"].encode("utf-8")
+        key_password = secrets.get("key-password", None)
+        old_csr = secrets["csr"].encode("utf-8")
+
+        subject = self._get_subject(cert_type)
+        new_csr = generate_csr(
+            private_key=key,
+            private_key_password=(None if key_password is None else key_password.encode("utf-8")),
+            subject=subject,
+            organization=self.charm.app.name,
+            **self._get_sans(cert_type),
+        )
+
+        self.charm.secrets.put_object(
+            scope, cert_type.val, {"csr": new_csr.decode("utf-8"), "subject": subject}, merge=True
+        )
+
+        self.certs.request_certificate_renewal(
+            old_certificate_signing_request=old_csr,
+            new_certificate_signing_request=new_csr,
+        )
 
     def _get_sans(self, cert_type: CertType) -> Dict[str, List[str]]:
         """Create a list of OID/IP/DNS names for an OpenSearch unit.

--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -201,7 +201,9 @@ class OpenSearchTLS(Object):
         if self.charm.model.get_relation(TLS_RELATION):
             self.certs.request_certificate_creation(certificate_signing_request=csr)
 
-    def _request_certificate_renewal(self, scope: Scope, cert_type: CertType, secrets: Dict[str, str]):
+    def _request_certificate_renewal(
+        self, scope: Scope, cert_type: CertType, secrets: Dict[str, str]
+    ):
         """Request new certificate and store the key/key-password/csr in the scope's data bag."""
         key = secrets["key"].encode("utf-8")
         key_password = secrets.get("key-password", None)

--- a/src/charm.py
+++ b/src/charm.py
@@ -5,6 +5,7 @@
 
 """Charmed Machine Operator for OpenSearch."""
 import logging
+from os import remove
 from os.path import exists
 from typing import Dict
 
@@ -71,6 +72,17 @@ class OpenSearchOperatorCharm(OpenSearchBaseCharm):
                     return False
 
         return exists(f"{certs_dir}/chain.pem") and exists(f"{certs_dir}/root-ca.cert")
+
+    @override
+    def _delete_stored_tls_resources(self):
+        """Delete the TLS resources of the unit that are stored on disk."""
+        certs_dir = self.opensearch.paths.certs
+        for cert_type in [CertType.UNIT_TRANSPORT, CertType.UNIT_HTTP]:
+            for extension in ["key", "cert"]:
+                try:
+                    remove(f"{certs_dir}/{cert_type}.{extension}")
+                except OSError:
+                    pass
 
 
 if __name__ == "__main__":

--- a/src/charm.py
+++ b/src/charm.py
@@ -82,6 +82,7 @@ class OpenSearchOperatorCharm(OpenSearchBaseCharm):
                 try:
                     remove(f"{certs_dir}/{cert_type}.{extension}")
                 except OSError:
+                    # thrown if file not exists, ignore
                     pass
 
 

--- a/tests/integration/ha/continuous_writes.py
+++ b/tests/integration/ha/continuous_writes.py
@@ -69,7 +69,8 @@ class ContinuousWrites:
         password = await self._secrets()
         self._queue.put(
             SimpleNamespace(
-                hosts=get_application_unit_ips(self._ops_test, app=self._app), password=password
+                hosts=await get_application_unit_ips(self._ops_test, app=self._app),
+                password=password,
             )
         )
 
@@ -175,7 +176,7 @@ class ContinuousWrites:
 
     async def _client(self, unit_ip: Optional[str] = None):
         """Build an opensearch client."""
-        hosts = get_application_unit_ips(self._ops_test, app=self._app)
+        hosts = await get_application_unit_ips(self._ops_test, app=self._app)
         if unit_ip:
             hosts = [unit_ip]
 

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -194,7 +194,7 @@ async def assert_continuous_writes_consistency(
     assert result.max_stored_id == result.last_expected_id
 
     # investigate the data in each shard, primaries and their respective replicas
-    units_ips = get_application_unit_ids_ips(ops_test, app)
+    units_ips = await get_application_unit_ids_ips(ops_test, app)
     shards = await get_shards_by_index(
         ops_test, list(units_ips.values())[0], ContinuousWrites.INDEX_NAME
     )
@@ -300,13 +300,13 @@ async def is_unit_reachable(from_host: str, to_host: str) -> bool:
         return False
 
 
-def is_network_restored(
+async def is_network_restored(
     ops_test: OpsTest, app: str, unit_id: int, unit_ip: str, retries: int = 20
 ) -> bool:
     try:
         for attempt in Retrying(stop=stop_after_attempt(retries), wait=wait_fixed(wait=30)):
             with attempt:
-                units_ips = get_application_unit_ids_ips(ops_test, app)
+                units_ips = await get_application_unit_ids_ips(ops_test, app)
                 if units_ips[unit_id] == unit_ip:
                     raise Exception
 

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -276,7 +276,7 @@ async def all_processes_down(ops_test: OpsTest, app: str) -> bool:
 
 
 async def cut_network_from_unit_with_ip_change(ops_test: OpsTest, app: str, unit_id: int) -> None:
-    """Cut network from a lxc container."""
+    """Cut network from a lxc container, triggering an IP change after restoration."""
     unit_ids_hostnames = await get_application_unit_ids_hostnames(ops_test, app)
     unit_hostname = unit_ids_hostnames[unit_id]
 
@@ -285,7 +285,7 @@ async def cut_network_from_unit_with_ip_change(ops_test: OpsTest, app: str, unit
     subprocess.check_call(cut_network_command.split())
 
 
-async def restore_network_for_unit(ops_test: OpsTest, app: str, unit_hostname: str) -> None:
+async def restore_network_for_unit(unit_hostname: str) -> None:
     """Restore network from a lxc container."""
     # remove mask from eth0
     restore_network_command = f"lxc config device remove {unit_hostname} eth0"
@@ -306,7 +306,7 @@ async def is_unit_reachable(from_host: str, to_host: str, retries: int = 5) -> b
         return True
 
 
-async def is_network_restored(
+async def is_network_restored_after_ip_change(
     ops_test: OpsTest, app: str, unit_id: int, unit_ip: str, retries: int = 25
 ) -> bool:
     try:

--- a/tests/integration/ha/test_ha.py
+++ b/tests/integration/ha/test_ha.py
@@ -545,6 +545,7 @@ async def test_restart_db_process_node_with_primary_shard(
     await assert_continuous_writes_consistency(ops_test, c_writes, app)
 
 
+@pytest.mark.abort_on_fail
 async def test_full_network_cut_with_ip_change_node_with_elected_cluster_manager(
     ops_test: OpsTest, c_writes: ContinuousWrites, c_writes_runner
 ) -> None:
@@ -622,13 +623,14 @@ async def test_full_network_cut_with_ip_change_node_with_elected_cluster_manager
     )
 
     # check unit network restored
+    unit_ids_ips = await get_application_unit_ids_ips(ops_test, app)
+    first_cm_unit_new_ip = unit_ids_ips[first_elected_cm_unit_id]
+
     assert await is_network_restored_after_ip_change(
         ops_test, app, first_elected_cm_unit_id, first_elected_cm_unit_ip
     ), "Network could not be restored."
 
     # check if node up and is included in the cluster formation
-    unit_ids_ips = await get_application_unit_ids_ips(ops_test, app)
-    first_cm_unit_new_ip = unit_ids_ips[first_elected_cm_unit_id]
     assert is_up(ops_test, first_cm_unit_new_ip), "Unit still not up."
 
     # verify the previously elected CM node successfully joined the rest of the fleet
@@ -640,6 +642,7 @@ async def test_full_network_cut_with_ip_change_node_with_elected_cluster_manager
     await assert_continuous_writes_consistency(ops_test, c_writes, app)
 
 
+@pytest.mark.abort_on_fail
 async def test_full_network_cut_with_ip_change_node_with_primary_shard(
     ops_test: OpsTest, c_writes: ContinuousWrites, c_writes_runner
 ) -> None:
@@ -727,13 +730,14 @@ async def test_full_network_cut_with_ip_change_node_with_primary_shard(
     )
 
     # check unit network restored
+    unit_ids_ips = await get_application_unit_ids_ips(ops_test, app)
+    first_unit_with_primary_shard_new_ip = unit_ids_ips[first_unit_with_primary_shard]
+
     assert await is_network_restored_after_ip_change(
         ops_test, app, first_unit_with_primary_shard, first_unit_with_primary_shard_ip
     ), "Network could not be restored."
 
     # check if node up and is included in the cluster formation
-    unit_ids_ips = await get_application_unit_ids_ips(ops_test, app)
-    first_unit_with_primary_shard_new_ip = unit_ids_ips[first_unit_with_primary_shard]
     assert is_up(ops_test, first_unit_with_primary_shard_new_ip), "Unit still not up."
 
     # check that the unit previously hosting the primary shard now hosts a replica

--- a/tests/integration/ha/test_ha.py
+++ b/tests/integration/ha/test_ha.py
@@ -17,7 +17,7 @@ from tests.integration.ha.helpers import (
     cut_network_from_unit_with_ip_change,
     get_elected_cm_unit_id,
     get_shards_by_index,
-    is_network_restored,
+    is_network_restored_after_ip_change,
     is_unit_reachable,
     restore_network_for_unit,
     send_kill_signal_to_process,
@@ -432,7 +432,7 @@ async def test_freeze_db_process_node_with_elected_cm(
 
 
 @pytest.mark.abort_on_fail
-async def test_restart_db_process_with_elected_cluster_manager(
+async def test_restart_db_process_node_with_elected_cluster_manager(
     ops_test: OpsTest, c_writes: ContinuousWrites, c_balanced_writes_runner
 ) -> None:
     """Check cluster self-healing & data indexed/read on process restart on CM node."""
@@ -484,7 +484,7 @@ async def test_restart_db_process_with_elected_cluster_manager(
 
 
 @pytest.mark.abort_on_fail
-async def test_restart_db_process_with_primary_shard(
+async def test_restart_db_process_node_with_primary_shard(
     ops_test: OpsTest, c_writes: ContinuousWrites, c_balanced_writes_runner
 ) -> None:
     """Check cluster can self-heal, data indexed/read on process restart on primary shard node."""
@@ -542,6 +542,209 @@ async def test_restart_db_process_with_primary_shard(
         ops_test, leader_unit_ip, get_application_unit_names(ops_test, app=app)
     )
 
+    await assert_continuous_writes_consistency(ops_test, c_writes, app)
+
+
+async def test_full_network_cut_with_ip_change_node_with_elected_cluster_manager(
+    ops_test: OpsTest, c_writes: ContinuousWrites, c_writes_runner
+) -> None:
+    """Check that cluster can self-heal and unit reconfigures itself with new IP."""
+    app = (await app_name(ops_test)) or APP_NAME
+
+    unit_ids_ips = await get_application_unit_ids_ips(ops_test, app)
+    unit_ids_hostnames = await get_application_unit_ids_hostnames(ops_test, app)
+
+    # find unit currently elected cluster_manager
+    leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
+    first_elected_cm_unit_id = await get_elected_cm_unit_id(ops_test, leader_unit_ip)
+    first_elected_cm_unit_ip = unit_ids_ips[first_elected_cm_unit_id]
+    first_elected_cm_unit_hostname = unit_ids_hostnames[first_elected_cm_unit_id]
+
+    # Killing the only instance can be disastrous.
+    if len(ops_test.model.applications[app].units) < 2:
+        await ops_test.model.applications[app].add_unit(count=1)
+        await ops_test.model.wait_for_idle(
+            apps=[app],
+            status="active",
+            timeout=1000,
+            idle_period=IDLE_PERIOD,
+        )
+
+    # verify the node is well reachable
+    assert await is_up(
+        ops_test, unit_ids_ips[first_elected_cm_unit_id]
+    ), "Initial elected cluster manager node not online."
+
+    # cut network from current elected cm unit
+    await cut_network_from_unit_with_ip_change(ops_test, app, first_elected_cm_unit_id)
+
+    # verify machine not reachable from / to peer units
+    for unit_id, unit_hostname in unit_ids_hostnames.items():
+        if unit_id != first_elected_cm_unit_id:
+            assert not await is_unit_reachable(
+                from_host=unit_hostname, to_host=first_elected_cm_unit_hostname
+            ), "Unit is still reachable from other units."
+            assert not await is_unit_reachable(
+                from_host=first_elected_cm_unit_hostname, to_host=unit_hostname
+            ), "Unit can still reach other units."
+
+    # check reach from controller - noticed that the controller is able to ping the unit for longer
+    assert not await is_unit_reachable(
+        from_host=await get_controller_hostname(ops_test), to_host=first_elected_cm_unit_hostname
+    ), "Unit is still reachable from controller"
+
+    # verify node not up anymore
+    assert not await is_up(
+        ops_test, unit_ids_ips[first_elected_cm_unit_id], retries=3
+    ), "Connection still possible to the first CM node where the network was cut."
+
+    # verify new writes are continuing by counting the number of writes before and after 5 seconds
+    writes = await c_writes.count()
+    time.sleep(5)
+    more_writes = await c_writes.count()
+    assert more_writes > writes, "Writes not continuing to DB"
+
+    # check new CM got elected
+    leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
+    current_elected_cm_unit_id = await get_elected_cm_unit_id(ops_test, leader_unit_ip)
+    assert current_elected_cm_unit_id != first_elected_cm_unit_id, "No CM re-election happened."
+
+    # restore the network on the unit
+    await restore_network_for_unit(first_elected_cm_unit_hostname)
+
+    # Wait until the cluster becomes idle (new TLS certs, node reconfigured / restarted).
+    await ops_test.model.wait_for_idle(
+        apps=[app],
+        status="active",
+        timeout=1000,
+        wait_for_exact_units=len(unit_ids_ips),
+        idle_period=IDLE_PERIOD,
+    )
+
+    # check unit network restored
+    assert await is_network_restored_after_ip_change(
+        ops_test, app, first_elected_cm_unit_id, first_elected_cm_unit_ip
+    ), "Network could not be restored."
+
+    # check if node up and is included in the cluster formation
+    unit_ids_ips = await get_application_unit_ids_ips(ops_test, app)
+    first_cm_unit_new_ip = unit_ids_ips[first_elected_cm_unit_id]
+    assert is_up(ops_test, first_cm_unit_new_ip), "Unit still not up."
+
+    # verify the previously elected CM node successfully joined the rest of the fleet
+    assert check_cluster_formation_successful(
+        ops_test, first_cm_unit_new_ip, get_application_unit_names(ops_test, app)
+    ), "Unit did NOT join the rest of the cluster."
+
+    # continuous writes checks
+    await assert_continuous_writes_consistency(ops_test, c_writes, app)
+
+
+async def test_full_network_cut_with_ip_change_node_with_primary_shard(
+    ops_test: OpsTest, c_writes: ContinuousWrites, c_writes_runner
+) -> None:
+    """Check that cluster can self-heal and unit reconfigures itself with new IP."""
+    app = (await app_name(ops_test)) or APP_NAME
+
+    unit_ids_ips = await get_application_unit_ids_ips(ops_test, app)
+    unit_ids_hostnames = await get_application_unit_ids_hostnames(ops_test, app)
+
+    leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
+
+    # find unit hosting the primary shard of the index "series-index"
+    shards = await get_shards_by_index(ops_test, leader_unit_ip, ContinuousWrites.INDEX_NAME)
+    first_unit_with_primary_shard = [shard.unit_id for shard in shards if shard.is_prim][0]
+    first_unit_with_primary_shard_ip = unit_ids_ips[first_unit_with_primary_shard]
+    first_unit_with_primary_shard_hostname = unit_ids_hostnames[first_unit_with_primary_shard]
+
+    # Killing the only instance can be disastrous.
+    if len(ops_test.model.applications[app].units) < 2:
+        await ops_test.model.applications[app].add_unit(count=1)
+        await ops_test.model.wait_for_idle(
+            apps=[app],
+            status="active",
+            timeout=1000,
+            idle_period=IDLE_PERIOD,
+        )
+
+    # verify the node is well reachable
+    assert await is_up(
+        ops_test, unit_ids_ips[first_unit_with_primary_shard]
+    ), "Initial node with primary shard of 'series_index' elected cluster manager node not online."
+
+    # cut network from current elected cm unit
+    await cut_network_from_unit_with_ip_change(ops_test, app, first_unit_with_primary_shard)
+
+    # verify machine not reachable from / to peer units
+    for unit_id, unit_hostname in unit_ids_hostnames.items():
+        if unit_id != first_unit_with_primary_shard:
+            assert not await is_unit_reachable(
+                from_host=unit_hostname, to_host=first_unit_with_primary_shard_hostname
+            ), "Unit is still reachable from other units."
+            assert not await is_unit_reachable(
+                from_host=first_unit_with_primary_shard_hostname, to_host=unit_hostname
+            ), "Unit can still reach other units."
+
+    # check reach from controller - noticed that the controller is able to ping the unit for longer
+    assert not await is_unit_reachable(
+        from_host=await get_controller_hostname(ops_test), to_host=first_unit_with_primary_shard_hostname
+    ), "Unit is still reachable from controller"
+
+    # verify node not up anymore
+    assert not await is_up(
+        ops_test, unit_ids_ips[first_unit_with_primary_shard], retries=3
+    ), "Connection still possible to the first unit with primary shard where the network was cut."
+
+    # verify new writes are continuing by counting the number of writes before and after 5 seconds
+    writes = await c_writes.count()
+    time.sleep(5)
+    more_writes = await c_writes.count()
+    assert more_writes > writes, "Writes not continuing to DB"
+
+    # check new primary shard got elected
+    leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
+
+    # fetch units hosting the new primary shards of the previous index
+    shards = await get_shards_by_index(ops_test, leader_unit_ip, ContinuousWrites.INDEX_NAME)
+    units_with_p_shards = [shard.unit_id for shard in shards if shard.is_prim]
+    assert len(units_with_p_shards) == 2
+    for unit_id in units_with_p_shards:
+        assert (
+            unit_id != first_unit_with_primary_shard
+        ), "Primary shard still assigned to the unit where the service was killed."
+
+    # restore the network on the unit
+    await restore_network_for_unit(first_unit_with_primary_shard_hostname)
+
+    # Wait until the cluster becomes idle (new TLS certs, node reconfigured / restarted).
+    await ops_test.model.wait_for_idle(
+        apps=[app],
+        status="active",
+        timeout=1000,
+        wait_for_exact_units=len(unit_ids_ips),
+        idle_period=IDLE_PERIOD,
+    )
+
+    # check unit network restored
+    assert await is_network_restored_after_ip_change(
+        ops_test, app, first_unit_with_primary_shard, first_unit_with_primary_shard_ip
+    ), "Network could not be restored."
+
+    # check if node up and is included in the cluster formation
+    unit_ids_ips = await get_application_unit_ids_ips(ops_test, app)
+    first_unit_with_primary_shard_new_ip = unit_ids_ips[first_unit_with_primary_shard]
+    assert is_up(ops_test, first_unit_with_primary_shard_new_ip), "Unit still not up."
+
+    # check that the unit previously hosting the primary shard now hosts a replica
+    units_with_r_shards = [shard.unit_id for shard in shards if not shard.is_prim]
+    assert first_unit_with_primary_shard in units_with_r_shards
+
+    # verify the node with the old primary successfully joined the rest of the fleet
+    assert check_cluster_formation_successful(
+        ops_test, first_unit_with_primary_shard_new_ip, get_application_unit_names(ops_test, app)
+    ), "Unit did NOT join the rest of the cluster."
+
+    # continuous writes checks
     await assert_continuous_writes_consistency(ops_test, c_writes, app)
 
 
@@ -651,99 +854,6 @@ async def test_full_cluster_restart(
     # check that cluster health is green (all primary and replica shards allocated)
     health_resp = await cluster_health(ops_test, leader_ip)
     assert health_resp["status"] == "green", f"Cluster {health_resp['status']} - expected green."
-
-    # continuous writes checks
-    await assert_continuous_writes_consistency(ops_test, c_writes, app)
-
-
-async def test_full_network_cut_elected_cm_with_ip_change(
-    ops_test: OpsTest, c_writes: ContinuousWrites, c_writes_runner
-) -> None:
-    """Check that cluster can self-heal and unit reconfigures itself with new IP."""
-    app = (await app_name(ops_test)) or APP_NAME
-
-    unit_ids_ips = await get_application_unit_ids_ips(ops_test, app)
-    unit_ids_hostnames = await get_application_unit_ids_hostnames(ops_test, app)
-
-    # Killing the only instance can be disastrous.
-    if len(ops_test.model.applications[app].units) < 2:
-        await ops_test.model.applications[app].add_unit(count=1)
-        await ops_test.model.wait_for_idle(
-            apps=[app],
-            status="active",
-            timeout=1000,
-            idle_period=IDLE_PERIOD,
-        )
-
-    # find unit currently elected cluster_manager
-    leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
-    first_elected_cm_unit_id = await get_elected_cm_unit_id(ops_test, leader_unit_ip)
-    first_elected_cm_unit_ip = unit_ids_ips[first_elected_cm_unit_id]
-    first_elected_cm_unit_hostname = unit_ids_hostnames[first_elected_cm_unit_id]
-
-    # verify the node is well reachable
-    assert await is_up(
-        ops_test, unit_ids_ips[first_elected_cm_unit_id]
-    ), "Initial elected cluster manager node not ."
-
-    # cut network from current elected cm unit
-    await cut_network_from_unit_with_ip_change(ops_test, app, first_elected_cm_unit_id)
-
-    # verify machine not reachable from / to peer units
-    for unit_id, unit_hostname in unit_ids_hostnames.items():
-        if unit_id != first_elected_cm_unit_id:
-            assert not await is_unit_reachable(
-                from_host=unit_hostname, to_host=first_elected_cm_unit_hostname
-            ), "Unit is still reachable from other units."
-            assert not await is_unit_reachable(
-                from_host=first_elected_cm_unit_hostname, to_host=unit_hostname
-            ), "Unit can still reach other units."
-
-    # check reach from controller - noticed that the controller is able to ping the unit for longer
-    assert not await is_unit_reachable(
-        from_host=await get_controller_hostname(ops_test), to_host=first_elected_cm_unit_hostname
-    ), "Unit is still reachable from controller"
-
-    # verify node not up anymore
-    assert not await is_up(
-        ops_test, unit_ids_ips[first_elected_cm_unit_id], retries=3
-    ), "Connection still possible to the first CM node where the network was cut."
-
-    # verify new writes are continuing by counting the number of writes before and after 5 seconds
-    writes = await c_writes.count()
-    time.sleep(5)
-    more_writes = await c_writes.count()
-    assert more_writes > writes, "Writes not continuing to DB"
-
-    # check new CM got elected
-    leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
-    current_elected_cm_unit_id = await get_elected_cm_unit_id(ops_test, leader_unit_ip)
-    assert current_elected_cm_unit_id != first_elected_cm_unit_id, "No CM election happened."
-
-    # restore the network on the unit
-    await restore_network_for_unit(ops_test, app, first_elected_cm_unit_hostname)
-
-    # Wait until the cluster becomes idle (node restart).
-    await ops_test.model.wait_for_idle(
-        apps=[app],
-        status="active",
-        timeout=1000,
-        wait_for_exact_units=len(unit_ids_ips),
-        idle_period=IDLE_PERIOD,
-    )
-
-    # check unit network restored
-    assert await is_network_restored(
-        ops_test, app, first_elected_cm_unit_id, first_elected_cm_unit_ip
-    ), "Network could not be restored."
-
-    # check if node up and is included in the cluster formation
-    unit_ids_ips = await get_application_unit_ids_ips(ops_test, app)
-    first_cm_unit_new_ip = unit_ids_ips[first_elected_cm_unit_id]
-    assert is_up(ops_test, first_cm_unit_new_ip), "Unit still not up."
-    assert check_cluster_formation_successful(
-        ops_test, first_cm_unit_new_ip, get_application_unit_names(ops_test, app)
-    ), "Unit did NOT join the rest of the cluster."
 
     # continuous writes checks
     await assert_continuous_writes_consistency(ops_test, c_writes, app)

--- a/tests/integration/ha/test_ha.py
+++ b/tests/integration/ha/test_ha.py
@@ -627,7 +627,7 @@ async def test_full_network_cut_with_ip_change_node_with_elected_cluster_manager
     first_cm_unit_new_ip = unit_ids_ips[first_elected_cm_unit_id]
 
     assert await is_network_restored_after_ip_change(
-        ops_test, app, first_elected_cm_unit_id, first_elected_cm_unit_ip
+        ops_test, app, first_elected_cm_unit_id, first_cm_unit_new_ip
     ), "Network could not be restored."
 
     # check if node up and is included in the cluster formation
@@ -734,7 +734,7 @@ async def test_full_network_cut_with_ip_change_node_with_primary_shard(
     first_unit_with_primary_shard_new_ip = unit_ids_ips[first_unit_with_primary_shard]
 
     assert await is_network_restored_after_ip_change(
-        ops_test, app, first_unit_with_primary_shard, first_unit_with_primary_shard_ip
+        ops_test, app, first_unit_with_primary_shard, first_unit_with_primary_shard_new_ip
     ), "Network could not be restored."
 
     # check if node up and is included in the cluster formation

--- a/tests/integration/ha/test_ha.py
+++ b/tests/integration/ha/test_ha.py
@@ -687,7 +687,8 @@ async def test_full_network_cut_with_ip_change_node_with_primary_shard(
 
     # check reach from controller - noticed that the controller is able to ping the unit for longer
     assert not await is_unit_reachable(
-        from_host=await get_controller_hostname(ops_test), to_host=first_unit_with_primary_shard_hostname
+        from_host=await get_controller_hostname(ops_test),
+        to_host=first_unit_with_primary_shard_hostname,
     ), "Unit is still reachable from controller"
 
     # verify node not up anymore

--- a/tests/integration/ha/test_ha.py
+++ b/tests/integration/ha/test_ha.py
@@ -547,7 +547,7 @@ async def test_restart_db_process_node_with_primary_shard(
 
 @pytest.mark.abort_on_fail
 async def test_full_network_cut_with_ip_change_node_with_elected_cluster_manager(
-    ops_test: OpsTest, c_writes: ContinuousWrites, c_writes_runner
+    ops_test: OpsTest, c_writes: ContinuousWrites, c_balanced_writes_runner
 ) -> None:
     """Check that cluster can self-heal and unit reconfigures itself with new IP."""
     app = (await app_name(ops_test)) or APP_NAME
@@ -644,7 +644,7 @@ async def test_full_network_cut_with_ip_change_node_with_elected_cluster_manager
 
 @pytest.mark.abort_on_fail
 async def test_full_network_cut_with_ip_change_node_with_primary_shard(
-    ops_test: OpsTest, c_writes: ContinuousWrites, c_writes_runner
+    ops_test: OpsTest, c_writes: ContinuousWrites, c_balanced_writes_runner
 ) -> None:
     """Check that cluster can self-heal and unit reconfigures itself with new IP."""
     app = (await app_name(ops_test)) or APP_NAME

--- a/tests/integration/ha/test_ha.py
+++ b/tests/integration/ha/test_ha.py
@@ -130,7 +130,7 @@ async def test_replication_across_members(
     """
     app = (await app_name(ops_test)) or APP_NAME
 
-    units = get_application_unit_ids_ips(ops_test, app=app)
+    units = await get_application_unit_ids_ips(ops_test, app=app)
     leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
 
     # create index with r_shards = nodes - 1
@@ -167,7 +167,7 @@ async def test_kill_db_process_node_with_primary_shard(
     """Check cluster can self-heal + data indexed/read when process dies on node with P_shard."""
     app = (await app_name(ops_test)) or APP_NAME
 
-    units_ips = get_application_unit_ids_ips(ops_test, app)
+    units_ips = await get_application_unit_ids_ips(ops_test, app)
     leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
 
     # find unit hosting the primary shard of the index "series-index"
@@ -230,7 +230,7 @@ async def test_kill_db_process_node_with_elected_cm(
     """Check cluster can self-heal, data indexed/read when process dies on node with elected CM."""
     app = (await app_name(ops_test)) or APP_NAME
 
-    units_ips = get_application_unit_ids_ips(ops_test, app)
+    units_ips = await get_application_unit_ids_ips(ops_test, app)
     leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
 
     # find unit currently elected cluster_manager
@@ -283,7 +283,7 @@ async def test_freeze_db_process_node_with_primary_shard(
     """Check cluster can self-heal + data indexed/read on process freeze on node with P_shard."""
     app = (await app_name(ops_test)) or APP_NAME
 
-    units_ips = get_application_unit_ids_ips(ops_test, app)
+    units_ips = await get_application_unit_ids_ips(ops_test, app)
     leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
 
     # find unit hosting the primary shard of the index "series-index"
@@ -318,7 +318,7 @@ async def test_freeze_db_process_node_with_primary_shard(
 
     # get reachable unit to perform requests against, in case the previously stopped unit
     # is leader unit, so its address is not reachable
-    reachable_ip = get_reachable_unit_ips(ops_test)[0]
+    reachable_ip = await get_reachable_unit_ips(ops_test)[0]
 
     # fetch unit hosting the new primary shard of the previous index
     shards = await get_shards_by_index(ops_test, reachable_ip, ContinuousWrites.INDEX_NAME)
@@ -366,7 +366,7 @@ async def test_freeze_db_process_node_with_elected_cm(
     """Check cluster can self-heal, data indexed/read on process freeze on node with elected CM."""
     app = (await app_name(ops_test)) or APP_NAME
 
-    units_ips = get_application_unit_ids_ips(ops_test, app)
+    units_ips = await get_application_unit_ids_ips(ops_test, app)
     leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
 
     # find unit currently elected cluster_manager
@@ -400,7 +400,7 @@ async def test_freeze_db_process_node_with_elected_cm(
 
     # get reachable unit to perform requests against, in case the previously stopped unit
     # is leader unit, so its address is not reachable
-    reachable_ip = get_reachable_unit_ips(ops_test)[0]
+    reachable_ip = await get_reachable_unit_ips(ops_test)[0]
 
     # fetch the current elected cluster_manager
     current_elected_cm_unit_id = await get_elected_cm_unit_id(ops_test, reachable_ip)
@@ -438,7 +438,7 @@ async def test_restart_db_process_with_elected_cluster_manager(
     """Check cluster self-healing & data indexed/read on process restart on CM node."""
     app = (await app_name(ops_test)) or APP_NAME
 
-    units_ips = get_application_unit_ids_ips(ops_test, app)
+    units_ips = await get_application_unit_ids_ips(ops_test, app)
     leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
 
     # find unit currently elected cluster manager
@@ -490,7 +490,7 @@ async def test_restart_db_process_with_primary_shard(
     """Check cluster can self-heal, data indexed/read on process restart on primary shard node."""
     app = (await app_name(ops_test)) or APP_NAME
 
-    units_ips = get_application_unit_ids_ips(ops_test, app)
+    units_ips = await get_application_unit_ids_ips(ops_test, app)
     leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
 
     # find unit hosting the primary shard of the index "series-index"
@@ -578,7 +578,7 @@ async def test_full_cluster_crash(
     time.sleep(ORIGINAL_RESTART_DELAY + 45)
 
     # verify all units are up and running
-    for unit_id, unit_ip in get_application_unit_ids_ips(ops_test, app).items():
+    for unit_id, unit_ip in await get_application_unit_ids_ips(ops_test, app).items():
         assert await is_up(ops_test, unit_ip), f"Unit {unit_id} not restarted after cluster crash."
 
     # check all nodes successfully joined the same cluster
@@ -634,7 +634,7 @@ async def test_full_cluster_restart(
     time.sleep(ORIGINAL_RESTART_DELAY + 45)
 
     # verify all units are up and running
-    for unit_id, unit_ip in get_application_unit_ids_ips(ops_test, app).items():
+    for unit_id, unit_ip in await get_application_unit_ids_ips(ops_test, app).items():
         assert await is_up(ops_test, unit_ip), f"Unit {unit_id} not restarted after cluster crash."
 
     # check all nodes successfully joined the same cluster
@@ -662,7 +662,7 @@ async def test_full_network_cut_elected_cm_with_ip_change(
     """Check that cluster can self-heal and unit reconfigures itself with new IP."""
     app = (await app_name(ops_test)) or APP_NAME
 
-    unit_ids_ips = get_application_unit_ids_ips(ops_test, app)
+    unit_ids_ips = await get_application_unit_ids_ips(ops_test, app)
     unit_ids_hostnames = await get_application_unit_ids_hostnames(ops_test, app)
 
     # Killing the only instance can be disastrous.
@@ -732,12 +732,12 @@ async def test_full_network_cut_elected_cm_with_ip_change(
     )
 
     # check unit network restored
-    assert is_network_restored(
+    assert await is_network_restored(
         ops_test, app, first_elected_cm_unit_id, first_elected_cm_unit_ip
     ), "Network could not be restored."
 
     # check if node up and is included in the cluster formation
-    unit_ids_ips = get_application_unit_ids_ips(ops_test, app)
+    unit_ids_ips = await get_application_unit_ids_ips(ops_test, app)
     first_cm_unit_new_ip = unit_ids_ips[first_elected_cm_unit_id]
     assert is_up(ops_test, first_cm_unit_new_ip), "Node still not up."
     assert check_cluster_formation_successful(

--- a/tests/integration/ha/test_ha.py
+++ b/tests/integration/ha/test_ha.py
@@ -558,7 +558,6 @@ async def test_full_network_cut_with_ip_change_node_with_elected_cluster_manager
     # find unit currently elected cluster_manager
     leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
     first_elected_cm_unit_id = await get_elected_cm_unit_id(ops_test, leader_unit_ip)
-    first_elected_cm_unit_ip = unit_ids_ips[first_elected_cm_unit_id]
     first_elected_cm_unit_hostname = unit_ids_hostnames[first_elected_cm_unit_id]
 
     # Killing the only instance can be disastrous.
@@ -657,7 +656,6 @@ async def test_full_network_cut_with_ip_change_node_with_primary_shard(
     # find unit hosting the primary shard of the index "series-index"
     shards = await get_shards_by_index(ops_test, leader_unit_ip, ContinuousWrites.INDEX_NAME)
     first_unit_with_primary_shard = [shard.unit_id for shard in shards if shard.is_prim][0]
-    first_unit_with_primary_shard_ip = unit_ids_ips[first_unit_with_primary_shard]
     first_unit_with_primary_shard_hostname = unit_ids_hostnames[first_unit_with_primary_shard]
 
     # Killing the only instance can be disastrous.

--- a/tests/integration/ha/test_ha.py
+++ b/tests/integration/ha/test_ha.py
@@ -318,7 +318,7 @@ async def test_freeze_db_process_node_with_primary_shard(
 
     # get reachable unit to perform requests against, in case the previously stopped unit
     # is leader unit, so its address is not reachable
-    reachable_ip = await get_reachable_unit_ips(ops_test)[0]
+    reachable_ip = (await get_reachable_unit_ips(ops_test))[0]
 
     # fetch unit hosting the new primary shard of the previous index
     shards = await get_shards_by_index(ops_test, reachable_ip, ContinuousWrites.INDEX_NAME)
@@ -400,7 +400,7 @@ async def test_freeze_db_process_node_with_elected_cm(
 
     # get reachable unit to perform requests against, in case the previously stopped unit
     # is leader unit, so its address is not reachable
-    reachable_ip = await get_reachable_unit_ips(ops_test)[0]
+    reachable_ip = (await get_reachable_unit_ips(ops_test))[0]
 
     # fetch the current elected cluster_manager
     current_elected_cm_unit_id = await get_elected_cm_unit_id(ops_test, reachable_ip)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -86,7 +86,8 @@ async def run_action(
         A SimpleNamespace with "status, response (results)"
     """
     if unit_id is None:
-        unit_id = list(await get_reachable_units(ops_test, app=app).keys())[0]
+        reachable_units = await get_reachable_units(ops_test, app=app)
+        unit_id = list(reachable_units.keys())[0]
 
     unit_name = [
         unit.name

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -242,7 +242,6 @@ async def get_application_unit_ids_hostnames(
     result = {}
     for unit in ops_test.model.applications[app].units:
         unit_id = int(unit.name.split("/")[1])
-        _, raw_hostname, _ = await ops_test.juju("ssh", f"{app}/{unit_id}", "hostname")
         result[unit_id] = await get_unit_hostname(ops_test, unit_id, app)
 
     return result

--- a/tests/integration/tls/test_tls.py
+++ b/tests/integration/tls/test_tls.py
@@ -66,7 +66,7 @@ async def test_security_index_initialised(ops_test: OpsTest) -> None:
 @pytest.mark.abort_on_fail
 async def test_tls_configured(ops_test: OpsTest) -> None:
     """Test that TLS is enabled when relating to the TLS Certificates Operator."""
-    for unit_name, unit_ip in await get_application_unit_ips_names(ops_test).items():
+    for unit_name, unit_ip in (await get_application_unit_ips_names(ops_test)).items():
         assert await check_unit_tls_configured(ops_test, unit_ip, unit_name)
 
 

--- a/tests/integration/tls/test_tls.py
+++ b/tests/integration/tls/test_tls.py
@@ -66,7 +66,7 @@ async def test_security_index_initialised(ops_test: OpsTest) -> None:
 @pytest.mark.abort_on_fail
 async def test_tls_configured(ops_test: OpsTest) -> None:
     """Test that TLS is enabled when relating to the TLS Certificates Operator."""
-    for unit_name, unit_ip in get_application_unit_ips_names(ops_test).items():
+    for unit_name, unit_ip in await get_application_unit_ips_names(ops_test).items():
         assert await check_unit_tls_configured(ops_test, unit_ip, unit_name)
 
 

--- a/tests/unit/lib/test_opensearch_base_charm.py
+++ b/tests/unit/lib/test_opensearch_base_charm.py
@@ -143,8 +143,6 @@ class TestOpenSearchBaseCharm(unittest.TestCase):
             self.peers_data.delete(Scope.APP, "security_index_initialised")
             _can_service_start.return_value = True
             self.harness.set_leader(True)
-            # start.reset_mock()
-
             self.charm.on.start.emit()
             _get_nodes.assert_called()
             _set_node_conf.assert_called()

--- a/tests/unit/lib/test_opensearch_base_charm.py
+++ b/tests/unit/lib/test_opensearch_base_charm.py
@@ -37,6 +37,8 @@ class TestOpenSearchBaseCharm(unittest.TestCase):
         self.opensearch = self.charm.opensearch
         self.opensearch.current = MagicMock()
         self.opensearch.current.return_value = Node("cm1", ["cluster_manager", "data"], "1.1.1.1")
+        self.opensearch.is_failed = MagicMock()
+        self.opensearch.is_failed.return_value = False
 
         self.peers_data = self.charm.peers_data
         self.rel_id = self.harness.add_relation(PeerRelationName, self.charm.app.name)
@@ -141,7 +143,8 @@ class TestOpenSearchBaseCharm(unittest.TestCase):
             self.peers_data.delete(Scope.APP, "security_index_initialised")
             _can_service_start.return_value = True
             self.harness.set_leader(True)
-            start.reset_mock()
+            # start.reset_mock()
+
             self.charm.on.start.emit()
             _get_nodes.assert_called()
             _set_node_conf.assert_called()


### PR DESCRIPTION
## Issue
This PR implements the HA test and fixes the bugs raised with it for [DPE-1557](https://warthogs.atlassian.net/browse/DPE-1557), namely - this PR implements:
- Integration tests for:
    - network cut - with IP change - on node with elected CM
    - network cut - with IP change - on node with primary shard of index
    - helpers for accurately retrieving all units related information
- implementation:
    - renewal of certificates for node after the IP change 
    - renewal of the `network.host` content with the new hosts
    - manual trigger of topology re-computing after network restored
- fixes:
    - duplication issue of the content of the `jvm.options` file 
    - infinite loop of the opensearch daemon restart
    - tls cert key format
    - only mark a unit as `ready` when it's fully able to take on requests 
    - unit tests

[DPE-1557]: https://warthogs.atlassian.net/browse/DPE-1557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ