### PR TITLE
[DPE-1557] - HA tests - network cut - without IP change

### DIFF
--- a/lib/charms/opensearch/v0/helper_charm.py
+++ b/lib/charms/opensearch/v0/helper_charm.py
@@ -40,20 +40,19 @@ class Status:
         context = self.charm.app if app else self.charm.unit
 
         condition: bool
-        match pattern:
-            case Status.CheckPattern.Equal:
-                condition = context.status.message == status_message
-            case Status.CheckPattern.Start:
-                condition = context.status.message.startswith(status_message)
-            case Status.CheckPattern.End:
-                condition = context.status.message.endswith(status_message)
-            case Status.CheckPattern.Interpolated:
-                condition = (
-                    re.fullmatch(status_message.replace("{}", "(?s:.*?)"), status_message)
-                    is not None
-                )
-            case _:
-                condition = status_message in context.status.message
+        if pattern == Status.CheckPattern.Equal:
+            condition = context.status.message == status_message
+        elif Status.CheckPattern.Start:
+            condition = context.status.message.startswith(status_message)
+        elif Status.CheckPattern.End:
+            condition = context.status.message.endswith(status_message)
+        elif Status.CheckPattern.Interpolated:
+            condition = (
+                re.fullmatch(status_message.replace("{}", "(?s:.*?)"), status_message)
+                is not None
+            )
+        else:
+            condition = status_message in context.status.message
 
         if condition:
             context.status = ActiveStatus()

--- a/lib/charms/opensearch/v0/helper_charm.py
+++ b/lib/charms/opensearch/v0/helper_charm.py
@@ -42,11 +42,11 @@ class Status:
         condition: bool
         if pattern == Status.CheckPattern.Equal:
             condition = context.status.message == status_message
-        elif Status.CheckPattern.Start:
+        elif pattern == Status.CheckPattern.Start:
             condition = context.status.message.startswith(status_message)
-        elif Status.CheckPattern.End:
+        elif pattern == Status.CheckPattern.End:
             condition = context.status.message.endswith(status_message)
-        elif Status.CheckPattern.Interpolated:
+        elif pattern == Status.CheckPattern.Interpolated:
             condition = (
                 re.fullmatch(status_message.replace("{}", "(?s:.*?)"), status_message) is not None
             )

--- a/lib/charms/opensearch/v0/helper_charm.py
+++ b/lib/charms/opensearch/v0/helper_charm.py
@@ -48,8 +48,7 @@ class Status:
             condition = context.status.message.endswith(status_message)
         elif Status.CheckPattern.Interpolated:
             condition = (
-                re.fullmatch(status_message.replace("{}", "(?s:.*?)"), status_message)
-                is not None
+                re.fullmatch(status_message.replace("{}", "(?s:.*?)"), status_message) is not None
             )
         else:
             condition = status_message in context.status.message

--- a/tests/integration/ha/continuous_writes.py
+++ b/tests/integration/ha/continuous_writes.py
@@ -46,6 +46,10 @@ class ContinuousWrites:
         self._queue = None
         self._process = None
 
+    @retry(
+        wait=wait_fixed(wait=5) + wait_random(0, 5),
+        stop=stop_after_attempt(5),
+    )
     async def start(self, repl_on_all_nodes: bool = False) -> None:
         """Run continuous writes in the background."""
         if not self._is_stopped:
@@ -74,6 +78,10 @@ class ContinuousWrites:
             )
         )
 
+    @retry(
+        wait=wait_fixed(wait=5) + wait_random(0, 5),
+        stop=stop_after_attempt(5),
+    )
     async def clear(self) -> None:
         """Stop writes and Delete the index."""
         if not self._is_stopped:
@@ -85,6 +93,10 @@ class ContinuousWrites:
         finally:
             client.close()
 
+    @retry(
+        wait=wait_fixed(wait=5) + wait_random(0, 5),
+        stop=stop_after_attempt(5),
+    )
     async def count(self, unit_ip: Optional[str] = None, preference: Optional[str] = None) -> int:
         """Count the number of documents in the index."""
         client = await self._client(unit_ip)
@@ -111,6 +123,10 @@ class ContinuousWrites:
         finally:
             client.close()
 
+    @retry(
+        wait=wait_fixed(wait=5) + wait_random(0, 5),
+        stop=stop_after_attempt(5),
+    )
     async def stop(self) -> SimpleNamespace:
         """Stop the continuous writes process and return max inserted ID."""
         if not self._is_stopped:

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -285,11 +285,43 @@ async def cut_network_from_unit_with_ip_change(ops_test: OpsTest, app: str, unit
     subprocess.check_call(cut_network_command.split())
 
 
-async def restore_network_for_unit(unit_hostname: str) -> None:
+async def cut_network_from_unit_without_ip_change(
+    ops_test: OpsTest, app: str, unit_id: int
+) -> None:
+    """Cut network from a lxc container (without causing the change of the unit IP address)."""
+    unit_ids_hostnames = await get_application_unit_ids_hostnames(ops_test, app)
+    unit_hostname = unit_ids_hostnames[unit_id]
+
+    override_command = f"lxc config device override {unit_hostname} eth0"
+    try:
+        subprocess.check_call(override_command.split())
+    except subprocess.CalledProcessError:
+        # Ignore if the interface was already overridden.
+        pass
+
+    limit_set_command = f"lxc config device set {unit_hostname} eth0 limits.egress=0kbit"
+    subprocess.check_call(limit_set_command.split())
+    limit_set_command = f"lxc config device set {unit_hostname} eth0 limits.ingress=1kbit"
+    subprocess.check_call(limit_set_command.split())
+    limit_set_command = f"lxc config set {unit_hostname} limits.network.priority=10"
+    subprocess.check_call(limit_set_command.split())
+
+
+async def restore_network_for_unit_with_ip_change(unit_hostname: str) -> None:
     """Restore network from a lxc container."""
     # remove mask from eth0
     restore_network_command = f"lxc config device remove {unit_hostname} eth0"
     subprocess.check_call(restore_network_command.split())
+
+
+async def restore_network_for_unit_without_ip_change(unit_hostname: str) -> None:
+    """Restore network from a lxc container (without causing the change of the unit IP address)."""
+    limit_set_command = f"lxc config device set {unit_hostname} eth0 limits.egress="
+    subprocess.check_call(limit_set_command.split())
+    limit_set_command = f"lxc config device set {unit_hostname} eth0 limits.ingress="
+    subprocess.check_call(limit_set_command.split())
+    limit_set_command = f"lxc config set {unit_hostname} limits.network.priority="
+    subprocess.check_call(limit_set_command.split())
 
 
 async def is_unit_reachable(from_host: str, to_host: str, retries: int = 5) -> bool:

--- a/tests/integration/ha/test_ha.py
+++ b/tests/integration/ha/test_ha.py
@@ -122,7 +122,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
 
 @pytest.mark.abort_on_fail
 async def test_replication_across_members(
-    ops_test: OpsTest, c_writes: ContinuousWrites, c_balanced_writes_runner
+    ops_test: OpsTest, c_writes: ContinuousWrites, c_writes_runner
 ) -> None:
     """Check consistency, ie write to node, read data from remaining nodes.
 

--- a/tests/integration/ha/test_ha.py
+++ b/tests/integration/ha/test_ha.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import logging
+import random
 import time
 
 import pytest
@@ -46,6 +47,7 @@ from tests.integration.helpers import (
     get_controller_hostname,
     get_leader_unit_ip,
     get_reachable_unit_ips,
+    http_request,
     is_up,
 )
 from tests.integration.tls.test_tls import TLS_CERTIFICATES_APP_NAME
@@ -79,6 +81,13 @@ async def c_writes_runner(ops_test: OpsTest, c_writes: ContinuousWrites):
     """Starts continuous write operations and clears writes at the end of the test."""
     await c_writes.start()
     yield
+
+    reachable_ip = random.choice(await get_reachable_unit_ips(ops_test))
+    await http_request(ops_test, "GET", f"https://{reachable_ip}:9200/_cat/nodes", json_resp=False)
+    await http_request(
+        ops_test, "GET", f"https://{reachable_ip}:9200/_cat/shards", json_resp=False
+    )
+
     await c_writes.clear()
 
 
@@ -87,6 +96,13 @@ async def c_balanced_writes_runner(ops_test: OpsTest, c_writes: ContinuousWrites
     """Same as previous runner, but starts continuous writes on cluster wide replicated index."""
     await c_writes.start(repl_on_all_nodes=True)
     yield
+
+    reachable_ip = random.choice(await get_reachable_unit_ips(ops_test))
+    await http_request(ops_test, "GET", f"https://{reachable_ip}:9200/_cat/nodes", json_resp=False)
+    await http_request(
+        ops_test, "GET", f"https://{reachable_ip}:9200/_cat/shards", json_resp=False
+    )
+
     await c_writes.clear()
 
 

--- a/tests/integration/ha/test_ha.py
+++ b/tests/integration/ha/test_ha.py
@@ -122,7 +122,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
 
 @pytest.mark.abort_on_fail
 async def test_replication_across_members(
-    ops_test: OpsTest, c_writes: ContinuousWrites, c_writes_runner
+    ops_test: OpsTest, c_writes: ContinuousWrites, c_balanced_writes_runner
 ) -> None:
     """Check consistency, ie write to node, read data from remaining nodes.
 

--- a/tests/integration/ha/test_ha.py
+++ b/tests/integration/ha/test_ha.py
@@ -15,11 +15,13 @@ from tests.integration.ha.helpers import (
     app_name,
     assert_continuous_writes_consistency,
     cut_network_from_unit_with_ip_change,
+    cut_network_from_unit_without_ip_change,
     get_elected_cm_unit_id,
     get_shards_by_index,
     is_network_restored_after_ip_change,
     is_unit_reachable,
-    restore_network_for_unit,
+    restore_network_for_unit_with_ip_change,
+    restore_network_for_unit_without_ip_change,
     send_kill_signal_to_process,
     update_restart_delay,
 )
@@ -432,7 +434,7 @@ async def test_freeze_db_process_node_with_elected_cm(
 
 
 @pytest.mark.abort_on_fail
-async def test_restart_db_process_node_with_elected_cluster_manager(
+async def test_restart_db_process_node_with_elected_cm(
     ops_test: OpsTest, c_writes: ContinuousWrites, c_balanced_writes_runner
 ) -> None:
     """Check cluster self-healing & data indexed/read on process restart on CM node."""
@@ -546,7 +548,7 @@ async def test_restart_db_process_node_with_primary_shard(
 
 
 @pytest.mark.abort_on_fail
-async def test_full_network_cut_with_ip_change_node_with_elected_cluster_manager(
+async def test_full_network_cut_with_ip_change_node_with_elected_cm(
     ops_test: OpsTest, c_writes: ContinuousWrites, c_balanced_writes_runner
 ) -> None:
     """Check that cluster can self-heal and unit reconfigures itself with new IP."""
@@ -610,7 +612,7 @@ async def test_full_network_cut_with_ip_change_node_with_elected_cluster_manager
     assert current_elected_cm_unit_id != first_elected_cm_unit_id, "No CM re-election happened."
 
     # restore the network on the unit
-    await restore_network_for_unit(first_elected_cm_unit_hostname)
+    await restore_network_for_unit_with_ip_change(first_elected_cm_unit_hostname)
 
     # Wait until the cluster becomes idle (new TLS certs, node reconfigured / restarted).
     await ops_test.model.wait_for_idle(
@@ -716,7 +718,7 @@ async def test_full_network_cut_with_ip_change_node_with_primary_shard(
         ), "Primary shard still assigned to the unit where the service was killed."
 
     # restore the network on the unit
-    await restore_network_for_unit(first_unit_with_primary_shard_hostname)
+    await restore_network_for_unit_with_ip_change(first_unit_with_primary_shard_hostname)
 
     # Wait until the cluster becomes idle (new TLS certs, node reconfigured / restarted).
     await ops_test.model.wait_for_idle(
@@ -745,6 +747,192 @@ async def test_full_network_cut_with_ip_change_node_with_primary_shard(
     # verify the node with the old primary successfully joined the rest of the fleet
     assert check_cluster_formation_successful(
         ops_test, first_unit_with_primary_shard_new_ip, get_application_unit_names(ops_test, app)
+    ), "Unit did NOT join the rest of the cluster."
+
+    # continuous writes checks
+    await assert_continuous_writes_consistency(ops_test, c_writes, app)
+
+
+@pytest.mark.abort_on_fail
+async def test_full_network_cut_without_ip_change_node_with_elected_cm(
+    ops_test: OpsTest, c_writes: ContinuousWrites, c_balanced_writes_runner
+) -> None:
+    """Check that cluster can self-heal and unit reconfigures itself with network cut.."""
+    app = (await app_name(ops_test)) or APP_NAME
+
+    unit_ids_ips = await get_application_unit_ids_ips(ops_test, app)
+    unit_ids_hostnames = await get_application_unit_ids_hostnames(ops_test, app)
+
+    # find unit currently elected cluster_manager
+    leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
+    first_elected_cm_unit_id = await get_elected_cm_unit_id(ops_test, leader_unit_ip)
+    first_elected_cm_unit_ip = unit_ids_ips[first_elected_cm_unit_id]
+    first_elected_cm_unit_hostname = unit_ids_hostnames[first_elected_cm_unit_id]
+
+    # Killing the only instance can be disastrous.
+    if len(ops_test.model.applications[app].units) < 2:
+        await ops_test.model.applications[app].add_unit(count=1)
+        await ops_test.model.wait_for_idle(
+            apps=[app],
+            status="active",
+            timeout=1000,
+            idle_period=IDLE_PERIOD,
+        )
+
+    # verify the node is well reachable
+    assert await is_up(
+        ops_test, first_elected_cm_unit_ip
+    ), "Initial elected cluster manager node not online."
+
+    # cut network from current elected cm unit
+    await cut_network_from_unit_without_ip_change(ops_test, app, first_elected_cm_unit_id)
+
+    # verify machine not reachable from / to peer units
+    for unit_id, unit_hostname in unit_ids_hostnames.items():
+        if unit_id != first_elected_cm_unit_id:
+            assert not await is_unit_reachable(
+                from_host=unit_hostname, to_host=first_elected_cm_unit_hostname
+            ), "Unit is still reachable from other units."
+
+    # check reach from controller - noticed that the controller is able to ping the unit for longer
+    assert not await is_unit_reachable(
+        from_host=await get_controller_hostname(ops_test), to_host=first_elected_cm_unit_hostname
+    ), "Unit is still reachable from controller"
+
+    # verify node not up anymore
+    assert not await is_up(
+        ops_test, first_elected_cm_unit_ip, retries=3
+    ), "Connection still possible to the first CM node where the network was cut."
+
+    # verify new writes are continuing by counting the number of writes before and after 5 seconds
+    writes = await c_writes.count()
+    time.sleep(5)
+    more_writes = await c_writes.count()
+    assert more_writes > writes, "Writes not continuing to DB"
+
+    # check new CM got elected
+    leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
+    current_elected_cm_unit_id = await get_elected_cm_unit_id(ops_test, leader_unit_ip)
+    assert current_elected_cm_unit_id != first_elected_cm_unit_id, "No CM re-election happened."
+
+    # restore the network on the unit
+    await restore_network_for_unit_without_ip_change(first_elected_cm_unit_hostname)
+
+    # Wait until the cluster becomes idle (new TLS certs, node reconfigured / restarted).
+    await ops_test.model.wait_for_idle(
+        apps=[app],
+        status="active",
+        timeout=1000,
+        wait_for_exact_units=len(unit_ids_ips),
+        idle_period=IDLE_PERIOD,
+    )
+
+    # check if node up and is included in the cluster formation
+    assert is_up(ops_test, first_elected_cm_unit_ip), "Unit still not up."
+
+    # verify the previously elected CM node successfully joined the rest of the fleet
+    assert check_cluster_formation_successful(
+        ops_test, first_elected_cm_unit_ip, get_application_unit_names(ops_test, app)
+    ), "Unit did NOT join the rest of the cluster."
+
+    # continuous writes checks
+    await assert_continuous_writes_consistency(ops_test, c_writes, app)
+
+
+@pytest.mark.abort_on_fail
+async def test_full_network_cut_without_ip_change_node_with_primary_shard(
+    ops_test: OpsTest, c_writes: ContinuousWrites, c_balanced_writes_runner
+) -> None:
+    """Check that cluster can self-heal and unit reconfigures itself with network cut."""
+    app = (await app_name(ops_test)) or APP_NAME
+
+    unit_ids_ips = await get_application_unit_ids_ips(ops_test, app)
+    unit_ids_hostnames = await get_application_unit_ids_hostnames(ops_test, app)
+
+    leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
+
+    # find unit hosting the primary shard of the index "series-index"
+    shards = await get_shards_by_index(ops_test, leader_unit_ip, ContinuousWrites.INDEX_NAME)
+    first_unit_with_primary_shard = [shard.unit_id for shard in shards if shard.is_prim][0]
+    first_unit_with_primary_shard_hostname = unit_ids_hostnames[first_unit_with_primary_shard]
+    first_unit_with_primary_shard_ip = unit_ids_ips[first_unit_with_primary_shard]
+
+    # Killing the only instance can be disastrous.
+    if len(ops_test.model.applications[app].units) < 2:
+        await ops_test.model.applications[app].add_unit(count=1)
+        await ops_test.model.wait_for_idle(
+            apps=[app],
+            status="active",
+            timeout=1000,
+            idle_period=IDLE_PERIOD,
+        )
+
+    # verify the node is well reachable
+    assert await is_up(
+        ops_test, first_unit_with_primary_shard_ip
+    ), "Initial node with primary shard of 'series_index' elected cluster manager node not online."
+
+    # cut network from current elected cm unit
+    await cut_network_from_unit_without_ip_change(ops_test, app, first_unit_with_primary_shard)
+
+    # verify machine not reachable from / to peer units
+    for unit_id, unit_hostname in unit_ids_hostnames.items():
+        if unit_id != first_unit_with_primary_shard:
+            assert not await is_unit_reachable(
+                from_host=unit_hostname, to_host=first_unit_with_primary_shard_hostname
+            ), "Unit is still reachable from other units."
+
+    # check reach from controller - noticed that the controller is able to ping the unit for longer
+    assert not await is_unit_reachable(
+        from_host=await get_controller_hostname(ops_test),
+        to_host=first_unit_with_primary_shard_hostname,
+    ), "Unit is still reachable from controller"
+
+    # verify node not up anymore
+    assert not await is_up(
+        ops_test, first_unit_with_primary_shard_ip, retries=3
+    ), "Connection still possible to the first unit with primary shard where the network was cut."
+
+    # verify new writes are continuing by counting the number of writes before and after 5 seconds
+    writes = await c_writes.count()
+    time.sleep(5)
+    more_writes = await c_writes.count()
+    assert more_writes > writes, "Writes not continuing to DB"
+
+    # check new primary shard got elected
+    leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
+
+    # fetch units hosting the new primary shards of the previous index
+    shards = await get_shards_by_index(ops_test, leader_unit_ip, ContinuousWrites.INDEX_NAME)
+    units_with_p_shards = [shard.unit_id for shard in shards if shard.is_prim]
+    assert len(units_with_p_shards) == 2
+    for unit_id in units_with_p_shards:
+        assert (
+            unit_id != first_unit_with_primary_shard
+        ), "Primary shard still assigned to the unit where the service was killed."
+
+    # restore the network on the unit
+    await restore_network_for_unit_without_ip_change(first_unit_with_primary_shard_hostname)
+
+    # Wait until the cluster becomes idle (new TLS certs, node reconfigured / restarted).
+    await ops_test.model.wait_for_idle(
+        apps=[app],
+        status="active",
+        timeout=1000,
+        wait_for_exact_units=len(unit_ids_ips),
+        idle_period=IDLE_PERIOD,
+    )
+
+    # check if node up and is included in the cluster formation
+    assert is_up(ops_test, first_unit_with_primary_shard_ip), "Unit still not up."
+
+    # check that the unit previously hosting the primary shard now hosts a replica
+    units_with_r_shards = [shard.unit_id for shard in shards if not shard.is_prim]
+    assert first_unit_with_primary_shard in units_with_r_shards
+
+    # verify the node with the old primary successfully joined the rest of the fleet
+    assert check_cluster_formation_successful(
+        ops_test, first_unit_with_primary_shard_ip, get_application_unit_names(ops_test, app)
     ), "Unit did NOT join the rest of the cluster."
 
     # continuous writes checks

--- a/tests/integration/ha/test_ha.py
+++ b/tests/integration/ha/test_ha.py
@@ -927,6 +927,7 @@ async def test_full_network_cut_without_ip_change_node_with_primary_shard(
     assert is_up(ops_test, first_unit_with_primary_shard_ip), "Unit still not up."
 
     # check that the unit previously hosting the primary shard now hosts a replica
+    shards = await get_shards_by_index(ops_test, leader_unit_ip, ContinuousWrites.INDEX_NAME)
     units_with_r_shards = [shard.unit_id for shard in shards if not shard.is_prim]
     assert first_unit_with_primary_shard in units_with_r_shards
 

--- a/tests/integration/ha/test_ha.py
+++ b/tests/integration/ha/test_ha.py
@@ -324,7 +324,7 @@ async def test_freeze_db_process_node_with_primary_shard(
     )
 
     # verify the unit is not reachable
-    is_node_up = await is_up(ops_test, units_ips[first_unit_with_primary_shard], retries=3)
+    is_node_up = await is_up(ops_test, units_ips[first_unit_with_primary_shard], retries=5)
     assert not is_node_up
 
     # verify new writes are continuing by counting the number of writes before and after 5 seconds
@@ -406,7 +406,7 @@ async def test_freeze_db_process_node_with_elected_cm(
     )
 
     # verify the unit is not reachable
-    is_node_up = await is_up(ops_test, units_ips[first_elected_cm_unit_id], retries=3)
+    is_node_up = await is_up(ops_test, units_ips[first_elected_cm_unit_id], retries=5)
     assert not is_node_up
 
     # verify new writes are continuing by counting the number of writes before and after 5 seconds

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -336,7 +336,7 @@ async def http_request(
             "method": method,
             "url": endpoint,
             "headers": {"Accept": "application/json", "Content-Type": "application/json"},
-            "timeout": 5,
+            "timeout": 10,
         }
         if isinstance(payload, str):
             request_kwargs["data"] = payload

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -332,11 +332,13 @@ async def http_request(
         chain.write(admin_secrets["ca-chain"])
         chain.seek(0)
 
+        logger.info(f"Calling: {method} -- {endpoint}")
+
         request_kwargs = {
             "method": method,
             "url": endpoint,
             "headers": {"Accept": "application/json", "Content-Type": "application/json"},
-            "timeout": 10,
+            "timeout": 15,
         }
         if isinstance(payload, str):
             request_kwargs["data"] = payload

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -309,6 +309,7 @@ async def http_request(
     verify=True,
     user_password: Optional[str] = None,
     app: str = APP_NAME,
+    json_resp: bool = True,
 ):
     """Makes an HTTP request.
 
@@ -321,6 +322,7 @@ async def http_request(
         verify: whether verify certificate chain or not
         user_password: use alternative password than the admin one in the secrets.
         app: the name of the current application.
+        json_resp: return a json response or simply log
 
     Returns:
         A json object.
@@ -337,9 +339,14 @@ async def http_request(
         request_kwargs = {
             "method": method,
             "url": endpoint,
-            "headers": {"Accept": "application/json", "Content-Type": "application/json"},
             "timeout": 15,
         }
+        if json_resp:
+            request_kwargs["headers"] = {
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+            }
+
         if isinstance(payload, str):
             request_kwargs["data"] = payload
         elif isinstance(payload, dict):
@@ -357,7 +364,11 @@ async def http_request(
         if resp_status_code:
             return resp.status_code
 
-        return resp.json()
+        if json_resp:
+            return resp.json()
+
+        logger.info(resp.text)
+        return resp
 
 
 async def debug_failed_unit(ops_test: OpsTest, app: str, endpoint: str) -> None:


### PR DESCRIPTION
## Issue
This PR implements the HA test and fixes the bugs raised with it for [DPE-1557](https://warthogs.atlassian.net/browse/DPE-1557), namely - this PR implements:
- Integration tests for:
    - network cut - without IP change - on node with elected CM
    - network cut - without IP change - on node with primary shard of index
- removed pattern matching because charmcraft `2.3` is based on `core20` which comes with `python 3.8` ==> charmcraft fails packing

[DPE-1557]: https://warthogs.atlassian.net/browse/DPE-1557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ