### PR TITLE
updating paths in preparation for snap update

### DIFF
--- a/src/opensearch.py
+++ b/src/opensearch.py
@@ -112,8 +112,8 @@ class OpenSearchSnap(OpenSearchDistribution):
             home=f"{self._SNAP_DATA}/usr/share/opensearch",
             conf=f"{self._SNAP_DATA}/etc/opensearch/config",
             jdk=f"{self._SNAP_DATA}/usr/share/opensearch",
-            data=f"{self._SNAP_COMMON}/data",
-            logs=f"{self._SNAP_COMMON}/logs",
+            data=f"{self._SNAP_COMMON}/var/lib/opensearch/data",
+            logs=f"{self._SNAP_COMMON}/var/log/opensearch/logs",
             tmp=f"{self._SNAP_COMMON}/tmp",
         )
 

--- a/src/opensearch.py
+++ b/src/opensearch.py
@@ -40,8 +40,6 @@ class OpenSearchSnap(OpenSearchDistribution):
     _BASE_SNAP_DIR = "/var/snap/opensearch"
     _SNAP_DATA = f"{_BASE_SNAP_DIR}/current"
     _SNAP_COMMON = f"{_BASE_SNAP_DIR}/common"
-    _ETC = f"{_SNAP_DATA}/etc/opensearch"
-    _USR = f"{_SNAP_DATA}/usr/share/opensearch"
 
     def __init__(self, charm, peer_relation: str):
         super().__init__(charm, peer_relation)
@@ -111,9 +109,9 @@ class OpenSearchSnap(OpenSearchDistribution):
           - OPENSEARCH_CONF: writeable by root or snap_daemon ($SNAP_COMMON) where config files are
         """
         return Paths(
-            home=f"{self._ETC}",
-            conf=f"{self._ETC}/config",
-            jdk=f"{self._USR}/jdk",
+            home=f"{self._SNAP_DATA}/usr/share/opensearch",
+            conf=f"{self._SNAP_DATA}/etc/opensearch/config",
+            jdk=f"{self._SNAP_DATA}/usr/share/opensearch",
             data=f"{self._SNAP_COMMON}/data",
             logs=f"{self._SNAP_COMMON}/logs",
             tmp=f"{self._SNAP_COMMON}/tmp",

--- a/src/opensearch.py
+++ b/src/opensearch.py
@@ -40,6 +40,8 @@ class OpenSearchSnap(OpenSearchDistribution):
     _BASE_SNAP_DIR = "/var/snap/opensearch"
     _SNAP_DATA = f"{_BASE_SNAP_DIR}/current"
     _SNAP_COMMON = f"{_BASE_SNAP_DIR}/common"
+    _ETC = f"{_SNAP_DATA}/etc/opensearch"
+    _USR = f"{_SNAP_DATA}/usr/share/opensearch"
 
     def __init__(self, charm, peer_relation: str):
         super().__init__(charm, peer_relation)
@@ -109,11 +111,11 @@ class OpenSearchSnap(OpenSearchDistribution):
           - OPENSEARCH_CONF: writeable by root or snap_daemon ($SNAP_COMMON) where config files are
         """
         return Paths(
-            home=f"{self._SNAP_DATA}",
-            conf=f"{self._SNAP_DATA}/config",
+            home=f"{self._ETC}",
+            conf=f"{self._ETC}/config",
+            jdk=f"{self._USR}/jdk",
             data=f"{self._SNAP_COMMON}/data",
             logs=f"{self._SNAP_COMMON}/logs",
-            jdk=f"{self._SNAP_DATA}/jdk",
             tmp=f"{self._SNAP_COMMON}/tmp",
         )
 


### PR DESCRIPTION
In [a separate PR](https://github.com/canonical/opensearch-snap/pull/35), I'm updating the filepaths that the charm uses. This PR updates those pathways in this charm. 

As an aside, we keep having this issue where we have to update these separately with no easy testing. It might be useful to create an easy way to test snap updates with a charm. Perhaps a CI stage that downloads a specific branch of the snap repo, then installs it instead of the snap? Not sure how the snap charmlib plays with local snaps, but it may be worth looking into. 