### PR TITLE
[DPE-3243][DPE-3246] Finishes the backup with fully async restore

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -160,16 +160,6 @@ jobs:
           sudo rm -rf /usr/local/share/boost
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
-      - name: Setup microceph
-        uses: phvalguima/microceph-action@main
-        with:
-          channel: 'latest/edge'
-          devname: '/dev/sdi'
-          accesskey: 'accesskey'
-          secretkey: 'secretkey'
-          bucket: 'testbucket'
-          osdsize: '5G'
-
       - name: Select tests
         id: select-tests
         run: |

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -174,13 +174,6 @@ jobs:
 
       - name: Run backup integration
         run: |
-          # load microceph output
-          # ATM: remove the https:// reference and stick with http only
-          sed -i 's@https://@http://@g' microceph.source
-          for i in $(cat microceph.source); do export $i; done
-          export TEST_NUM_APP_UNITS=2
-
-          # Set kernel params
           sudo sysctl -w vm.max_map_count=262144 vm.swappiness=0 net.ipv4.tcp_retries2=5
           tox run -e ha-backup-integration -- -m '${{ steps.select-tests.outputs.mark_expression }}'
         env:

--- a/actions.yaml
+++ b/actions.yaml
@@ -78,5 +78,5 @@ restore:
   required:
     - backup-id
 
-check-restore-status:
+check-restore-current:
   description: Check the progress of current restore.

--- a/actions.yaml
+++ b/actions.yaml
@@ -42,6 +42,14 @@ get-password:
 create-backup:
   description: Create a database backup.
     S3 credentials are retrieved from a relation with the S3 integrator charm.
+  params:
+    wait-for-completion:
+      type: boolean
+      default: false
+      description: |
+        Wait for the backup to complete before returning.
+        If not waiting for completion, the  status can be retrieved with list-backups action.
+
 
 list-backups:
   description: List available backup_ids in the S3 bucket and path provided by the S3 integrator charm.
@@ -60,6 +68,15 @@ restore:
     backup-id:
       type: integer
       description: |
-        A backup-id to identify the backup to restore. Format: <backup-id, int>
+        A backup-id to identify the backup to restore. Format: backup-id=<integer>.
+    wait-for-completion:
+      type: boolean
+      default: false
+      description: |
+        Wait for the restore to complete before returning.
+        If not waiting for completion, the restore status can be retrieved with check-restore-status action.
   required:
     - backup-id
+
+check-restore-status:
+  description: Check the progress of current restore.

--- a/actions.yaml
+++ b/actions.yaml
@@ -42,14 +42,6 @@ get-password:
 create-backup:
   description: Create a database backup.
     S3 credentials are retrieved from a relation with the S3 integrator charm.
-  params:
-    wait-for-completion:
-      type: boolean
-      default: false
-      description: |
-        Wait for the backup to complete before returning.
-        If not waiting for completion, the  status can be retrieved with list-backups action.
-
 
 list-backups:
   description: List available backup_ids in the S3 bucket and path provided by the S3 integrator charm.
@@ -69,14 +61,5 @@ restore:
       type: integer
       description: |
         A backup-id to identify the backup to restore. Format: backup-id=<integer>.
-    wait-for-completion:
-      type: boolean
-      default: false
-      description: |
-        Wait for the restore to complete before returning.
-        If not waiting for completion, the restore status can be retrieved with check-restore-status action.
   required:
     - backup-id
-
-check-restore-current:
-  description: Check the progress of current restore.

--- a/lib/charms/opensearch/v0/constants_charm.py
+++ b/lib/charms/opensearch/v0/constants_charm.py
@@ -72,6 +72,7 @@ HorizontalScaleUpSuggest = "Horizontal scale up advised: {} shards unassigned."
 WaitingForOtherUnitServiceOps = "Waiting for other units to complete the ops on their service."
 NewIndexRequested = "new index {index} requested"
 RestoreStarting = "Restore action started."
+PluginConfigStart = "Plugin configuration started."
 
 
 # Relation Interfaces

--- a/lib/charms/opensearch/v0/constants_charm.py
+++ b/lib/charms/opensearch/v0/constants_charm.py
@@ -57,7 +57,6 @@ PClusterWrongRolesProvided = "Cannot start cluster with current set of roles."
 PClusterWrongNodesCountForQuorum = (
     "Even number of members in quorum if current unit started. Add or remove 1 unit."
 )
-RestoreActionFailed = "Restore action failed, please check the logs."
 
 # Wait status
 RequestUnitServiceOps = "Requesting lock on operation: {}"
@@ -71,7 +70,7 @@ TLSNewCertsRequested = "Requesting new TLS certificates..."
 HorizontalScaleUpSuggest = "Horizontal scale up advised: {} shards unassigned."
 WaitingForOtherUnitServiceOps = "Waiting for other units to complete the ops on their service."
 NewIndexRequested = "new index {index} requested"
-RestoreStarting = "Restore action started."
+RestoreInProgress = "Restore in progress..."
 PluginConfigStart = "Plugin configuration started."
 
 

--- a/lib/charms/opensearch/v0/constants_charm.py
+++ b/lib/charms/opensearch/v0/constants_charm.py
@@ -57,6 +57,7 @@ PClusterWrongRolesProvided = "Cannot start cluster with current set of roles."
 PClusterWrongNodesCountForQuorum = (
     "Even number of members in quorum if current unit started. Add or remove 1 unit."
 )
+RestoreActionFailed = "Restore action failed, please check the logs."
 
 # Wait status
 RequestUnitServiceOps = "Requesting lock on operation: {}"
@@ -70,6 +71,7 @@ TLSNewCertsRequested = "Requesting new TLS certificates..."
 HorizontalScaleUpSuggest = "Horizontal scale up advised: {} shards unassigned."
 WaitingForOtherUnitServiceOps = "Waiting for other units to complete the ops on their service."
 NewIndexRequested = "new index {index} requested"
+RestoreStarting = "Restore action started."
 
 
 # Relation Interfaces

--- a/lib/charms/opensearch/v0/helper_cluster.py
+++ b/lib/charms/opensearch/v0/helper_cluster.py
@@ -281,11 +281,14 @@ class ClusterState:
         opensearch: OpenSearchDistribution,
         host: Optional[str] = None,
         alt_hosts: Optional[List[str]] = None,
+        expand_wildcards: str = None,
     ) -> List[Dict[str, str]]:
         """Get all shards of all indexes in the cluster."""
-        idx = opensearch.request("GET", "/_cat/indices", host=host, alt_hosts=alt_hosts)
+        endpoint = "/_cat/indices"
+        if expand_wildcards:
+            endpoint = f"{endpoint}?expand_wildcards={expand_wildcards}"
         idx = {}
-        for index in opensearch.request("GET", "/_cat/indices", host=host, alt_hosts=alt_hosts):
+        for index in opensearch.request("GET", endpoint, host=host, alt_hosts=alt_hosts):
             idx[index["index"]] = {"health": index["health"], "status": index["status"]}
         return idx
 

--- a/lib/charms/opensearch/v0/helper_cluster.py
+++ b/lib/charms/opensearch/v0/helper_cluster.py
@@ -32,12 +32,7 @@ class IndexStateEnum(BaseStrEnum):
     CLOSED = "closed"
 
 
-class IndexHealthEnum(BaseStrEnum):
-    """Enum for index health."""
-
-    GREEN = "green"
-    YELLOW = "yellow"
-    RED = "red"
+INDEX_WILDCARD = "all"
 
 
 class ClusterTopology:
@@ -284,9 +279,7 @@ class ClusterState:
         expand_wildcards: str = None,
     ) -> List[Dict[str, str]]:
         """Get all shards of all indexes in the cluster."""
-        endpoint = "/_cat/indices"
-        if expand_wildcards:
-            endpoint = f"{endpoint}?expand_wildcards={expand_wildcards}"
+        endpoint = f"/_cat/indices?expand_wildcards={INDEX_WILDCARD}"
         idx = {}
         for index in opensearch.request("GET", endpoint, host=host, alt_hosts=alt_hosts):
             idx[index["index"]] = {"health": index["health"], "status": index["status"]}

--- a/lib/charms/opensearch/v0/helper_cluster.py
+++ b/lib/charms/opensearch/v0/helper_cluster.py
@@ -6,6 +6,7 @@ import logging
 from random import choice
 from typing import Dict, List, Optional
 
+from charms.opensearch.v0.helper_enums import BaseStrEnum
 from charms.opensearch.v0.models import Node
 from charms.opensearch.v0.opensearch_distro import OpenSearchDistribution
 from tenacity import retry, stop_after_attempt, wait_exponential
@@ -22,6 +23,21 @@ LIBPATCH = 1
 
 
 logger = logging.getLogger(__name__)
+
+
+class IndexStateEnum(BaseStrEnum):
+    """Enum for index states."""
+
+    OPEN = "open"
+    CLOSED = "closed"
+
+
+class IndexHealthEnum(BaseStrEnum):
+    """Enum for index health."""
+
+    GREEN = "green"
+    YELLOW = "yellow"
+    RED = "red"
 
 
 class ClusterTopology:

--- a/lib/charms/opensearch/v0/helper_cluster.py
+++ b/lib/charms/opensearch/v0/helper_cluster.py
@@ -32,9 +32,6 @@ class IndexStateEnum(BaseStrEnum):
     CLOSED = "closed"
 
 
-INDEX_WILDCARD = "all"
-
-
 class ClusterTopology:
     """Class for creating the best possible configuration for a Node."""
 

--- a/lib/charms/opensearch/v0/helper_cluster.py
+++ b/lib/charms/opensearch/v0/helper_cluster.py
@@ -276,10 +276,9 @@ class ClusterState:
         opensearch: OpenSearchDistribution,
         host: Optional[str] = None,
         alt_hosts: Optional[List[str]] = None,
-        expand_wildcards: str = None,
     ) -> List[Dict[str, str]]:
         """Get all shards of all indexes in the cluster."""
-        endpoint = f"/_cat/indices?expand_wildcards={INDEX_WILDCARD}"
+        endpoint = "/_cat/indices?expand_wildcards=all"
         idx = {}
         for index in opensearch.request("GET", endpoint, host=host, alt_hosts=alt_hosts):
             idx[index["index"]] = {"health": index["health"], "status": index["status"]}

--- a/lib/charms/opensearch/v0/opensearch_backups.py
+++ b/lib/charms/opensearch/v0/opensearch_backups.py
@@ -302,10 +302,10 @@ class OpenSearchBackup(Object):
         if not rel:
             # Running on a single unit, wait_for_completion=false not supported
             return True
-        closed_idx = set(rel.data[self.charm.app].get("restore_in_progress", "").split(",")).copy()
-        if not closed_idx:
+        if not rel.data[self.charm.app].get("restore_in_progress"):
             # Dealing with an empty set
             return True
+        closed_idx = set(rel.data[self.charm.app].get("restore_in_progress", "").split(",")).copy()
         # Check if all indices are open again
         try:
             indices_status = self._request(

--- a/lib/charms/opensearch/v0/opensearch_backups.py
+++ b/lib/charms/opensearch/v0/opensearch_backups.py
@@ -244,7 +244,11 @@ class OpenSearchBackup(Object):
                 with attempt:
                     to_close = {
                         index
-                        for index, state in ClusterState.indices(self.charm.opensearch).items()
+                        for index, state in ClusterState.indices(
+                            self.charm.opensearch,
+                            # We need to know about all indices, including those that are hidden
+                            expand_wildcards="all",
+                        ).items()
                         if (
                             index in backup_indices
                             and state["status"] != IndexStateEnum.CLOSED

--- a/lib/charms/opensearch/v0/opensearch_backups.py
+++ b/lib/charms/opensearch/v0/opensearch_backups.py
@@ -351,7 +351,7 @@ class OpenSearchBackup(Object):
             return
 
         msg = "Restore is complete" if self._is_restore_complete() else "Restore in progress..."
-        self.charm.status.clear(RestoreStarting, start_with=True)
+        self.charm.status.clear(RestoreStarting)
         event.set_results(
             {"backup-id": backup_id, "status": msg, "closed-indices": str(closed_idx)}
         )

--- a/lib/charms/opensearch/v0/opensearch_backups.py
+++ b/lib/charms/opensearch/v0/opensearch_backups.py
@@ -222,7 +222,9 @@ class OpenSearchBackup(Object):
                 resp.get("shards_acknowledged", False)
                 and all(
                     [
-                        state and state.get("closed") == "true"
+                        # The statement of explicit "is True" below assures we have a boolean
+                        # as the response has the form of "true" or "false" originally
+                        state and state.get("closed") is True
                         for state in resp.get("indices", {}).values()
                     ]
                 )

--- a/lib/charms/opensearch/v0/opensearch_backups.py
+++ b/lib/charms/opensearch/v0/opensearch_backups.py
@@ -322,7 +322,7 @@ class OpenSearchBackup(Object):
         closed_idx = set()
         try:
             closed_idx = self._close_indices_if_needed(backup_id)
-            output = self._restore(backup_id)
+            output = self._restore(backup_id, closed_idx)
             logger.debug(f"Restore action: received response: {output}")
             logger.info(f"Restore action succeeded for backup_id {backup_id}")
         except (OpenSearchHttpError, OpenSearchRestoreIndexClosingError) as e:

--- a/lib/charms/opensearch/v0/opensearch_backups.py
+++ b/lib/charms/opensearch/v0/opensearch_backups.py
@@ -303,7 +303,7 @@ class OpenSearchBackup(Object):
             # Running on a single unit, wait_for_completion=false not supported
             return True
         closed_idx = set(rel.data[self.charm.app].get("restore_in_progress", "").split(",")).copy()
-        if not closed_idx or closed_idx == {""}:
+        if not closed_idx:
             # Dealing with an empty set
             return True
         # Check if all indices are open again
@@ -356,10 +356,8 @@ class OpenSearchBackup(Object):
                 event.set_results({"state": "successful restore!"})
                 return
             event.set_results({"state": "restore in progress..."})
-            return
         except Exception as e:
             event.fail(f"Failed: {e}")
-            return
 
     def _backup_is_available_for_restore(self, backup_id: int) -> bool:
         """Checks if the backup_id exists and is ready for a restore."""
@@ -732,13 +730,13 @@ class OpenSearchBackup(Object):
     def _check_repo_status(self) -> BackupServiceState:
         try:
             return self.get_service_status(self._request("GET", f"_snapshot/{S3_REPOSITORY}"))
-        except (ValueError, OpenSearchHttpError, requests.HTTPError):
+        except OpenSearchHttpError:
             return BackupServiceState.RESPONSE_FAILED_NETWORK
 
     def _check_snapshot_status(self) -> BackupServiceState:
         try:
             return self.get_snapshot_status(self._request("GET", "/_snapshot/_status"))
-        except (ValueError, OpenSearchHttpError, requests.HTTPError):
+        except OpenSearchHttpError:
             return BackupServiceState.RESPONSE_FAILED_NETWORK
 
     def _get_endpoint_protocol(self, endpoint: str) -> str:

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -21,6 +21,7 @@ from charms.opensearch.v0.constants_charm import (
     COSUser,
     PeerRelationName,
     PluginConfigChangeError,
+    PluginConfigStart,
     RequestUnitServiceOps,
     SecurityIndexInitProgress,
     ServiceIsStopping,
@@ -101,7 +102,7 @@ from ops.charm import (
     UpdateStatusEvent,
 )
 from ops.framework import EventBase, EventSource
-from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
+from ops.model import BlockedStatus, MaintenanceStatus, WaitingStatus
 
 # The unique Charmhub library identifier, never change it
 LIBID = "cba015bae34642baa1b6bb27bb35a2f7"
@@ -495,6 +496,7 @@ class OpenSearchBaseCharm(CharmBase):
             event.defer()
             return
 
+        self.status.set(MaintenanceStatus(PluginConfigStart))
         try:
             if self.plugin_manager.run():
                 self.on[self.service_manager.name].acquire_lock.emit(
@@ -508,7 +510,8 @@ class OpenSearchBaseCharm(CharmBase):
             self.status.set(BlockedStatus(PluginConfigChangeError))
             event.defer()
             return
-        self.status.set(ActiveStatus())
+        self.status.clear(PluginConfigChangeError)
+        self.status.clear(PluginConfigStart)
 
     def _on_set_password_action(self, event: ActionEvent):
         """Set new admin password from user input or generate if not passed."""

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -500,13 +500,12 @@ class OpenSearchBaseCharm(CharmBase):
                 self.on[self.service_manager.name].acquire_lock.emit(
                     callback_override="_restart_opensearch"
                 )
-        except OpenSearchPluginError as e:
-            logger.exception(e)
-            if isinstance(e, OpenSearchPluginRelationClusterNotReadyError):
-                logger.warn("Plugin management: cluster not ready yet at config changed")
-            else:
-                # There was an unexpected error, log it and block the unit
-                self.status.set(BlockedStatus(PluginConfigChangeError))
+        except OpenSearchPluginRelationClusterNotReadyError:
+            logger.warning("Plugin management: cluster not ready yet at config changed")
+            event.defer()
+            return
+        except OpenSearchPluginError:
+            self.status.set(BlockedStatus(PluginConfigChangeError))
             event.defer()
             return
         self.status.set(ActiveStatus())

--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -208,7 +208,6 @@ class OpenSearchDistribution(ABC):
         Raises:
             ValueError if method or endpoint are missing
             OpenSearchHttpError if hosts are unreachable
-            requests.HTTPError if connection to opensearch fails
         """
 
         def full_urls() -> List[str]:

--- a/lib/charms/opensearch/v0/opensearch_plugin_manager.py
+++ b/lib/charms/opensearch/v0/opensearch_plugin_manager.py
@@ -209,20 +209,6 @@ class OpenSearchPluginManager:
 
         return self._install_plugin(plugin)
 
-    def configure(self, plugin: OpenSearchPlugin) -> bool:
-        """Configures a given plugin without checks."""
-        try:
-            return self._apply_config(plugin.config())
-        except KeyError as e:
-            raise OpenSearchPluginMissingConfigError(e)
-
-    def disable(self, plugin: OpenSearchPlugin) -> bool:
-        """Disables a given plugin without checks."""
-        try:
-            return self._apply_config(plugin.disable())
-        except KeyError as e:
-            raise OpenSearchPluginMissingConfigError(e)
-
     def _configure_if_needed(self, plugin: OpenSearchPlugin) -> bool:
         """Gathers all the configuration changes needed and applies them."""
         try:
@@ -233,7 +219,7 @@ class OpenSearchPluginManager:
                 # Leave this method if either user did not request to enable this plugin
                 # or plugin has been already enabled.
                 return False
-            return self._apply_config(plugin.config())
+            return self.apply_config(plugin.config())
         except KeyError as e:
             raise OpenSearchPluginMissingConfigError(e)
 
@@ -248,11 +234,11 @@ class OpenSearchPluginManager:
                 # represents a plugin that has been installed but either not yet configured
                 # or user explicitly disabled.
                 return False
-            return self._apply_config(plugin.disable())
+            return self.apply_config(plugin.disable())
         except KeyError as e:
             raise OpenSearchPluginMissingConfigError(e)
 
-    def _apply_config(self, config: OpenSearchPluginConfig) -> bool:
+    def apply_config(self, config: OpenSearchPluginConfig) -> bool:
         """Runs the configuration changes as passed via OpenSearchPluginConfig.
 
         For each: configuration and secret

--- a/lib/charms/opensearch/v0/opensearch_plugin_manager.py
+++ b/lib/charms/opensearch/v0/opensearch_plugin_manager.py
@@ -209,6 +209,20 @@ class OpenSearchPluginManager:
 
         return self._install_plugin(plugin)
 
+    def configure(self, plugin: OpenSearchPlugin) -> bool:
+        """Configures a given plugin without checks."""
+        try:
+            return self._apply_config(plugin.config())
+        except KeyError as e:
+            raise OpenSearchPluginMissingConfigError(e)
+
+    def disable(self, plugin: OpenSearchPlugin) -> bool:
+        """Disables a given plugin without checks."""
+        try:
+            return self._apply_config(plugin.disable())
+        except KeyError as e:
+            raise OpenSearchPluginMissingConfigError(e)
+
     def _configure_if_needed(self, plugin: OpenSearchPlugin) -> bool:
         """Gathers all the configuration changes needed and applies them."""
         try:

--- a/tests/integration/ha/continuous_writes.py
+++ b/tests/integration/ha/continuous_writes.py
@@ -134,19 +134,12 @@ class ContinuousWrites:
     async def _create_fully_replicated_index(self):
         """Create index with 1 p_shard and an r_shard on each node."""
         client = await self._client()
-        units = await get_application_unit_ips(self._ops_test, app=self._app)
-
         try:
             # create index with a replica shard on every node
             client.indices.create(
                 index=ContinuousWrites.INDEX_NAME,
                 body={
-                    "settings": {
-                        "index": {
-                            "number_of_shards": len(units) - 1,
-                            "auto_expand_replicas": "1-all",
-                        }
-                    }
+                    "settings": {"index": {"number_of_shards": 2, "auto_expand_replicas": "1-all"}}
                 },
             )
         finally:

--- a/tests/integration/ha/continuous_writes.py
+++ b/tests/integration/ha/continuous_writes.py
@@ -39,13 +39,14 @@ class ContinuousWrites:
     LAST_WRITTEN_VAL_PATH = "last_written_value"
     CERT_PATH = "/tmp/ca_chain.cert"
 
-    def __init__(self, ops_test: OpsTest, app: str):
+    def __init__(self, ops_test: OpsTest, app: str, initial_count: int = 0):
         self._ops_test = ops_test
         self._app = app
         self._is_stopped = True
         self._event = None
         self._queue = None
         self._process = None
+        self._initial_count = initial_count
 
     @retry(
         wait=wait_fixed(wait=5) + wait_random(0, 5),
@@ -186,7 +187,7 @@ class ContinuousWrites:
         self._process = Process(
             target=ContinuousWrites._run_async,
             name="continuous_writes",
-            args=(self._event, self._queue, 0, True),
+            args=(self._event, self._queue, self._initial_count, True),
         )
 
     def _stop_process(self):

--- a/tests/integration/ha/continuous_writes.py
+++ b/tests/integration/ha/continuous_writes.py
@@ -133,12 +133,19 @@ class ContinuousWrites:
     async def _create_fully_replicated_index(self):
         """Create index with 1 p_shard and an r_shard on each node."""
         client = await self._client()
+        units = await get_application_unit_ips(self._ops_test, app=self._app)
+
         try:
             # create index with a replica shard on every node
             client.indices.create(
                 index=ContinuousWrites.INDEX_NAME,
                 body={
-                    "settings": {"index": {"number_of_shards": 2, "auto_expand_replicas": "1-all"}}
+                    "settings": {
+                        "index": {
+                            "number_of_shards": len(units) - 1,
+                            "auto_expand_replicas": "1-all",
+                        }
+                    }
                 },
             )
         finally:

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -456,8 +456,8 @@ async def wait_backup_finish(ops_test, leader_id):
             if action.status == "completed" and len(backups) > 0:
                 logger.debug(f"list-backups output: {action}")
                 return
-            else:
-                raise Exception("Backup not finished yet")
+
+            raise Exception("Backup not finished yet")
 
 
 async def wait_restore_finish(ops_test, unit_ip):
@@ -474,7 +474,6 @@ async def wait_restore_finish(ops_test, unit_ip):
                 for shard in info["shards"]:
                     if shard["type"] == "SNAPSHOT" and shard["stage"] != "DONE":
                         raise Exception()
-            return
 
 
 async def continuous_writes_increases(ops_test: OpsTest, unit_ip: str, app: str) -> bool:

--- a/tests/integration/ha/helpers_data.py
+++ b/tests/integration/ha/helpers_data.py
@@ -249,7 +249,7 @@ async def search(
             return resp["hits"]["hits"]
 
 
-async def index_count(
+async def index_docs_count(
     ops_test: OpsTest,
     app: str,
     unit_ip: str,

--- a/tests/integration/ha/helpers_data.py
+++ b/tests/integration/ha/helpers_data.py
@@ -247,3 +247,22 @@ async def search(
         with attempt:  # Raises RetryError if failed after "retries"
             resp = await http_request(ops_test, "GET", endpoint, payload=query, app=app)
             return resp["hits"]["hits"]
+
+
+async def index_count(
+    ops_test: OpsTest,
+    app: str,
+    unit_ip: str,
+    index_name: str,
+    retries: int = 15,
+) -> int:
+    """Returns the number of documents in an index."""
+    endpoint = f"https://{unit_ip}:9200/{index_name}/_count"
+    for attempt in Retrying(
+        stop=stop_after_attempt(retries), wait=wait_fixed(wait=5) + wait_random(0, 5)
+    ):
+        with attempt:  # Raises RetryError if failed after "retries"
+            resp = await http_request(ops_test, "GET", endpoint, app=app)
+            if isinstance(resp["count"], int):
+                return resp["count"]
+            return int(resp["count"])

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -156,7 +156,7 @@ def microceph():
                 "-c",
                 "latest/edge",
                 "-d",
-                "/dev/sdf",
+                "/dev/sdi",
                 "-a",
                 "accesskey",
                 "-s",
@@ -370,14 +370,9 @@ async def test_02_restore_cluster(ops_test: OpsTest) -> None:
     """Deletes the TEST_BACKUP_INDEX, restores the cluster and tries to search for index."""
     app = (await app_name(ops_test)) or APP_NAME
     leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
-    # We delete the series index from c_writes
-    # The idea is to ensure we will have data after restore
-    await http_request(
-        ops_test,
-        "DELETE",
-        f"https://{leader_unit_ip}:9200/{ContinuousWrites.INDEX_NAME}",
-        app=app,
-    )
+    import pdb
+
+    pdb.set_trace()
     await _restore_cluster(ops_test)
     # Count the number of docs in the index
     count = await index_count(ops_test, app, leader_unit_ip, ContinuousWrites.INDEX_NAME)
@@ -413,14 +408,14 @@ async def test_03_restore_cluster_after_app_destroyed(
 
     app = (await app_name(ops_test)) or APP_NAME
     leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
-    # We delete the series index from c_writes
-    # The idea is to ensure we will have data after restore
-    await http_request(
-        ops_test,
-        "DELETE",
-        f"https://{leader_unit_ip}:9200/{ContinuousWrites.INDEX_NAME}",
-        app=app,
-    )
+    # # We delete the series index from c_writes
+    # # The idea is to ensure we will have data after restore
+    # await http_request(
+    #     ops_test,
+    #     "DELETE",
+    #     f"https://{leader_unit_ip}:9200/{ContinuousWrites.INDEX_NAME}",
+    #     app=app,
+    # )
     await _restore_cluster(ops_test)
     # Count the number of docs in the index
     count = await index_count(ops_test, app, leader_unit_ip, ContinuousWrites.INDEX_NAME)
@@ -457,14 +452,14 @@ async def test_04_remove_and_readd_s3_relation(ops_test: OpsTest) -> None:
     await _backup_cluster(ops_test)
     app = (await app_name(ops_test)) or APP_NAME
     leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
-    # We delete the series index from c_writes
-    # The idea is to ensure we will have data after restore
-    await http_request(
-        ops_test,
-        "DELETE",
-        f"https://{leader_unit_ip}:9200/{ContinuousWrites.INDEX_NAME}",
-        app=app,
-    )
+    # # We delete the series index from c_writes
+    # # The idea is to ensure we will have data after restore
+    # await http_request(
+    #     ops_test,
+    #     "DELETE",
+    #     f"https://{leader_unit_ip}:9200/{ContinuousWrites.INDEX_NAME}",
+    #     app=app,
+    # )
     await _restore_cluster(ops_test)
     # Count the number of docs in the index
     count = await index_count(ops_test, app, leader_unit_ip, ContinuousWrites.INDEX_NAME)

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -370,9 +370,6 @@ async def test_02_restore_cluster(ops_test: OpsTest) -> None:
     """Deletes the TEST_BACKUP_INDEX, restores the cluster and tries to search for index."""
     app = (await app_name(ops_test)) or APP_NAME
     leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
-    import pdb
-
-    pdb.set_trace()
     await _restore_cluster(ops_test)
     # Count the number of docs in the index
     count = await index_count(ops_test, app, leader_unit_ip, ContinuousWrites.INDEX_NAME)

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -148,7 +148,7 @@ def microceph():
                 "-c",
                 "latest/edge",
                 "-d",
-                "/dev/sdd",
+                "/dev/sdc",
                 "-a",
                 "accesskey",
                 "-s",
@@ -261,7 +261,6 @@ async def test_restore_cluster_after_app_destroyed(ops_test: OpsTest) -> None:
     Restores the backup and then checks if the same TEST_BACKUP_INDEX is there.
     """
     app = (await app_name(ops_test)) or APP_NAME
-    leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
 
     logging.info("Destroying the application")
     await ops_test.model.remove_application(app, block_until_done=True)
@@ -282,6 +281,7 @@ async def test_restore_cluster_after_app_destroyed(ops_test: OpsTest) -> None:
     )
 
     leader_id = await get_leader_unit_id(ops_test)
+    leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
     assert await restore_cluster(
         ops_test,
         1,  # backup_id

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -392,7 +392,7 @@ async def test_03_restore_cluster_after_app_destroyed(
                 preference="_only_local",
             )
             # Validate the index and document are present
-            assert len(docs) == 1
+            assert len(docs) == 2
             assert docs[0]["_source"] == default_doc(TEST_BACKUP_INDEX, doc_id)
 
 
@@ -444,5 +444,5 @@ async def test_04_remove_and_readd_s3_relation(ops_test: OpsTest) -> None:
                 preference="_only_local",
             )
             # Validate the index and document are present
-            assert len(docs) == 1
+            assert len(docs) == 3
             assert docs[0]["_source"] == default_doc(TEST_BACKUP_INDEX, doc_id)

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -7,12 +7,14 @@ import json
 import logging
 import os
 import random
+import subprocess
 import time
 
 # from pathlib import Path
 #
 # import boto3
 import pytest
+import requests
 from pytest_operator.plugin import OpsTest
 from tenacity import Retrying, stop_after_attempt, wait_fixed
 
@@ -133,13 +135,7 @@ async def c_writes_runner(ops_test: OpsTest, c_writes: ContinuousWrites):
 @pytest.fixture(scope="session")
 def microceph():
     """Starts microceph radosgw."""
-    import subprocess
-
     if "microceph" not in subprocess.check_output(["sudo", "snap", "list"]).decode():
-        import os
-
-        import requests
-
         uceph = "/tmp/microceph.sh"
 
         with open(uceph, "w") as f:

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -148,7 +148,7 @@ def microceph():
                 "-c",
                 "latest/edge",
                 "-d",
-                "/dev/sdi",
+                "/dev/sdd",
                 "-a",
                 "accesskey",
                 "-s",

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -255,16 +255,12 @@ async def test_restore_cluster(ops_test: OpsTest) -> None:
 
 
 @pytest.mark.abort_on_fail
-async def test_restore_cluster_after_app_destroyed(
-    ops_test: OpsTest,
-) -> None:
+async def test_restore_cluster_after_app_destroyed(ops_test: OpsTest) -> None:
     """Deletes the entire OpenSearch cluster and redeploys from scratch.
 
     Restores the backup and then checks if the same TEST_BACKUP_INDEX is there.
     """
     app = (await app_name(ops_test)) or APP_NAME
-    leader_id = await get_leader_unit_id(ops_test)
-    unit_ip = await get_leader_unit_ip(ops_test)
     leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
 
     logging.info("Destroying the application")
@@ -285,6 +281,7 @@ async def test_restore_cluster_after_app_destroyed(
         idle_period=IDLE_PERIOD,
     )
 
+    leader_id = await get_leader_unit_id(ops_test)
     assert await restore_cluster(
         ops_test,
         1,  # backup_id
@@ -293,7 +290,7 @@ async def test_restore_cluster_after_app_destroyed(
     # Count the number of docs in the index
     count = await index_docs_count(ops_test, app, leader_unit_ip, ContinuousWrites.INDEX_NAME)
     assert count > 0
-    await continuous_writes_increases(ops_test, unit_ip, app)
+    await continuous_writes_increases(ops_test, leader_unit_ip, app)
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -148,7 +148,7 @@ def microceph():
                 "-c",
                 "latest/edge",
                 "-d",
-                "/dev/sdi",
+                "/dev/sdc",
                 "-a",
                 "accesskey",
                 "-s",

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -226,13 +226,12 @@ async def test_backup_cluster(
     ops_test: OpsTest, c_writes: ContinuousWrites, c_writes_runner
 ) -> None:
     """Runs the backup process whilst writing to the cluster into 'noisy-index'."""
-    unit_ip = await get_leader_unit_ip(ops_test)
     app = (await app_name(ops_test)) or APP_NAME
+    leader_id = await get_leader_unit_id(ops_test)
 
     assert await backup_cluster(
         ops_test,
-        unit_ip,
-        app,
+        leader_id,
     )
     # continuous writes checks
     await assert_continuous_writes_consistency(ops_test, c_writes, app)
@@ -327,8 +326,7 @@ async def test_remove_and_readd_s3_relation(ops_test: OpsTest) -> None:
 
     assert await backup_cluster(
         ops_test,
-        unit_ip,
-        app,
+        leader_id,
     )
     assert await restore_cluster(
         ops_test,

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -148,7 +148,7 @@ def microceph():
                 "-c",
                 "latest/edge",
                 "-d",
-                "/dev/sdc",
+                "/dev/sdi",
                 "-a",
                 "accesskey",
                 "-s",
@@ -247,6 +247,7 @@ async def test_restore_cluster(ops_test: OpsTest) -> None:
     assert await restore_cluster(
         ops_test,
         1,  # backup_id
+        unit_ip,
         leader_id,
     )
     count = await index_docs_count(ops_test, app, unit_ip, ContinuousWrites.INDEX_NAME)
@@ -285,6 +286,7 @@ async def test_restore_cluster_after_app_destroyed(ops_test: OpsTest) -> None:
     assert await restore_cluster(
         ops_test,
         1,  # backup_id
+        leader_unit_ip,
         leader_id,
     )
     # Count the number of docs in the index
@@ -328,6 +330,7 @@ async def test_remove_and_readd_s3_relation(ops_test: OpsTest) -> None:
     assert await restore_cluster(
         ops_test,
         1,  # backup_id
+        unit_ip,
         leader_id,
     )
     count = await index_docs_count(ops_test, app, unit_ip, ContinuousWrites.INDEX_NAME)

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -342,7 +342,9 @@ async def test_backup_cluster(
 
 
 @pytest.mark.abort_on_fail
-async def test_restore_cluster(ops_test: OpsTest, c_writes: ContinuousWrites) -> None:
+async def test_restore_cluster(
+    ops_test: OpsTest, c_writes: ContinuousWrites, c_writes_runner
+) -> None:
     """Deletes the TEST_BACKUP_INDEX, restores the cluster and tries to search for index."""
     await _restore_cluster(ops_test)
 

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -16,20 +16,23 @@ import requests
 from pytest_operator.plugin import OpsTest
 
 from tests.integration.ha.continuous_writes import ContinuousWrites
-from tests.integration.ha.helpers import app_name, assert_continuous_writes_consistency
+from tests.integration.ha.helpers import (
+    app_name,
+    assert_continuous_writes_consistency,
+    backup_cluster,
+    continuous_writes_increases,
+    restore_cluster,
+)
 from tests.integration.ha.helpers_data import index_docs_count
 from tests.integration.ha.test_horizontal_scaling import IDLE_PERIOD
 from tests.integration.helpers import (
     APP_NAME,
     MODEL_CONFIG,
     SERIES,
-    backup_cluster,
-    continuous_writes_increases,
     get_leader_unit_id,
     get_leader_unit_ip,
     get_reachable_unit_ips,
     http_request,
-    restore_cluster,
     run_action,
 )
 from tests.integration.tls.test_tls import TLS_CERTIFICATES_APP_NAME

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -354,7 +354,7 @@ async def test_restore_cluster(ops_test: OpsTest, c_writes: ContinuousWrites) ->
 
 @pytest.mark.abort_on_fail
 async def test_restore_cluster_after_app_destroyed(
-    ops_test: OpsTest, c_writes, c_writes_runner
+    ops_test: OpsTest,
 ) -> None:
     """Deletes the entire OpenSearch cluster and redeploys from scratch.
 
@@ -379,12 +379,13 @@ async def test_restore_cluster_after_app_destroyed(
     )
     # This is the same check as the previous restore action.
     # Call the method again
+    app = (await app_name(ops_test)) or APP_NAME
     await _restore_cluster(ops_test)
     await _restart_writes_and_assert(ops_test, app)
 
 
 @pytest.mark.abort_on_fail
-async def test_remove_and_readd_s3_relation(ops_test: OpsTest, c_writes) -> None:
+async def test_remove_and_readd_s3_relation(ops_test: OpsTest) -> None:
     """Removes and re-adds the s3-credentials relation to test backup and restore."""
     logger.info("Remove s3-credentials relation")
     # Remove relation
@@ -411,4 +412,5 @@ async def test_remove_and_readd_s3_relation(ops_test: OpsTest, c_writes) -> None
     # Backup should generate a new backup id
     await _backup_cluster(ops_test)
     await _restore_cluster(ops_test)
+    app = (await app_name(ops_test)) or APP_NAME
     await _restart_writes_and_assert(ops_test, app)

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -322,7 +322,7 @@ async def test_build_and_deploy(
     tls_config = {"generate-self-signed-certificates": "true", "ca-common-name": "CN_CA"}
 
     # Convert to integer as environ always returns string
-    app_num_units = int(os.environ.get("TEST_NUM_APP_UNITS", None) or 2)
+    app_num_units = 3
 
     await asyncio.gather(
         ops_test.model.deploy(TLS_CERTIFICATES_APP_NAME, channel="stable", config=tls_config),
@@ -387,7 +387,7 @@ async def test_03_restore_cluster_after_app_destroyed(
     """
     app = (await app_name(ops_test)) or APP_NAME
     await ops_test.model.remove_application(app, block_until_done=True)
-    app_num_units = int(os.environ.get("TEST_NUM_APP_UNITS", None) or 2)
+    app_num_units = 3
     my_charm = await ops_test.build_charm(".")
     # Redeploy
     await asyncio.gather(

--- a/tests/unit/lib/test_backups.py
+++ b/tests/unit/lib/test_backups.py
@@ -269,11 +269,7 @@ def test_restore_finished_true(harness, mock_request, leader, request_value, res
                 "index2": {"status": IndexStateEnum.OPEN},
                 "index3": {"status": IndexStateEnum.OPEN},
             },
-            {
-                "acknowledged": True,
-                "shards_acknowledged": True,
-                "indices": {}
-            },
+            {"acknowledged": True, "shards_acknowledged": True, "indices": {}},
             True,
         ),
         # Represents an error where request failed
@@ -307,10 +303,7 @@ def test_close_indices_if_needed(
         idx = {
             i
             for i in list_backup_response[1]["indices"]
-            if (
-                i in cluster_state.keys()
-                and cluster_state[i]["status"] != IndexStateEnum.CLOSED
-            )
+            if (i in cluster_state.keys() and cluster_state[i]["status"] != IndexStateEnum.CLOSED)
         }
         mock_request.assert_called_with(
             "POST",

--- a/tests/unit/lib/test_backups.py
+++ b/tests/unit/lib/test_backups.py
@@ -183,10 +183,10 @@ def test_restore_finished_true(harness, mock_request, leader, request_value, res
                 "shards_acknowledged": True,
                 "indices": {
                     "index1": {
-                        "closed": "true",
+                        "closed": True,
                     },
                     "index2": {
-                        "closed": "true",
+                        "closed": True,
                     },
                 },  # represents the closed indices
             },
@@ -208,10 +208,10 @@ def test_restore_finished_true(harness, mock_request, leader, request_value, res
                 "shards_acknowledged": True,
                 "indices": {
                     "index1": {
-                        "closed": "true",
+                        "closed": True,
                     },
                     "index2": {
-                        "closed": "true",
+                        "closed": True,
                     },
                 },  # represents the closed indices
             },
@@ -233,7 +233,7 @@ def test_restore_finished_true(harness, mock_request, leader, request_value, res
                 "shards_acknowledged": True,
                 "indices": {
                     "index1": {
-                        "closed": "true",
+                        "closed": True,
                     },
                 },  # represents the closed indices
             },
@@ -252,10 +252,10 @@ def test_restore_finished_true(harness, mock_request, leader, request_value, res
                 "shards_acknowledged": True,
                 "indices": {
                     "index1": {
-                        "closed": "true",
+                        "closed": True,
                     },
                     "index2": {
-                        "closed": "false",
+                        "closed": False,
                     },
                 },  # represents the closed indices
             },

--- a/tests/unit/lib/test_backups.py
+++ b/tests/unit/lib/test_backups.py
@@ -267,11 +267,16 @@ class TestBackups(unittest.TestCase):
         result = self.charm.backup._check_if_restore_finished()
         self.assertTrue(result)
 
-    def test_restore_finished_empty_restore_in_progress(self):
+    @patch("charms.opensearch.v0.opensearch_backups.OpenSearchBackup._request")
+    def test_restore_finished_empty_restore_in_progress(self, mock_request):
         class RelationData:
             def __init__(self, app):
-                self.data = {app: {"restore_in_progress": ""}}
+                self.data = {app: {}}
 
+        mock_request.return_value = {
+            "index1": {"shards": [{"type": "SNAPSHOT", "stage": "DONE"}]},
+            "index2": {"shards": [{"type": "SNAPSHOT", "stage": "DONE"}]},
+        }
         self.charm.backup.model.get_relation = MagicMock(return_value=RelationData(self.charm.app))
         result = self.charm.backup._check_if_restore_finished()
         self.assertTrue(result)

--- a/tests/unit/lib/test_opensearch_base_charm.py
+++ b/tests/unit/lib/test_opensearch_base_charm.py
@@ -202,7 +202,7 @@ class TestOpenSearchBaseCharm(unittest.TestCase):
             self.assertTrue(self.peers_data.get(Scope.APP, "security_index_initialised"))
 
     @patch(f"{BASE_LIB_PATH}.opensearch_backups.OpenSearchBackup.is_backup_in_progress")
-    @patch(f"{BASE_LIB_PATH}.opensearch_backups.OpenSearchBackup._check_if_restore_finished")
+    @patch(f"{BASE_LIB_PATH}.opensearch_backups.OpenSearchBackup._is_restore_complete")
     @patch(f"{BASE_CHARM_CLASS}._stop_opensearch")
     @patch(f"{BASE_LIB_PATH}.opensearch_base_charm.cert_expiration_remaining_hours")
     @patch(f"{BASE_LIB_PATH}.opensearch_users.OpenSearchUserManager.remove_users_and_roles")

--- a/tests/unit/lib/test_opensearch_base_charm.py
+++ b/tests/unit/lib/test_opensearch_base_charm.py
@@ -201,10 +201,12 @@ class TestOpenSearchBaseCharm(unittest.TestCase):
             _initialize_security_index.assert_called_once()
             self.assertTrue(self.peers_data.get(Scope.APP, "security_index_initialised"))
 
+    @patch(f"{BASE_LIB_PATH}.opensearch_backups.OpenSearchBackup.is_backup_in_progress")
+    @patch(f"{BASE_LIB_PATH}.opensearch_backups.OpenSearchBackup._check_if_restore_finished")
     @patch(f"{BASE_CHARM_CLASS}._stop_opensearch")
     @patch(f"{BASE_LIB_PATH}.opensearch_base_charm.cert_expiration_remaining_hours")
     @patch(f"{BASE_LIB_PATH}.opensearch_users.OpenSearchUserManager.remove_users_and_roles")
-    def test_on_update_status(self, _, cert_expiration_remaining_hours, _stop_opensearch):
+    def test_on_update_status(self, _, cert_expiration_remaining_hours, _stop_opensearch, __, ___):
         """Test on update status."""
         with patch(
             f"{self.OPENSEARCH_DISTRO}.missing_sys_requirements"


### PR DESCRIPTION
[DPE-3243](https://warthogs.atlassian.net/browse/DPE-3243): list-backups now contains only relevant information, in this case the backup-id and its status; the PR removes the "backup-type" column, as it has no meaning in OpenSearch

[DPE-3246](https://warthogs.atlassian.net/browse/DPE-3246): backups will be async and restores will be synchronous. Users can follow the restore in the juju status. In any case, the indices that are being restored will be closed, so the user needs to wait.

[DPE-3243]: https://warthogs.atlassian.net/browse/DPE-3243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DPE-3246]: https://warthogs.atlassian.net/browse/DPE-3246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DPE-3192]: https://warthogs.atlassian.net/browse/DPE-3192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ