### PR TITLE
Remove s3-repo at relation broken and fix status clearing in backup

### DIFF
--- a/lib/charms/opensearch/v0/constants_charm.py
+++ b/lib/charms/opensearch/v0/constants_charm.py
@@ -72,6 +72,8 @@ WaitingForOtherUnitServiceOps = "Waiting for other units to complete the ops on 
 NewIndexRequested = "new index {index} requested"
 RestoreInProgress = "Restore in progress..."
 PluginConfigStart = "Plugin configuration started."
+BackupServiceSettingUp = "Setting up backup service: {}"
+BackupDisablingInProgress = "Disabling backup service: {}"
 
 
 # Relation Interfaces


### PR DESCRIPTION
Messages in `credentials-changed` and `s3-relation-broken` are not getting properly cleared. This PR fixes by using constant messages.

It also adds logic to remove the s3 repo from opensearch once `s3-broken` happens.