### PR TITLE
Fixed jdk path

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -32,6 +32,7 @@ from charms.opensearch.v0.opensearch_exceptions import (
     OpenSearchStartTimeoutError,
 )
 from charms.opensearch.v0.opensearch_internal_data import Scope
+from tenacity import retry, stop_after_attempt, wait_fixed
 
 # The unique Charmhub library identifier, never change it
 LIBID = "7145c219467d43beb9c566ab4a72c454"
@@ -317,6 +318,7 @@ class OpenSearchDistribution(ABC):
             f.write(data)
 
     @staticmethod
+    @retry(stop=stop_after_attempt(3), wait=wait_fixed(0.5), reraise=True)
     def _run_cmd(command: str, args: str = None, stdin: str = None) -> str:
         """Run command.
 
@@ -362,6 +364,7 @@ class OpenSearchDistribution(ABC):
     def _set_env_variables(self):
         """Set the necessary environment variables."""
         os.environ["OPENSEARCH_HOME"] = self.paths.home
+        os.environ["JAVA_HOME"] = self.paths.jdk
         os.environ["OPENSEARCH_JAVA_HOME"] = self.paths.jdk
         os.environ["OPENSEARCH_PATH_CONF"] = self.paths.conf
         os.environ["OPENSEARCH_TMPDIR"] = self.paths.tmp

--- a/src/opensearch.py
+++ b/src/opensearch.py
@@ -131,7 +131,7 @@ class OpenSearchSnap(OpenSearchDistribution):
             conf=f"{self._SNAP_DATA}/etc/opensearch",
             data=f"{self._SNAP_COMMON}/var/lib/opensearch",
             logs=f"{self._SNAP_COMMON}/var/log/opensearch",
-            jdk=f"{self._SNAP}/usr/share/opensearch/jdk",
+            jdk=f"{self._SNAP}/usr/lib/jvm/java-17-openjdk-amd64",
             tmp=f"{self._SNAP_COMMON}/usr/share/tmp",
             bin=f"{self._SNAP}/usr/share/opensearch/bin",
         )


### PR DESCRIPTION
## Issue
The new version of the snap relies on the jdk of the snap environment instead of the one bundled by OpenSearch.
This PR replaces the path of the JDK by the correct one 