### PR TITLE
[DPE-1817] Github workflows adopted for Juju 3 testing (limited set of tests)

### DIFF
--- a/.github/workflows/integration-limited-juju3.yaml
+++ b/.github/workflows/integration-limited-juju3.yaml
@@ -1,0 +1,80 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+on:
+  workflow_call:
+    inputs:
+      juju-snap-channel:
+        description: Snap channel for Juju CLI
+        default: 3.1/stable
+        type: string
+      libjuju-version-specifier:
+        description: |
+            python-libjuju version specifier (e.g. ">=1.3")
+            https://packaging.python.org/en/latest/glossary/#term-Version-Specifier
+        required: false
+        type: string
+
+jobs:
+  build:
+    name: Build charms
+    uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v2
+
+  integration-test:
+    needs:
+      - build
+    strategy:
+      fail-fast: false
+      matrix:
+        tox-environments:
+          - charm-integration
+          - tls-integration
+          - client-integration
+        runner: ["ubuntu-22.04"]
+    name: ${{ matrix.tox-environments }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Juju environment
+        # Runs on juju 3 by default
+        # TODO: Replace with custom image on self-hosted runner
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: lxd
+          juju-channel: ${{ inputs.juju-snap-channel }}
+
+      - name: Download packed charm(s)
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.build.outputs.artifact-name }}
+
+      - name: Select tests
+        id: select-tests
+        run: |
+          if [ "${{ github.event_name }}" == "schedule" ]
+          then
+            echo Running unstable and stable tests
+            echo "mark_expression=" >> $GITHUB_OUTPUT
+          else
+            echo Skipping unstable tests
+            echo "mark_expression=not unstable" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run integration tests
+        run: |
+          # free space in the runner
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/boost
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+
+          # Set kernel params
+          sudo sysctl -w vm.max_map_count=262144 vm.swappiness=0 net.ipv4.tcp_retries2=5
+          tox run -e ${{ matrix.tox-environments }} -- -m '${{ steps.select-tests.outputs.mark_expression }}' # --model testing
+        env:
+          CI_PACKED_CHARMS: ${{ needs.build.outputs.charms }}
+          LIBJUJU_VERSION_SPECIFIER: ${{ inputs.libjuju-version-specifier }}
+      # - name: Print logs
+      #   run: juju switch testing; juju debug-log --replay --no-tail

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,14 +10,29 @@ on:
   pull_request:
 
 jobs:
-  pre-integration-checks:
+  pre-integration-checks-juju2:
     secrets: inherit
     uses: ./.github/workflows/pre_integration_checks.yaml
+    with:
+      libjuju-version-specifier: ==2.9.42.4
 
-  integration:
+  integration-juju2:
     needs:
-      - pre-integration-checks
+      - pre-integration-checks-juju2
     uses: ./.github/workflows/integration.yaml
     with:
       juju-snap-channel: 2.9/stable
       libjuju-version-specifier: ==2.9.42.4
+
+  pre-integration-checks-juju3:
+    secrets: inherit
+    uses: ./.github/workflows/pre_integration_checks.yaml
+    with:
+      libjuju-version-specifier: ==3.2.0.1
+
+  integration-juju3-secrets:
+    needs:
+      - pre-integration-checks-juju3
+    uses: ./.github/workflows/integration-limited-juju3.yaml
+    with:
+      libjuju-version-specifier: ==3.2.0.1

--- a/.github/workflows/pre_integration_checks.yaml
+++ b/.github/workflows/pre_integration_checks.yaml
@@ -4,6 +4,13 @@ name: Pre-integration checks
 
 on:
   workflow_call:
+    inputs:
+      libjuju-version-specifier:
+        description: |
+            python-libjuju version specifier (e.g. ">=1.3")
+            https://packaging.python.org/en/latest/glossary/#term-Version-Specifier
+        required: false
+        type: string
 
 jobs:
   lint:
@@ -33,6 +40,8 @@ jobs:
         run: python3 -m pip install tox
       - name: Run tests
         run: tox run -e unit
+        env:
+          LIBJUJU_VERSION_SPECIFIER: ${{ inputs.libjuju-version-specifier }}
 
   lib-check:
     name: Check libraries

--- a/tox.ini
+++ b/tox.ini
@@ -60,6 +60,7 @@ commands =
 [testenv:unit]
 description = Run unit tests
 deps =
+    juju{env:LIBJUJU_VERSION_SPECIFIER:==2.9.42.4}
     pytest
     pytest-asyncio
     coverage[toml]
@@ -93,4 +94,3 @@ commands =
     h-scaling: pytest -v --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/ha/test_horizontal_scaling.py
     ha-storage: pytest -v --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/ha/test_storage.py
     ha-networking: pytest -v --tb native --log-cli-level=INFO -s {posargs} {[vars]tests_path}/integration/ha/test_ha_networking.py
-


### PR DESCRIPTION
## Issue

Pipelines are only running tests on Juju3 on PRs.

## Solution

Partial (essential) set of tests added in a matrix to be also run on Juju3

**Rationale**: These tests are sufficient for secrets testing, and keep a good balance on the pipeline execution time.

**NOTE**: The different set of tests was the reason for the "copy-paste" instead of a simple matrix.

**NOTE2**: `h-scaling-integation` failures are global to the repository, unrelated to changes presented here.