### PR TITLE
[DPE-2345][DPE-2451] restore action

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -45,8 +45,15 @@ create-backup:
 
 list-backups:
   description: List available backup_ids in the S3 bucket and path provided by the S3 integrator charm.
+  params:
+    output:
+      type: string
+      default: "table"
+      description: |
+        Format which the data should be returned. Possible values: table, json.
+        The json format will bring more details, such as shard status, indices name, etc.
 
-restore-backup:
+restore:
   description: Restore a database backup.
     S3 credentials are retrieved from a relation with the S3 integrator charm.
   params:

--- a/actions.yaml
+++ b/actions.yaml
@@ -45,3 +45,14 @@ create-backup:
 
 list-backups:
   description: List available backup_ids in the S3 bucket and path provided by the S3 integrator charm.
+
+restore-backup:
+  description: Restore a database backup.
+    S3 credentials are retrieved from a relation with the S3 integrator charm.
+  params:
+    backup-id:
+      type: integer
+      description: |
+        A backup-id to identify the backup to restore. Format: <backup-id, int>
+  required:
+    - backup-id

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -237,8 +237,8 @@ async def test_backup_cluster(
     logger.info(f"list-backups output: {list_backups}")
 
     # Expected format:
-    # namespace(status='completed', response={'return-code': 0, 'snapshots': '{"1": ...}'})
-    backups = json.loads(list_backups.response["snapshots"])
+    # namespace(status='completed', response={'return-code': 0, 'backups': '{"1": ...}'})
+    backups = json.loads(list_backups.response["backups"])
     assert list_backups.status == "completed"
     assert len(backups.keys()) == int(action.response["backup-id"])
     assert backups[action.response["backup-id"]]["state"] == "SUCCESS"
@@ -376,8 +376,8 @@ async def test_remove_and_readd_s3_relation(ops_test: OpsTest) -> None:
     logger.info(f"list-backups output: {list_backups}")
 
     # Expected format:
-    # namespace(status='completed', response={'return-code': 0, 'snapshots': '{"1": ...}'})
-    backups = json.loads(list_backups.response["snapshots"])
+    # namespace(status='completed', response={'return-code': 0, 'backups': '{"1": ...}'})
+    backups = json.loads(list_backups.response["backups"])
     assert list_backups.status == "completed"
     assert len(backups.keys()) == int(action.response["backup-id"])
     assert backups[action.response["backup-id"]]["state"] == "SUCCESS"

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -29,6 +29,7 @@ from tests.integration.helpers import (
     get_application_unit_ids_ips,
     get_leader_unit_id,
     get_leader_unit_ip,
+    http_request,
     run_action,
 )
 from tests.integration.tls.test_tls import TLS_CERTIFICATES_APP_NAME
@@ -37,6 +38,7 @@ logger = logging.getLogger(__name__)
 
 
 S3_INTEGRATOR_NAME = "s3-integrator"
+TEST_BACKUP_DOC_ID = 10
 CLOUD_CONFIGS = {
     "aws": {
         "endpoint": "https://s3.amazonaws.com",
@@ -95,6 +97,9 @@ value_before_backup, value_after_backup = None, None
 #         backup_path = str(Path(config["path"]) / backups_by_cloud[cloud_name])
 #         for bucket_object in bucket.objects.filter(Prefix=backup_path):
 #             bucket_object.delete()
+
+
+TEST_BACKUP_INDEX = "test_backup_index"
 
 
 @pytest.fixture()
@@ -200,13 +205,11 @@ async def test_backup_cluster(
     units = await get_application_unit_ids_ips(ops_test, app=app)
     leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
 
-    # create index with r_shards = nodes - 1
-    test_backup_index = "test_backup_index"
-    await create_index(ops_test, app, leader_unit_ip, test_backup_index, r_shards=len(units) - 1)
+    await create_index(ops_test, app, leader_unit_ip, TEST_BACKUP_INDEX, r_shards=len(units) - 1)
 
     # index document
-    doc_id = 10
-    await index_doc(ops_test, app, leader_unit_ip, test_backup_index, doc_id)
+    doc_id = TEST_BACKUP_DOC_ID
+    await index_doc(ops_test, app, leader_unit_ip, TEST_BACKUP_INDEX, doc_id)
 
     # check that the doc can be retrieved from any node
     logger.info("Test backup index: searching")
@@ -215,13 +218,13 @@ async def test_backup_cluster(
             ops_test,
             app,
             u_ip,
-            test_backup_index,
+            TEST_BACKUP_INDEX,
             query={"query": {"term": {"_id": doc_id}}},
             preference="_only_local",
         )
         # Validate the index and document are present
         assert len(docs) == 1
-        assert docs[0]["_source"] == default_doc(test_backup_index, doc_id)
+        assert docs[0]["_source"] == default_doc(TEST_BACKUP_INDEX, doc_id)
 
     leader_id = await get_leader_unit_id(ops_test, app)
 
@@ -234,12 +237,175 @@ async def test_backup_cluster(
     logger.info(f"list-backups output: {list_backups}")
 
     # Expected format:
-    # namespace(status='completed', response={'return-code': 0, 'snapshots': '{"1": "SUCCESS"}'})
+    # namespace(status='completed', response={'return-code': 0, 'snapshots': '{"1": ...}'})
+    backups = json.loads(list_backups.response["snapshots"])
     assert list_backups.status == "completed"
-    assert len(json.loads(list_backups.response["snapshots"])) == int(action.response["backup-id"])
-    assert (
-        json.loads(list_backups.response["snapshots"])[action.response["backup-id"]] == "SUCCESS"
-    )
+    assert len(backups.keys()) == int(action.response["backup-id"])
+    assert backups[action.response["backup-id"]]["state"] == "SUCCESS"
 
     # continuous writes checks
     await assert_continuous_writes_consistency(ops_test, c_writes, app)
+
+
+@pytest.mark.abort_on_fail
+async def test_restore_cluster(
+    ops_test: OpsTest,
+) -> None:
+    """Deletes the TEST_BACKUP_INDEX, restores the cluster and tries to search for index."""
+    app = (await app_name(ops_test)) or APP_NAME
+
+    units = await get_application_unit_ids_ips(ops_test, app=app)
+    leader_id = await get_leader_unit_id(ops_test, app)
+    leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
+
+    await http_request(
+        ops_test,
+        "DELETE",
+        f"https://{leader_unit_ip}:9200/{TEST_BACKUP_INDEX}",
+        app=app,
+    )
+
+    action = await run_action(ops_test, leader_id, "restore-backup", params={"backup-id": 1})
+    logger.info(f"restore-backup output: {action}")
+    assert action.status == "completed"
+
+    # index document
+    doc_id = TEST_BACKUP_DOC_ID
+    # check that the doc can be retrieved from any node
+    logger.info("Test backup index: searching")
+    for u_id, u_ip in units.items():
+        docs = await search(
+            ops_test,
+            app,
+            u_ip,
+            TEST_BACKUP_INDEX,
+            query={"query": {"term": {"_id": doc_id}}},
+            preference="_only_local",
+        )
+        # Validate the index and document are present
+        assert len(docs) == 1
+        assert docs[0]["_source"] == default_doc(TEST_BACKUP_INDEX, doc_id)
+
+
+@pytest.mark.abort_on_fail
+async def test_restore_cluster_after_app_destroyed(ops_test: OpsTest) -> None:
+    """Deletes the entire OpenSearch cluster and redeploys from scratch.
+
+    Restores the backup and then checks if the same TEST_BACKUP_INDEX is there.
+    """
+    app = (await app_name(ops_test)) or APP_NAME
+    await ops_test.model.remove_application(app, block_until_done=True)
+    app_num_units = int(os.environ.get("TEST_NUM_APP_UNITS", None) or 3)
+    my_charm = await ops_test.build_charm(".")
+    # Redeploy
+    await asyncio.gather(
+        ops_test.model.deploy(my_charm, num_units=app_num_units, series=SERIES),
+    )
+    # Relate it to OpenSearch to set up TLS.
+    await ops_test.model.relate(APP_NAME, TLS_CERTIFICATES_APP_NAME)
+    await ops_test.model.relate(APP_NAME, S3_INTEGRATOR_NAME)
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME],
+        status="active",
+        timeout=1400,
+        idle_period=IDLE_PERIOD,
+    )
+
+    units = await get_application_unit_ids_ips(ops_test, app=app)
+    leader_id = await get_leader_unit_id(ops_test, app)
+
+    action = await run_action(ops_test, leader_id, "restore-backup", params={"backup-id": 1})
+    logger.info(f"restore-backup output: {action}")
+    assert action.status == "completed"
+
+    # index document
+    doc_id = TEST_BACKUP_DOC_ID
+    # check that the doc can be retrieved from any node
+    logger.info("Test backup index: searching")
+    for u_id, u_ip in units.items():
+        docs = await search(
+            ops_test,
+            app,
+            u_ip,
+            TEST_BACKUP_INDEX,
+            query={"query": {"term": {"_id": doc_id}}},
+            preference="_only_local",
+        )
+        # Validate the index and document are present
+        assert len(docs) == 1
+        assert docs[0]["_source"] == default_doc(TEST_BACKUP_INDEX, doc_id)
+
+
+@pytest.mark.abort_on_fail
+async def test_remove_and_readd_s3_relation(ops_test: OpsTest) -> None:
+    """Removes and re-adds the s3-credentials relation to test backup and restore."""
+    app = (await app_name(ops_test)) or APP_NAME
+    units = await get_application_unit_ids_ips(ops_test, app=app)
+    leader_id = await get_leader_unit_id(ops_test, app)
+    leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
+
+    logger.info("Remove s3-credentials relation")
+    # Remove relation
+    await ops_test.model.applications[APP_NAME].destroy_relation(
+        "s3-credentials", f"{S3_INTEGRATOR_NAME}:s3-credentials"
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME],
+        status="active",
+        timeout=1400,
+        idle_period=IDLE_PERIOD,
+    )
+
+    logger.info("Re-add s3-credentials relation")
+    await ops_test.model.relate(APP_NAME, S3_INTEGRATOR_NAME)
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME],
+        status="active",
+        timeout=1400,
+        idle_period=IDLE_PERIOD,
+    )
+
+    leader_id = await get_leader_unit_id(ops_test, app)
+
+    action = await run_action(ops_test, leader_id, "create-backup")
+    logger.info(f"create-backup output: {action}")
+
+    assert action.status == "completed"
+
+    list_backups = await run_action(ops_test, leader_id, "list-backups")
+    logger.info(f"list-backups output: {list_backups}")
+
+    # Expected format:
+    # namespace(status='completed', response={'return-code': 0, 'snapshots': '{"1": ...}'})
+    backups = json.loads(list_backups.response["snapshots"])
+    assert list_backups.status == "completed"
+    assert len(backups.keys()) == int(action.response["backup-id"])
+    assert backups[action.response["backup-id"]]["state"] == "SUCCESS"
+
+    await http_request(
+        ops_test,
+        "DELETE",
+        f"https://{leader_unit_ip}:9200/{TEST_BACKUP_INDEX}",
+        app=app,
+    )
+
+    action = await run_action(ops_test, leader_id, "restore-backup", params={"backup-id": 1})
+    logger.info(f"restore-backup output: {action}")
+    assert action.status == "completed"
+
+    # index document
+    doc_id = TEST_BACKUP_DOC_ID
+    # check that the doc can be retrieved from any node
+    logger.info("Test backup index: searching")
+    for u_id, u_ip in units.items():
+        docs = await search(
+            ops_test,
+            app,
+            u_ip,
+            TEST_BACKUP_INDEX,
+            query={"query": {"term": {"_id": doc_id}}},
+            preference="_only_local",
+        )
+        # Validate the index and document are present
+        assert len(docs) == 1
+        assert docs[0]["_source"] == default_doc(TEST_BACKUP_INDEX, doc_id)

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -233,7 +233,7 @@ async def test_backup_cluster(
 
     assert action.status == "completed"
 
-    list_backups = await run_action(ops_test, leader_id, "list-backups")
+    list_backups = await run_action(ops_test, leader_id, "list-backups", params={"output": "json"})
     logger.info(f"list-backups output: {list_backups}")
 
     # Expected format:
@@ -265,8 +265,8 @@ async def test_restore_cluster(
         app=app,
     )
 
-    action = await run_action(ops_test, leader_id, "restore-backup", params={"backup-id": 1})
-    logger.info(f"restore-backup output: {action}")
+    action = await run_action(ops_test, leader_id, "restore", params={"backup-id": 1})
+    logger.info(f"restore output: {action}")
     assert action.status == "completed"
 
     # index document
@@ -314,8 +314,8 @@ async def test_restore_cluster_after_app_destroyed(ops_test: OpsTest) -> None:
     units = await get_application_unit_ids_ips(ops_test, app=app)
     leader_id = await get_leader_unit_id(ops_test, app)
 
-    action = await run_action(ops_test, leader_id, "restore-backup", params={"backup-id": 1})
-    logger.info(f"restore-backup output: {action}")
+    action = await run_action(ops_test, leader_id, "restore", params={"backup-id": 1})
+    logger.info(f"restore output: {action}")
     assert action.status == "completed"
 
     # index document
@@ -372,7 +372,7 @@ async def test_remove_and_readd_s3_relation(ops_test: OpsTest) -> None:
 
     assert action.status == "completed"
 
-    list_backups = await run_action(ops_test, leader_id, "list-backups")
+    list_backups = await run_action(ops_test, leader_id, "list-backups", params={"output": "json"})
     logger.info(f"list-backups output: {list_backups}")
 
     # Expected format:
@@ -389,7 +389,9 @@ async def test_remove_and_readd_s3_relation(ops_test: OpsTest) -> None:
         app=app,
     )
 
-    action = await run_action(ops_test, leader_id, "restore-backup", params={"backup-id": 1})
+    action = await run_action(
+        ops_test, leader_id, "restore", params={"backup-id": int(action.response["backup-id"])}
+    )
     logger.info(f"restore-backup output: {action}")
     assert action.status == "completed"
 

--- a/tests/unit/lib/test_backups.py
+++ b/tests/unit/lib/test_backups.py
@@ -128,7 +128,7 @@ class TestBackups(unittest.TestCase):
     @patch("charms.opensearch.v0.opensearch_distro.OpenSearchDistribution.request")
     @patch("charms.opensearch.v0.opensearch_backups.OpenSearchBackup._execute_s3_broken_calls")
     @patch("charms.opensearch.v0.opensearch_plugin_manager.OpenSearchPluginManager.status")
-    def test_99_relation_broken(
+    def test_20_relation_broken(
         self,
         mock_status,
         mock_execute_s3_broken_calls,
@@ -144,6 +144,7 @@ class TestBackups(unittest.TestCase):
             {"SUCCESS"},
         ]
         mock_status.return_value = PluginState.ENABLED
+        self.harness.remove_relation_unit(self.s3_rel_id, "s3-integrator/0")
         self.harness.remove_relation(self.s3_rel_id)
         mock_request.called_once_with("GET", "/_snapshot/_status")
         mock_execute_s3_broken_calls.assert_called_once()

--- a/tests/unit/lib/test_backups.py
+++ b/tests/unit/lib/test_backups.py
@@ -57,6 +57,12 @@ class TestBackups(unittest.TestCase):
             self.harness.add_relation_unit(self.s3_rel_id, "s3-integrator/0")
             mock_pm_run.assert_not_called()
 
+    def test_get_endpoint_protocol(self) -> None:
+        """Tests the get_endpoint_protocol method."""
+        assert self.charm.backup._get_endpoint_protocol("http://10.0.0.1:8000") == "http"
+        assert self.charm.backup._get_endpoint_protocol("https://10.0.0.2:8000") == "https"
+        assert self.charm.backup._get_endpoint_protocol("test.not-valid-url") == "https"
+
     @patch("charms.opensearch.v0.opensearch_plugin_manager.OpenSearchPluginManager.status")
     @patch("charms.opensearch.v0.opensearch_backups.OpenSearchBackup.apply_api_config_if_needed")
     @patch("charms.opensearch.v0.opensearch_plugin_manager.OpenSearchPluginManager._apply_config")
@@ -91,9 +97,10 @@ class TestBackups(unittest.TestCase):
             ).__dict__
         )
 
+    @patch("charms.opensearch.v0.opensearch_backups.OpenSearchBackup._request")
     @patch("charms.opensearch.v0.opensearch_distro.OpenSearchDistribution.request")
     @patch("charms.opensearch.v0.opensearch_plugin_manager.OpenSearchPluginManager.status")
-    def test_01_apply_api_config_if_needed(self, mock_status, mock_request) -> None:
+    def test_01_apply_api_config_if_needed(self, mock_status, _, mock_request) -> None:
         """Tests the application of post-restart steps."""
         self.harness.update_relation_data(
             self.s3_rel_id,
@@ -110,15 +117,18 @@ class TestBackups(unittest.TestCase):
         )
         mock_status.return_value = PluginState.ENABLED
         self.charm.backup.apply_api_config_if_needed()
-        mock_request.called_once_with("GET", f"_snapshot/{S3_REPOSITORY}")
-        mock_request.called_once_with(
+        mock_request.assert_called_with(
             "PUT",
             f"_snapshot/{S3_REPOSITORY}",
             payload={
                 "type": "s3",
                 "settings": {
+                    "endpoint": "localhost",
+                    "protocol": "https",
                     "bucket": TEST_BUCKET_NAME,
                     "base_path": TEST_BASE_PATH,
+                    "region": "testing-region",
+                    "storage_class": "storageclass",
                 },
             },
         )


### PR DESCRIPTION
Extends https://github.com/canonical/opensearch-operator/pull/135 and adds restore support.

This PR will roll the cluster's indices back to the snapshot and override any conflicting index.

It tests two scenarios:
1) Snapshot / restore in the same cluster
2) Snapshot / redeploy cluster / restore