### PR TITLE
[DPE-2589] OpenSearchSnap refreshes snapd before installation

### DIFF
--- a/src/opensearch.py
+++ b/src/opensearch.py
@@ -65,7 +65,6 @@ class OpenSearchSnap(OpenSearchDistribution):
             self._snapd.ensure(snap.SnapState.Latest, channel="latest/stable")
             self._opensearch.ensure(snap.SnapState.Latest, channel="edge")
             self._opensearch.connect("process-control")
-            self._opensearch.connect("shmem-perf-analyzer")
         except SnapError as e:
             logger.error(f"Failed to install opensearch. \n{e}")
             raise OpenSearchInstallError()

--- a/src/opensearch.py
+++ b/src/opensearch.py
@@ -48,6 +48,7 @@ class OpenSearchSnap(OpenSearchDistribution):
             with attempt:
                 cache = snap.SnapCache()
                 self._opensearch = cache["opensearch"]
+                self._snapd = cache["snapd"]
 
     @retry(
         stop=stop_after_attempt(3),
@@ -61,8 +62,10 @@ class OpenSearchSnap(OpenSearchDistribution):
             return
 
         try:
+            self._snapd.ensure(snap.SnapState.Latest, channel="latest/stable")
             self._opensearch.ensure(snap.SnapState.Latest, channel="edge")
             self._opensearch.connect("process-control")
+            self._opensearch.connect("shmem-perf-analyzer")
         except SnapError as e:
             logger.error(f"Failed to install opensearch. \n{e}")
             raise OpenSearchInstallError()


### PR DESCRIPTION
Commit: https://github.com/canonical/opensearch-snap/commit/e9964ef7b8c41df8bdd193bc126b3ff3a2a21065

In opensearch-snap added a dependency to snapd 2.60, otherwise installing opensearch snap fails with permission denied to /dev/shm/performance-analyzer.
However, not all deployments will start at this version and should be refreshed before installation can proceed.

Resolves issue: https://github.com/canonical/opensearch-operator/issues/119