### PR TITLE
[DPE-2421] Change replication factor of new built-in indices

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -600,7 +600,7 @@ class OpenSearchBaseCharm(CharmBase):
         # Remove the 'starting' flag on the unit
         self.peers_data.delete(Scope.UNIT, "starting")
 
-        # apply post_start fixes (to work around upstream bugs)
+        # apply post_start fixes to resolve start related upstream bugs
         self.opensearch_fixes.apply_on_start()
 
         # apply cluster health

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -56,6 +56,7 @@ from charms.opensearch.v0.opensearch_exceptions import (
     OpenSearchStartTimeoutError,
     OpenSearchStopError,
 )
+from charms.opensearch.v0.opensearch_fixes import OpenSearchFixes
 from charms.opensearch.v0.opensearch_health import HealthColors, OpenSearchHealth
 from charms.opensearch.v0.opensearch_locking import OpenSearchOpsLock
 from charms.opensearch.v0.opensearch_nodes_exclusions import (
@@ -117,6 +118,7 @@ class OpenSearchBaseCharm(CharmBase):
         self.opensearch = distro(self, PeerRelationName)
         self.opensearch_config = OpenSearchConfig(self.opensearch)
         self.opensearch_exclusions = OpenSearchExclusions(self)
+        self.opensearch_fixes = OpenSearchFixes(self)
         self.peers_data = RelationDataStore(self, PeerRelationName)
         self.secrets = SecretsDataStore(self, PeerRelationName)
         self.tls = OpenSearchTLS(self, TLS_RELATION)
@@ -597,6 +599,9 @@ class OpenSearchBaseCharm(CharmBase):
 
         # Remove the 'starting' flag on the unit
         self.peers_data.delete(Scope.UNIT, "starting")
+
+        # apply post_start fixes (to work around upstream bugs)
+        self.opensearch_fixes.apply_on_start()
 
         # apply cluster health
         self.health.apply()

--- a/lib/charms/opensearch/v0/opensearch_fixes.py
+++ b/lib/charms/opensearch/v0/opensearch_fixes.py
@@ -1,0 +1,46 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Base class for the OpenSearch Fixes of bugs introduced by upstream."""
+from charms.opensearch.v0.opensearch_exceptions import OpenSearchHttpError
+
+# The unique Charmhub library identifier, never change it
+LIBID = "3bdf0a053a53493abefe8265dac85419"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+
+class OpenSearchFixes:
+    """This class implements various fixes of bugs introduced in OpenSearch upstream."""
+
+    def __init__(self, charm):
+        self._charm = charm
+
+    def apply_on_start(self):
+        """Fixes to apply on start."""
+        self._reconfigure_replicas_of_builtin_indices()
+
+    def _reconfigure_replicas_of_builtin_indices(self):
+        """This changes the replication factor of some core indices."""
+        # Bug https://github.com/opensearch-project/OpenSearch/issues/8862
+        # Introduced in: 2.9.0
+        target_indices = [
+            ".plugins-ml-config",
+            ".opensearch-sap-log-types-config",
+            ".opensearch-sap-pre-packaged-rules-config",
+        ]
+        for index in target_indices:
+            try:
+                self._charm.opensearch.request(
+                    method="PUT",
+                    endpoint=f"/{index}/_settings",
+                    payload={"index": {"auto_expand_replicas": "0-all"}},
+                )
+            except OpenSearchHttpError as e:
+                if e.response_code != 404:
+                    raise

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -97,13 +97,13 @@ async def get_shards_by_state(ops_test: OpsTest, unit_ip: str) -> Dict[str, List
         f"https://{unit_ip}:9200/_cat/shards",
     )
 
+    logger.info(f"Shards:\n{response}")
+
     indexes_by_status = {}
     for shard in response:
-        state = shard["state"]
-        if state not in indexes_by_status:
-            indexes_by_status[state] = []
-
-        indexes_by_status[state].append(f"{shard['node']}/{shard['index']}")
+        indexes_by_status.setdefault(shard["state"], []).append(
+            f"{shard['node']}/{shard['index']}"
+        )
 
     return indexes_by_status
 


### PR DESCRIPTION
## Issue
OpenSearch 2.9.0 introduced a "bug" or at least strange behavior where some indices have fixed numbers of replicas, this prevents the cluster from ever being green in a 1 node setup.

This PR implements [DPE-2421](https://warthogs.atlassian.net/browse/DPE-2421) - namely, this PR implements:
- reconfiguration of the replication factor of those indices