### PR TITLE
[DPE-2327] Add KNN Plugin Support

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -17,3 +17,4 @@ parts:
       - libffi-dev
       - libssl-dev
       - rustc
+      - git

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,8 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+options:
+  plugin_opensearch_knn:
+    default: false
+    type: boolean
+    description: Enable opensearch-knn

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -407,6 +407,13 @@ class OpenSearchBaseCharm(CharmBase):
             self.on[PeerRelationName].relation_joined.emit(
                 self.model.get_relation(PeerRelationName)
             )
+        if (
+            self.opensearch_config.check_charmconfig_if_plugins_updated()
+            and self.opensearch.is_started()
+        ):
+            self.on[self.service_manager.name].acquire_lock.emit(
+                callback_override="_restart_opensearch"
+            )
 
     def _on_set_password_action(self, event: ActionEvent):
         """Set new admin password from user input or generate if not passed."""

--- a/lib/charms/opensearch/v0/opensearch_exceptions.py
+++ b/lib/charms/opensearch/v0/opensearch_exceptions.py
@@ -92,3 +92,11 @@ class OpenSearchScaleDownError(OpenSearchError):
 
 class OpenSearchIndexError(OpenSearchError):
     """Exception thrown when an opensearch index is invalid."""
+
+
+class OpenSearchPluginError(OpenSearchError):
+    """Exception thrown when an opensearch plugin is invalid."""
+
+
+class OpenSearchKeystoreError(OpenSearchError):
+    """Exception thrown when an opensearch keystore is invalid."""

--- a/lib/charms/opensearch/v0/opensearch_ml_plugins.py
+++ b/lib/charms/opensearch/v0/opensearch_ml_plugins.py
@@ -1,0 +1,57 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Implements the KNN and ML-Commons plugins for OpenSearch."""
+
+import logging
+from typing import Optional, List
+
+from charms.opensearch.v0.opensearch_plugins import OpenSearchPlugin
+from ops.framework import Object
+
+logger = logging.getLogger(__name__)
+
+
+# The unique Charmhub library identifier, never change it
+LIBID = "71166db20ab244099ae966c8055db2df"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+
+class OpenSearchPluginKnn(OpenSearchPlugin):
+    """Implements the opensearch-knn plugin."""
+
+    def __init__(self, name: str, charm: Object, relname: Optional[str] = None):
+        super().__init__(name, charm, relname)
+        self._depends_on = []
+
+    def upgrade(self, uri: str) -> None:
+        """Runs the upgrade process in this plugin."""
+        raise NotImplementedError
+
+    def is_enabled(self) -> bool:
+        """Returns True if the plugin is enabled."""
+        return (
+            True
+            if self.distro.config.load(self.CONFIG_YML).get("knn.plugin.enabled", "false")
+            == "true"
+            else False
+        )
+
+    def disable(self) -> bool:
+        """Disables the plugin."""
+        return self.configure(opensearch_yml={"knn.plugin.enabled": False})
+
+    def enable(self) -> bool:
+        """Enables the plugin."""
+        return self.configure(opensearch_yml={"knn.plugin.enabled": True})
+
+    @property
+    def depends_on(self) -> List[str]:
+        """Returns a list of plugins it depends on."""
+        return self._depends_on

--- a/lib/charms/opensearch/v0/opensearch_plugin_manager.py
+++ b/lib/charms/opensearch/v0/opensearch_plugin_manager.py
@@ -1,0 +1,65 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Implements the plugin manager class."""
+
+from typing import Dict, List
+
+from charms.opensearch.v0.opensearch_plugins import OpenSearchPlugin
+from ops.framework import Object
+from ops.model import ActiveStatus, StatusBase
+
+# The unique Charmhub library identifier, never change it
+LIBID = "da838485175f47dbbbb83d76c07cab4c"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+
+OpenSearchPluginsAvailable = {}
+
+
+class OpenSearchPluginManager:
+    """Manages the currently enabled plugins."""
+
+    def __init__(self, charm: Object):
+        self._charm = charm
+
+    @property
+    def plugins(self) -> Dict[str, OpenSearchPlugin]:
+        """Returns dict of installed plugins."""
+        return {
+            key: plugin_data["class"](key, self._charm)
+            for key, plugin_data in OpenSearchPluginsAvailable.items()
+        }
+
+    def plugin_map_config_name_to_class(self) -> Dict[str, OpenSearchPlugin]:
+        """Returns dict of plugins installed either via config or relation.
+
+        The dict has the format:
+            {
+                "{relation,config}-name": <class>,
+            }
+        Relation names will take precedence over config.
+        """
+        return {
+            plugin_data["relation-name"]
+            if plugin_data.get("relation-name", None)
+            else plugin_data["config-name"]: plugin_data["class"](key, self._charm)
+            for key, plugin_data in OpenSearchPluginsAvailable.items()
+        }
+
+    def get_status(self) -> StatusBase:
+        """Returns if one of the plugins are not active, otherwise, returns active status."""
+        for stat in self.plugins:
+            if not isinstance(stat, ActiveStatus):
+                return stat
+        return ActiveStatus("")
+
+    def plugins_need_upgrade(self) -> List[OpenSearchPlugin]:
+        """Returns a list of plugins that need upgrade."""
+        return [name for name, obj in self.plugins.items() if obj.needs_upgrade]

--- a/lib/charms/opensearch/v0/opensearch_plugins.py
+++ b/lib/charms/opensearch/v0/opensearch_plugins.py
@@ -1,0 +1,277 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""OpenSearch Plugin model.
+
+In OpenSearch, plugins are also called interchangeably as extensions and modules.
+
+A plugin configuration footprint is composed of:
+* Jar files installed in one of the
+  ${OPENSEARCH_HOME}/plugins
+  ${OPENSEARCH_HOME}/modules
+* Configuration passed to the main opensearch.yml, must be removed at plugin removal
+* Secrets stored in the keystore
+* The file: plugin.properties
+* And the security policy in: security.policy
+* Other plugins which it depends upon
+
+One last piece of the configuration is any index data uploaded to the cluster using
+OpenSearch APIs. That last bit of data must be done by inherinting the OpenSearchPlugin
+class and implementing the necessary extra logic.
+
+
+This file implements abstract methods and data that are common to every plugin during
+its lifecycle, including methods to manage configuration files, main processes (install,
+upgrade, uninstall, etc).
+
+The plugin lifecycle runs through the following steps:
+
+INSTALL > is_installed > is_enabled > needs_upgrade > upgrade > UNINSTALL
+
+The meaning of each step is, as follows:
+* is_installed: the installation happened correctly and the JAR files are set
+* is_enabled: all the configurations have been applied and restart is done, if needed
+* needs_upgrade: once the main OpenSearch is upgraded, the plugin needs to check if an
+                 upgrade is also needed or not.
+* upgrade: run the necessary actions to upgrade the plugin
+
+========================================================================================
+
+                             STEPS TO ADD A NEW PLUGIN
+
+========================================================================================
+
+
+For a new plugin, add the plugin to the list of "OpenSearchPluginsAvailable" available
+in opensearch_plugin_manager.py and override the abstract OpenSearchPlugin.
+
+Add a new configuration in the config.yaml with "plugin_" as prefix to its name.
+Add the corresponding config-name to the OpenSearchPluginsAvailable.
+
+If a given plugin depends on a relation, e.g. repository-s3, then add relation name
+as well. For example:
+    OpenSearchPluginsAvailable = {
+        ...
+        "opensearch-knn": {
+            "class": OpenSearchPlugin,
+            "config-name": "plugin_opensearch_knn",
+            "relation-name": ""
+        },
+    }
+"""
+
+import logging
+import os
+from abc import ABC, abstractmethod
+from typing import Dict, List, Optional, Union
+
+from charms.opensearch.v0.opensearch_exceptions import (
+    OpenSearchKeystoreError,
+    OpenSearchPluginError,
+)
+from jproperties import Properties
+from ops.framework import Object
+from ops.model import ActiveStatus, BlockedStatus, StatusBase
+
+# The unique Charmhub library identifier, never change it
+LIBID = "3b05456c6e304680b4af8e20dae246a2"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+logger = logging.getLogger(__name__)
+
+
+class OpenSearchPlugin(ABC):
+    """Abstract class describing an OpenSearch plugin."""
+
+    PLUGIN_PROPERTIES = "plugin-descriptor.properties"
+    CONFIG_YML = "opensearch.yml"
+
+    def __init__(self, name: str, charm: Object, relname: Optional[str] = None):
+        """Creates the OpenSearchPlugin object.
+
+        The *args enable children classes to pass relations.
+        """
+        self.relname = relname
+        self.charm = charm
+        self.distro = self.charm.opensearch
+        self.CONFIG_YML = self.charm.opensearch_config.CONFIG_YML
+        self._name = name
+        self._plugin_properties = Properties()
+
+    @property
+    def version(self) -> str:
+        """Returns the current version of the plugin."""
+        with open(os.path.join(f"{self.distro.paths.plugins}", f"{self.PLUGIN_PROPERTIES}")) as f:
+            self._plugin_properties.load(f.read())
+        return self._plugin_properties._properties["version"]
+
+    def _is_started(self) -> bool:
+        return self.distro.is_started()
+
+    def _request(self, *args, **kwargs) -> dict:
+        return self.distro.request(*args, **kwargs)
+
+    def is_related(self) -> bool:
+        """Returns True if a relation is expected and it is set."""
+        if not self.relname:
+            return True
+        return len(self.charm.framework.model.relations[self.relname] or {}) > 0
+
+    def _update_keystore_and_reload(
+        self, keystore: Dict[str, str], force: bool = True, remove_keys: bool = False
+    ) -> None:
+        if not keystore:
+            return
+        try:
+            for key, value in keystore.items():
+                if remove_keys:
+                    self.distro.remove_from_keystore(key)
+                else:
+                    self.distro.add_to_keystore(key, value, force=force)
+            # Now, reload the security settings and return if opensearch needs restart
+            post = self._request("POST", "_nodes/reload_secure_settings")
+            logger.debug(f"_update_keystore_and_reload: response received {post}")
+        except OpenSearchKeystoreError as ek:
+            raise ek
+        except Exception as e:
+            logger.exception(e)
+            raise OpenSearchPluginError("Unknown error during keystore reload")
+        if post["status"] < 200 or post["status"] >= 300:
+            raise OpenSearchPluginError("Error while processing _nodes reload")
+
+    @property
+    def name(self) -> str:
+        """Returns the name of the plugin."""
+        return self._name
+
+    def uninstall(
+        self,
+        opensearch_yml: Dict[str, str],
+        keystore: Dict[str, str],
+    ) -> bool:
+        """Erases relevant data for this plugin. Returns True if restart needed."""
+        if not self._is_started():
+            return False
+        self._update_keystore_and_reload(keystore)
+        return any(
+            [
+                self.distro.config.delete(self.CONFIG_YML, c, v)[c] == v
+                for c, v in opensearch_yml.items()
+            ]
+        )
+
+    @property
+    def needs_upgrade(self) -> bool:
+        """Returns if the plugin needs an upgrade or not.
+
+        Needs upgrade must be set if an upgrade on the charm happens and plugins must
+        be updated.
+
+        Consider overriding this method only if the plugin needs an special care at upgrade.
+        """
+        current_version = self.version
+        # Now check if the format of this plugin and OpenSearch's match
+        num_points = len(self.distro.version.split("."))
+        return self.distro.version != current_version[:num_points]
+
+    @abstractmethod
+    def upgrade(self, uri: str) -> None:
+        """Runs the upgrade process in this plugin."""
+        pass
+
+    @abstractmethod
+    def is_enabled(self) -> bool:
+        """Returns True if the plugin is enabled."""
+        pass
+
+    @abstractmethod
+    def disable(self) -> bool:
+        """Disables the plugin.
+
+        Runs the configure() method with the configuration to disable the plugin.
+        """
+        pass
+
+    @abstractmethod
+    def enable(self) -> bool:
+        """Enables the plugin.
+
+        Runs the configure() method with the configuration to enable the plugin.
+        """
+        pass
+
+    def configure(
+        self,
+        opensearch_yml: Dict[str, str],
+        keystore: Dict[str, str] = {},
+    ) -> bool:
+        """Sets the plugin configuration. Returns True if restart needed."""
+        if not self._is_started():
+            return False
+        self._update_keystore_and_reload(keystore)
+        return any(
+            [
+                self.distro.config.put(self.CONFIG_YML, c, v)[c] == v
+                for c, v in opensearch_yml.items()
+            ]
+        )
+
+    def is_installed(self) -> bool:
+        """Returns True if the plugin name is present in the list of installed plugins."""
+        if not self._is_started():
+            return False
+        return self.name in self.distro.list_plugins()
+
+    def install(self, uri: str, batch=True) -> bool:
+        """Installs the plugin specified in the URI.
+
+        The URI can have one of the following formats:
+        * A zip file
+        * An URL that downloads a zip file
+        * A maven coded dependency
+        """
+        if self.is_installed():
+            # It is already available as a plugin, return True
+            return True
+        if self._depends_on:
+            plugins = self.distro.list_plugins()
+            missing = []
+            for dependency in self.depends_on:
+                if dependency not in plugins:
+                    missing.append(dependency)
+                if dependency:
+                    raise OpenSearchPluginError("Missing dependencies")
+        self.distro.add_plugin_without_restart(uri, batch=batch)
+
+    @property
+    @abstractmethod
+    def depends_on(self) -> List[str]:
+        """Returns a list of plugins it depends on."""
+        pass
+
+    def get_status(self) -> Union[int, StatusBase]:
+        """Returns the status of the plugin.
+
+        Status:
+            0: blocked, not installed
+            1: blocked, not enabled
+            2: active
+            3: blocked, waiting for an upgrade action
+        """
+        code = 0
+        if not self.is_installed():
+            return code, BlockedStatus(f"Plugin {self.name} waiting to be installed")
+        elif self.is_enabled():
+            code = 1
+            return code, BlockedStatus(f"Plugin {self.name} waiting to be enabled")
+        elif not self.needs_upgrade:
+            code = 2
+            return code, ActiveStatus(f"Plugin {self.name} active")
+        code = 3
+        return code, BlockedStatus(f"Plugin {self.name} waiting for upgrade to be executed")

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ requests==2.31.0
 ruamel.yaml==0.17.31
 tenacity==8.2.2
 urllib3==1.26.15
+git+https://git.launchpad.net/python-jproperties@debian/main
+

--- a/tests/unit/lib/test_plugins.py
+++ b/tests/unit/lib/test_plugins.py
@@ -1,0 +1,117 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit test for the opensearch_plugins library."""
+import unittest
+from unittest.mock import MagicMock, call, patch
+
+import charms
+from charms.opensearch.v0.opensearch_plugins import OpenSearchPlugin
+from ops.testing import Harness
+
+from charm import OpenSearchOperatorCharm
+
+
+class TestPlugin(OpenSearchPlugin):
+    """Overrides the OpenSearchPlugin and returns a is_enabled=True always."""
+
+    test_plugin_disable_called = False
+    PLUGIN_PROPERTIES = "test_plugin.properties"
+
+    def __init__(self, name, charm):
+        super().__init__(name, charm, None)
+
+    def is_enabled(self) -> bool:
+        return True
+
+    def disable(self) -> bool:
+        return True
+
+    def upgrade(self, _: str) -> None:
+        """Runs the upgrade process in this plugin."""
+        raise NotImplementedError
+
+    def enable(self) -> bool:
+        """This method is not used."""
+        raise NotImplementedError
+
+    def depends_on(self):
+        """This method is not used."""
+        raise NotImplementedError
+
+    def _is_started(self):
+        return True
+
+
+class TestOpenSearchPlugin(unittest.TestCase):
+    def setUp(self) -> None:
+        self.harness = Harness(OpenSearchOperatorCharm)
+        self.addCleanup(self.harness.cleanup)
+        self.harness.begin()
+        self.charm = self.harness.charm
+        # Override the plugins folder path
+        self.charm.opensearch.paths.plugins = "tests/unit/resources"
+        self.plugin_manager = self.charm.opensearch._plugin_manager
+        # Override the OpenSearchPluginsAvailable
+        charms.opensearch.v0.opensearch_plugin_manager.OpenSearchPluginsAvailable = {
+            "test": {
+                "class": TestPlugin,
+                "config-name": "plugin_test",
+                "relation-name": None,
+            }
+        }
+
+    def test_install_plugin_and_check_version(self) -> None:
+        """Reconfigure the plugin at main configuration file."""
+        test_plugin = self.plugin_manager.plugins["test"]
+        assert test_plugin.version == "2.9.0.0"
+
+    @patch("charms.opensearch.v0.opensearch_distro.OpenSearchDistribution.request")
+    def test_check_manager_if_plugins_need_upgrade(self, mock_request) -> None:
+        """Validates the plugin manager when checking for an upgrade."""
+        mock_request.return_value = {"version": {"number": "3.0"}}
+        assert self.plugin_manager.plugins_need_upgrade() == ["test"]
+
+    @patch("charms.opensearch.v0.helper_conf_setter.YamlConfigSetter.put")
+    def test_reconfigure_plugin(self, mock_put) -> None:
+        """Reconfigure the plugin at main configuration file."""
+        config = {"param": "tested"}
+        mock_put.return_value = config
+        test_plugin = self.plugin_manager.plugins["test"]
+
+        self.assertTrue(test_plugin.configure(opensearch_yml=config))
+        self.charm.opensearch.config.put.assert_has_calls(
+            [call(test_plugin.CONFIG_YML, "param", "tested")]
+        )
+
+    # Test the integration between opensearch_config and plugin
+
+    def test_reconfigure_add_keystore_plugin(self) -> None:
+        """Reconfigure the keystore only.
+
+        Should not trigger restart, hence return False in the configure() method.
+        """
+        test_plugin = self.plugin_manager.plugins["test"]
+
+        test_plugin.distro.add_to_keystore = MagicMock()
+        test_plugin._request = MagicMock()
+        test_plugin._request.return_value = {"status": 200}
+
+        self.assertFalse(test_plugin.configure(opensearch_yml={}, keystore={"key1": "secret1"}))
+        self.charm.opensearch.add_to_keystore.assert_has_calls(
+            [call("key1", "secret1", force=True)]
+        )
+        test_plugin._request.assert_has_calls([call("POST", "_nodes/reload_secure_settings")])
+
+    def test_check_plugin_updated_after_config(self) -> None:
+        """Reconfigure the keystore only.
+
+        Should not trigger restart, hence return False in the configure() method.
+        """
+        self.charm.opensearch_config.update_host_if_needed = MagicMock()
+        self.charm.opensearch_config.update_host_if_needed.return_value = False
+        self.charm.model._config = {
+            "plugin_test": False,
+            "ignore_this_setting": False,
+        }
+        self.assertTrue(self.charm.opensearch_config.check_charmconfig_if_plugins_updated())

--- a/tests/unit/resources/test_plugin.properties
+++ b/tests/unit/resources/test_plugin.properties
@@ -1,0 +1,60 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+#
+# Modifications Copyright OpenSearch Contributors. See
+# GitHub history for details.
+#
+
+# OpenSearch plugin descriptor file
+# This file must exist as 'plugin-descriptor.properties' inside a plugin.
+#
+### example plugin for "foo"
+#
+# foo.zip <-- zip file for the plugin, with this structure:
+# |____   <arbitrary name1>.jar <-- classes, resources, dependencies
+# |____   <arbitrary nameN>.jar <-- any number of jars
+# |____   plugin-descriptor.properties <-- example contents below:
+#
+# classname=foo.bar.BazPlugin
+# description=My cool plugin
+# version=6.0
+# opensearch.version=6.0
+# java.version=1.8
+#
+### mandatory elements for all plugins:
+#
+# 'description': simple summary of the plugin
+description=OpenSearch k-NN plugin
+#
+# 'version': plugin's version
+version=2.9.0.0
+#
+# 'name': the plugin name
+name=opensearch-knn
+#
+# 'classname': the name of the class to load, fully-qualified
+classname=org.opensearch.knn.plugin.KNNPlugin
+#
+# 'java.version': version of java the code is built against
+# use the system property java.specification.version
+# version string must be a sequence of nonnegative decimal integers
+# separated by "."'s and may have leading zeros
+java.version=11
+#
+# 'opensearch.version': semantic version of opensearch the plugin is compatible with
+# does not include -SNAPSHOT if compiled against a snapshot build
+opensearch.version=2.9.0
+#
+### optional elements for plugins:
+#
+# 'custom.foldername': the custom name of the folder in which the plugin is installed
+custom.foldername=
+#
+# 'extended.plugins': other plugins this plugin extends through SPI
+extended.plugins=lang-painless
+#
+# 'has.native.controller': whether or not the plugin has a native controller


### PR DESCRIPTION
Modelling the K-NN plugin support.

This PR implements [DPE-2327](https://warthogs.atlassian.net/browse/DPE-2327) with K-NN support. It adds a new config option: ```plugin_opensearch_knn``` that allows to enable and disable the K-NN plugin.

This PR is based on #105 

[DPE-2327]: https://warthogs.atlassian.net/browse/DPE-2327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ