### PR TITLE
Clearing statuses correctly

### DIFF
--- a/lib/charms/opensearch/v0/constants_charm.py
+++ b/lib/charms/opensearch/v0/constants_charm.py
@@ -39,9 +39,13 @@ ClusterHealthRed = "1 or more 'primary' shards are not assigned, please scale yo
 ClusterHealthYellow = (
     "1 or more 'replica' shards are not assigned, please scale your application up."
 )
+IndexCreationFailed = "failed to create {index} index - deferring index-requested event..."
+UserCreationFailed = "failed to create users for {rel_name} relation {id}"
+
 
 # Wait status
 RequestUnitServiceOps = "Requesting lock on operation: {}"
+
 
 # Maintenance statuses
 InstallProgress = "Installing OpenSearch..."
@@ -49,6 +53,7 @@ SecurityIndexInitProgress = "Initializing the security index..."
 AdminUserInitProgress = "Configuring admin user..."
 HorizontalScaleUpSuggest = "Horizontal scale up advised: {} shards unassigned."
 WaitingForOtherUnitServiceOps = "Waiting for other units to complete the ops on their service."
+NewIndexRequested = "new index {index} requested"
 
 
 # Relation Interfaces

--- a/lib/charms/opensearch/v0/opensearch_relation_provider.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_provider.py
@@ -381,12 +381,11 @@ class OpenSearchProvider(Object):
             ips = set([node.ip for node in self.charm._get_nodes(use_localhost=True)])
         except OpenSearchHttpError:
             logger.error("unable to get nodes")
-            # TODO maybe set endpoints to 0?
-            return
+            ips = set()
 
         port = self.opensearch.port
         endpoints = ",".join([f"{ip}:{port}" for ip in ips - omit_endpoints])
         databag_endpoints = relation.data[relation.app].get("endpoints")
 
-        if endpoints and endpoints != databag_endpoints:
+        if endpoints != databag_endpoints:
             self.opensearch_provides.set_endpoints(relation.id, endpoints)

--- a/lib/charms/opensearch/v0/opensearch_relation_provider.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_provider.py
@@ -350,8 +350,9 @@ class OpenSearchProvider(Object):
         if not self.unit.is_leader():
             return
         if self._unit_departing(event.relation):
-            # This unit is being removed, so don't update the relation.
+            # This unit is being removed.
             self.charm.peers_data.delete(Scope.UNIT, self._depart_flag(event.relation))
+            self.update_endpoints(event.relation, omit_endpoints={self.charm.unit_ip})
             return
 
         self.user_manager.remove_users_and_roles(event.relation.id)

--- a/lib/charms/opensearch/v0/opensearch_relation_provider.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_provider.py
@@ -348,6 +348,7 @@ class OpenSearchProvider(Object):
         """Check if this relation is being removed, and update the peer databag accordingly."""
         if event.departing_unit == self.charm.unit:
             self.charm.peers_data.put(Scope.UNIT, self._depart_flag(event.relation), True)
+            self.update_endpoints(event.relation, omit_endpoints={self.charm.unit_ip})
 
     def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Handle client relation-broken event."""
@@ -364,7 +365,7 @@ class OpenSearchProvider(Object):
     def update_endpoints(self, relation: Relation, omit_endpoints: Optional[Set[str]] = None):
         """Updates endpoints in the databag for the given relation."""
         # we can only set endpoints if we're the leader
-        if not self.unit.is_leader():
+        if not self.unit.is_leader() or not self.opensearch.is_node_up():
             return
 
         if not omit_endpoints:

--- a/lib/charms/opensearch/v0/opensearch_relation_provider.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_provider.py
@@ -350,7 +350,7 @@ class OpenSearchProvider(Object):
         """Check if this relation is being removed, and update the peer databag accordingly."""
         # remove departing unit from endpoints available to requirer charm.
         if event.departing_unit.app == self.charm.app:
-            departing_unit_ip = unit_ip(self.charm, event.departing_unit.name, PeerRelationName)
+            departing_unit_ip = unit_ip(self.charm, event.departing_unit, PeerRelationName)
             self.update_endpoints(event.relation, omit_endpoints={departing_unit_ip})
 
         if event.departing_unit == self.charm.unit:

--- a/tests/integration/ha/test_ha.py
+++ b/tests/integration/ha/test_ha.py
@@ -106,7 +106,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     await ops_test.model.wait_for_idle(
         apps=[TLS_CERTIFICATES_APP_NAME, APP_NAME],
         status="active",
-        timeout=1000,
+        timeout=1400,
         idle_period=IDLE_PERIOD,
     )
     assert len(ops_test.model.applications[APP_NAME].units) == 3

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -33,7 +33,7 @@ TARBALL_INSTALL_CERTS_DIR = "/etc/opensearch/config/certificates"
 
 MODEL_CONFIG = {
     "logging-config": "<root>=INFO;unit=DEBUG",
-    "update-status-hook-interval": "25s",
+    "update-status-hook-interval": "1m",
     "cloudinit-userdata": """postruncmd:
         - [ 'sysctl', '-w', 'vm.max_map_count=262144' ]
         - [ 'sysctl', '-w', 'fs.file-max=1048576' ]

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -33,7 +33,7 @@ TARBALL_INSTALL_CERTS_DIR = "/etc/opensearch/config/certificates"
 
 MODEL_CONFIG = {
     "logging-config": "<root>=INFO;unit=DEBUG",
-    "update-status-hook-interval": "1m",
+    "update-status-hook-interval": "25s",
     "cloudinit-userdata": """postruncmd:
         - [ 'sysctl', '-w', 'vm.max_map_count=262144' ]
         - [ 'sysctl', '-w', 'fs.file-max=1048576' ]

--- a/tests/integration/relations/opensearch_provider/test_opensearch_provider.py
+++ b/tests/integration/relations/opensearch_provider/test_opensearch_provider.py
@@ -206,11 +206,15 @@ async def test_scaling(ops_test: OpsTest):
         await get_num_of_endpoints(CLIENT_APP_NAME, FIRST_RELATION_NAME)
         == get_num_of_opensearch_units()
     ), await rel_endpoints(CLIENT_APP_NAME, FIRST_RELATION_NAME)
-    await ops_test.model.wait_for_idle(status="active", apps=ALL_APPS, idle_period=65)
+    await ops_test.model.wait_for_idle(
+        status="active", apps=ALL_APPS, timeout=1600, idle_period=65
+    )
 
     # Test scale down
     await scale_application(ops_test, OPENSEARCH_APP_NAME, get_num_of_opensearch_units() - 1)
-    await ops_test.model.wait_for_idle(status="active", apps=ALL_APPS, idle_period=65)
+    await ops_test.model.wait_for_idle(
+        status="active", apps=ALL_APPS, timeout=1600, idle_period=65
+    )
     assert (
         await get_num_of_endpoints(CLIENT_APP_NAME, FIRST_RELATION_NAME)
         == get_num_of_opensearch_units()
@@ -218,7 +222,7 @@ async def test_scaling(ops_test: OpsTest):
 
     # test scale back up again
     await scale_application(ops_test, OPENSEARCH_APP_NAME, get_num_of_opensearch_units() + 1)
-    await ops_test.model.wait_for_idle(status="active", apps=ALL_APPS, idle_period=65)
+    await ops_test.model.wait_for_idle(status="active", apps=ALL_APPS, timeout=1600)
     assert (
         await get_num_of_endpoints(CLIENT_APP_NAME, FIRST_RELATION_NAME)
         == get_num_of_opensearch_units()
@@ -241,7 +245,10 @@ async def test_multiple_relations(ops_test: OpsTest, application_charm):
     wait_for_relation_joined_between(ops_test, OPENSEARCH_APP_NAME, SECONDARY_CLIENT_APP_NAME)
 
     await ops_test.model.wait_for_idle(
-        status="active", apps=[SECONDARY_CLIENT_APP_NAME] + ALL_APPS, timeout=(60 * 20)
+        status="active",
+        apps=[SECONDARY_CLIENT_APP_NAME] + ALL_APPS,
+        timeout=(60 * 20),
+        idle_period=65,
     )
 
     # Test that the permissions are respected between relations by running the same request as
@@ -273,8 +280,8 @@ async def test_multiple_relations_accessing_same_index(ops_test: OpsTest):
     await ops_test.model.wait_for_idle(
         status="active",
         apps=[SECONDARY_CLIENT_APP_NAME] + ALL_APPS,
-        timeout=(60 * 12),
-        idle_period=20,
+        timeout=(60 * 20),
+        idle_period=65,
     )
 
     # Test that different applications can access the same index if they present it in their
@@ -310,8 +317,8 @@ async def test_admin_relation(ops_test: OpsTest):
     await ops_test.model.wait_for_idle(
         status="active",
         apps=[SECONDARY_CLIENT_APP_NAME] + ALL_APPS,
-        timeout=(60 * 10),
-        idle_period=20,
+        timeout=(60 * 20),
+        idle_period=65,
     )
 
     # Verify we can access whatever data we like as admin
@@ -460,7 +467,7 @@ async def test_relation_broken(ops_test: OpsTest):
         ops_test, f"{CLIENT_APP_NAME}/0", FIRST_RELATION_NAME, "username"
     )
     await ops_test.model.wait_for_idle(
-        status="active", apps=[SECONDARY_CLIENT_APP_NAME] + ALL_APPS
+        status="active", apps=[SECONDARY_CLIENT_APP_NAME] + ALL_APPS, timeout=1600, idle_period=65
     )
 
     # Break the relation.
@@ -483,6 +490,8 @@ async def test_relation_broken(ops_test: OpsTest):
         ops_test.model.wait_for_idle(
             apps=[OPENSEARCH_APP_NAME, TLS_CERTIFICATES_APP_NAME, SECONDARY_CLIENT_APP_NAME],
             status="active",
+            timeout=1600,
+            idle_period=65,
         ),
     )
 
@@ -507,7 +516,7 @@ async def test_data_persists_on_relation_rejoin(ops_test: OpsTest):
     wait_for_relation_joined_between(ops_test, OPENSEARCH_APP_NAME, CLIENT_APP_NAME)
 
     await ops_test.model.wait_for_idle(
-        apps=[SECONDARY_CLIENT_APP_NAME] + ALL_APPS, timeout=1200, status="active"
+        apps=[SECONDARY_CLIENT_APP_NAME] + ALL_APPS, timeout=2000, status="active", idle_period=65
     )
 
     read_index_endpoint = "/albums/_search?q=Jazz"

--- a/tests/integration/relations/opensearch_provider/test_opensearch_provider.py
+++ b/tests/integration/relations/opensearch_provider/test_opensearch_provider.py
@@ -187,6 +187,7 @@ async def test_scaling(ops_test: OpsTest):
     """Test that scaling correctly updates endpoints in databag.
 
     scale_application also contains a wait_for_idle check, including checking for active status.
+    Idle_period checks must be greater than 1 minute to guarantee update_status fires correctly.
     """
 
     async def rel_endpoints(app_name: str, rel_name: str) -> str:
@@ -205,11 +206,11 @@ async def test_scaling(ops_test: OpsTest):
         await get_num_of_endpoints(CLIENT_APP_NAME, FIRST_RELATION_NAME)
         == get_num_of_opensearch_units()
     ), await rel_endpoints(CLIENT_APP_NAME, FIRST_RELATION_NAME)
-    await ops_test.model.wait_for_idle(status="active", apps=ALL_APPS)
+    await ops_test.model.wait_for_idle(status="active", apps=ALL_APPS, idle_period=65)
 
     # Test scale down
     await scale_application(ops_test, OPENSEARCH_APP_NAME, get_num_of_opensearch_units() - 1)
-    await ops_test.model.wait_for_idle(status="active", apps=ALL_APPS)
+    await ops_test.model.wait_for_idle(status="active", apps=ALL_APPS, idle_period=65)
     assert (
         await get_num_of_endpoints(CLIENT_APP_NAME, FIRST_RELATION_NAME)
         == get_num_of_opensearch_units()
@@ -217,7 +218,7 @@ async def test_scaling(ops_test: OpsTest):
 
     # test scale back up again
     await scale_application(ops_test, OPENSEARCH_APP_NAME, get_num_of_opensearch_units() + 1)
-    await ops_test.model.wait_for_idle(status="active", apps=ALL_APPS)
+    await ops_test.model.wait_for_idle(status="active", apps=ALL_APPS, idle_period=65)
     assert (
         await get_num_of_endpoints(CLIENT_APP_NAME, FIRST_RELATION_NAME)
         == get_num_of_opensearch_units()

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -38,7 +38,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
         num_units=DEFAULT_NUM_UNITS,
         series=SERIES,
     )
-    await ops_test.model.wait_for_idle(wait_for_exact_units=DEFAULT_NUM_UNITS, timeout=1400)
+    await ops_test.model.wait_for_idle(wait_for_exact_units=DEFAULT_NUM_UNITS, timeout=1800)
 
 
 @pytest.mark.abort_on_fail
@@ -67,7 +67,7 @@ async def test_actions_get_admin_password(ops_test: OpsTest) -> None:
     # Relate it to OpenSearch to set up TLS.
     await ops_test.model.relate(APP_NAME, TLS_CERTIFICATES_APP_NAME)
     await ops_test.model.wait_for_idle(
-        apps=[APP_NAME], status="active", timeout=1000, wait_for_exact_units=DEFAULT_NUM_UNITS
+        apps=[APP_NAME], status="active", timeout=1200, wait_for_exact_units=DEFAULT_NUM_UNITS
     )
 
     leader_ip = await get_leader_unit_ip(ops_test)

--- a/tests/unit/lib/test_opensearch_relation_provider.py
+++ b/tests/unit/lib/test_opensearch_relation_provider.py
@@ -8,11 +8,11 @@ from charms.opensearch.v0.constants_charm import ClientRelationName, PeerRelatio
 from charms.opensearch.v0.helper_databag import Scope
 from charms.opensearch.v0.opensearch_base_charm import SERVICE_MANAGER
 from charms.opensearch.v0.opensearch_users import OpenSearchUserMgmtError
-from helpers import patch_network_get
 from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
 
 from charm import OpenSearchOperatorCharm
+from tests.helpers import patch_network_get
 
 
 @patch_network_get("1.1.1.1")
@@ -125,8 +125,7 @@ class TestOpenSearchProvider(unittest.TestCase):
         _create_user.assert_called_with(username, roles, hashed_pw)
         _patch_user.assert_called_with(username, patches)
 
-    @patch("charms.opensearch.v0.opensearch_relation_provider.unit_ip", return_value="1.1.1.2")
-    def test_on_relation_departed(self, _):
+    def test_on_relation_departed(self):
         event = MagicMock()
         event.departing_unit.name = "some other unit"
         self.opensearch_provider._on_relation_departed(event)

--- a/tests/unit/lib/test_opensearch_relation_provider.py
+++ b/tests/unit/lib/test_opensearch_relation_provider.py
@@ -125,10 +125,10 @@ class TestOpenSearchProvider(unittest.TestCase):
         _create_user.assert_called_with(username, roles, hashed_pw)
         _patch_user.assert_called_with(username, patches)
 
-    # @patch("charms.opensearch.v0.opensearch_relation_provider.unit_ip", return_value="1.1.1.2")
-    def test_on_relation_departed(self):
+    @patch("charms.opensearch.v0.opensearch_relation_provider.unit_ip", return_value="1.1.1.2")
+    def test_on_relation_departed(self, _):
         event = MagicMock()
-        event.departing_unit = None
+        event.departing_unit.name = "some other unit"
         self.opensearch_provider._on_relation_departed(event)
         assert not self.charm.peers_data.get(
             Scope.UNIT, self.opensearch_provider._depart_flag(event.relation)

--- a/tests/unit/lib/test_opensearch_relation_provider.py
+++ b/tests/unit/lib/test_opensearch_relation_provider.py
@@ -172,10 +172,14 @@ class TestOpenSearchProvider(unittest.TestCase):
         _remove_users.assert_called_with(event.relation.id)
 
     @patch("charms.data_platform_libs.v0.data_interfaces.OpenSearchProvides.set_endpoints")
+    @patch(
+        "charms.opensearch.v0.opensearch_distro.OpenSearchDistribution.is_node_up",
+        return_value=True,
+    )
     @patch("charm.OpenSearchOperatorCharm._get_nodes")
     @patch("charm.OpenSearchOperatorCharm._put_admin_user")
     @patch("charm.OpenSearchOperatorCharm._purge_users")
-    def test_update_endpoints(self, _, __, _nodes, _set_endpoints):
+    def test_update_endpoints(self, _, __, _nodes, _is_node_up, _set_endpoints):
         self.harness.set_leader(True)
         node = MagicMock()
         node.ip = "4.4.4.4"


### PR DESCRIPTION
Previously we weren't making use of the `status.clear()` function to clear the unit status after the relation-created hook fires. This PR fixes that, allowing us to preserve status information. 