### PR TITLE
[DPE-3573][DPE-3579] Fix #164 - check _cluster/settings instead of opensearch.yml for plugins

### DIFF
--- a/lib/charms/opensearch/v0/helper_cluster.py
+++ b/lib/charms/opensearch/v0/helper_cluster.py
@@ -58,6 +58,23 @@ class ClusterTopology:
         return base_roles + ["cluster_manager"]
 
     @staticmethod
+    def get_cluster_settings(
+        opensearch: OpenSearchDistribution,
+        host: Optional[str] = None,
+        alt_hosts: Optional[List[str]] = None,
+        include_defaults: bool = False,
+    ) -> Dict[str, any]:
+        """Get the cluster settings."""
+        settings = opensearch.request(
+            "GET",
+            f"/_cluster/settings?flat_settings=true&include_defaults={str(include_defaults).lower()}",
+            host=host,
+            alt_hosts=alt_hosts,
+        )
+
+        return dict(settings["defaults"] | settings["persistent"] | settings["transient"])
+
+    @staticmethod
     def recompute_nodes_conf(app_name: str, nodes: List[Node]) -> Dict[str, Node]:
         """Recompute the configuration of all the nodes (cluster set to auto-generate roles)."""
         # in case the cluster nodes' roles were previously "manually generated" - we need

--- a/lib/charms/opensearch/v0/opensearch_relation_provider.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_provider.py
@@ -328,18 +328,18 @@ class OpenSearchProvider(Object):
         """
         if not self.unit.is_leader():
             # We're updating app databags in this function, so it can't be called on follower
-            # units.
+            # units. This is not checked in `set_tls_ca`, in data-interfaces.
             return
-        if not ca_chain:
-            try:
-                ca_chain = self.charm.secrets.get_object(Scope.APP, CertType.APP_ADMIN.val).get(
-                    "chain"
-                )
-            except AttributeError:
-                # cert doesn't exist - presumably we don't yet have a TLS relation.
-                return
-
-        self.opensearch_provides.set_tls_ca(relation_id, ca_chain)
+        try:
+            # If the ca_chain=None, then we try to load the CA from the app-admin secret.
+            _ch_chain = ca_chain or self.charm.secrets.get_object(
+                Scope.APP, CertType.APP_ADMIN.val
+            ).get("chain")
+        except AttributeError:
+            # cert doesn't exist - presumably we don't yet have a TLS relation.
+            logger.warning("unable to get ca_chain")
+            return
+        self.opensearch_provides.set_tls_ca(relation_id, _ch_chain)
 
     def _on_relation_changed(self, event: RelationChangedEvent) -> None:
         if not self.unit.is_leader():

--- a/tests/integration/ha/test_large_deployments.py
+++ b/tests/integration/ha/test_large_deployments.py
@@ -120,6 +120,8 @@ async def test_set_roles_manually(
         assert node.temperature is None, "Node temperature was erroneously set."
 
     # change cluster name and roles + temperature, should trigger a rolling restart
+
+    logger.info("Changing cluster name and roles + temperature.")
     await ops_test.model.applications[app].set_config(
         {"cluster_name": "new_cluster_name", "roles": "cluster_manager, data.cold"}
     )
@@ -131,6 +133,8 @@ async def test_set_roles_manually(
         wait_for_exact_units=len(nodes),
         idle_period=IDLE_PERIOD,
     )
+
+    logger.info("Checking if the cluster name and roles + temperature were changed.")
     assert await check_cluster_formation_successful(
         ops_test, leader_unit_ip, get_application_unit_names(ops_test, app=app)
     )

--- a/tests/unit/lib/test_ml_plugins.py
+++ b/tests/unit/lib/test_ml_plugins.py
@@ -54,7 +54,12 @@ class TestOpenSearchKNN(unittest.TestCase):
         }
         self.charm.opensearch.is_started = MagicMock(return_value=True)
         self.charm.health.apply = MagicMock(return_value=HealthColors.GREEN)
+        self.plugin_manager._is_cluster_ready = MagicMock(return_value=True)
+        charms.opensearch.v0.helper_cluster.ClusterTopology.get_cluster_settings = MagicMock(
+            return_value={}
+        )
 
+    @patch(f"{BASE_LIB_PATH}.opensearch_distro.OpenSearchDistribution.is_node_up")
     @patch(
         f"{BASE_LIB_PATH}.opensearch_peer_clusters.OpenSearchPeerClustersManager.deployment_desc"
     )
@@ -78,6 +83,7 @@ class TestOpenSearchKNN(unittest.TestCase):
         mock_version,
         mock_acquire_lock,
         ___,
+        mock_is_node_up,
     ) -> None:
         """Tests entire config_changed event with KNN plugin."""
         mock_status.return_value = PluginState.ENABLED
@@ -89,12 +95,12 @@ class TestOpenSearchKNN(unittest.TestCase):
         self.plugin_manager._opensearch_config.delete_plugin = MagicMock()
         self.plugin_manager._opensearch_config.add_plugin = MagicMock()
         self.charm.status = MagicMock()
+        mock_is_node_up.return_value = True
+        self.charm._get_nodes = MagicMock(return_value=[1])
+        self.charm.planned_units = MagicMock(return_value=1)
 
         self.harness.update_config({"plugin_opensearch_knn": False})
         mock_acquire_lock.assert_called_once()
-        self.plugin_manager._opensearch_config.delete_plugin.assert_called_once_with(
-            {"knn.plugin.enabled": True}
-        )
         self.plugin_manager._opensearch_config.add_plugin.assert_called_once_with(
-            {"knn.plugin.enabled": False}
+            {"knn.plugin.enabled": "false"}
         )


### PR DESCRIPTION
Adds a GET /_cluster/settings, which returns the configuration of the cluster at the moment, including defaults. This way, plugins can check if they should add their configs and request a restart during the start cycle of the charm.

The `_is_enabled` is also extended to use the cluster settings instead of checking the configuration files directly. 

Moved `OpenSearchPluginConfig` to extend `pydantic.BaseModel`. It ensures that configuration is translated to `Dict[str, str]`, in special the boolean value, that must have a format of: `true` or `false`.

Also closes [DPE-3579](https://warthogs.atlassian.net/browse/DPE-3579): move the plugin settings status to use the charm's `status.{set,clear}` APIs.

[DPE-3579]: https://warthogs.atlassian.net/browse/DPE-3579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ