### PR TITLE
[Fix] Fix missing env variable on release pipeline 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,15 @@ on:
 jobs:
   pre-integration-checks:
     secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - libjuju: ==3.1.0.1
+          - libjuju: ==2.9.42.4
     uses: ./.github/workflows/pre_integration_checks.yaml
+    with:
+      libjuju-version-specifier: ${{ matrix.libjuju }}
 
   integration:
     needs:


### PR DESCRIPTION
## Issue

Release pipeline was missing to pass a value for the LIBJUJU_VERSION_SPECIFIER variable for unittests (that need to know what version of Juju is running, since divergences on Juju3 feature: Secrets)

## Solution

Passing the missing info on the Release pipeline

## Testing

Tested on this pipeline: https://github.com/canonical/opensearch-operator/actions/runs/6048563873