### PR TITLE
[DPE-3660] Add backups testing infra

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -58,8 +58,8 @@ restore:
     S3 credentials are retrieved from a relation with the S3 integrator charm.
   params:
     backup-id:
-      type: integer
+      type: string
       description: |
-        A backup-id to identify the backup to restore. Format: backup-id=<integer>.
+        A backup-id to identify the backup to restore. Format: backup-id=<string>.
   required:
     - backup-id

--- a/actions.yaml
+++ b/actions.yaml
@@ -58,8 +58,8 @@ restore:
     S3 credentials are retrieved from a relation with the S3 integrator charm.
   params:
     backup-id:
-      type: string
+      type: integer
       description: |
-        A backup-id to identify the backup to restore. Format: backup-id=<string>.
+        A backup-id to identify the backup to restore. Format: backup-id=<integer>.
   required:
     - backup-id

--- a/lib/charms/opensearch/v0/opensearch_backups.py
+++ b/lib/charms/opensearch/v0/opensearch_backups.py
@@ -198,7 +198,7 @@ class OpenSearchBackup(Object):
                 f"List backups action failed - {str(e)} - check the application logs for the full stack trace."
             )
         if event.params.get("output").lower() == "json":
-            event.set_results({"backups": (json.dumps(backups)).replace("_", "-")})
+            event.set_results({"backups": json.dumps(backups)})
         elif event.params.get("output").lower() == "table":
             event.set_results({"backups": self._generate_backup_list_output(backups)})
         else:
@@ -329,7 +329,7 @@ class OpenSearchBackup(Object):
             event.fail("Failed: previous restore is still in progress")
             return
         # Now, validate the backup is working
-        backup_id = str(event.params.get("backup-id"))
+        backup_id = event.params.get("backup-id")
         if not self._is_backup_available_for_restore(backup_id):
             event.fail(f"Failed: no backup-id {backup_id}")
             return

--- a/lib/charms/opensearch/v0/opensearch_backups.py
+++ b/lib/charms/opensearch/v0/opensearch_backups.py
@@ -542,7 +542,7 @@ class OpenSearchBackup(Object):
             logger.error(f"Failed to setup backup service with state {state}")
             self.charm.status.set(BlockedStatus(BackupSetupFailed), app=True)
             return
-        self.charm.status.clear(BackupSetupFailed)
+        self.charm.status.clear(BackupSetupFailed, app=True)
         self.charm.status.clear(BackupConfigureStart)
 
     def _on_s3_broken(self, event: EventBase) -> None:  # noqa: C901

--- a/lib/charms/opensearch/v0/opensearch_backups.py
+++ b/lib/charms/opensearch/v0/opensearch_backups.py
@@ -329,7 +329,7 @@ class OpenSearchBackup(Object):
             event.fail("Failed: previous restore is still in progress")
             return
         # Now, validate the backup is working
-        backup_id = event.params.get("backup-id")
+        backup_id = str(event.params.get("backup-id"))
         if not self._is_backup_available_for_restore(backup_id):
             event.fail(f"Failed: no backup-id {backup_id}")
             return

--- a/lib/charms/opensearch/v0/opensearch_backups.py
+++ b/lib/charms/opensearch/v0/opensearch_backups.py
@@ -540,7 +540,7 @@ class OpenSearchBackup(Object):
         #     (3) based on the response, set the message status
         if state != BackupServiceState.SUCCESS:
             logger.error(f"Failed to setup backup service with state {state}")
-            self.charm.status.set(BlockedStatus(BackupSetupFailed))
+            self.charm.status.set(BlockedStatus(BackupSetupFailed), app=True)
             return
         self.charm.status.clear(BackupSetupFailed)
         self.charm.status.clear(BackupConfigureStart)

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -9,6 +9,7 @@ import time
 from typing import Dict, List, Optional
 
 from charms.opensearch.v0.models import Node
+from charms.opensearch.v0.opensearch_backups import S3_REPOSITORY
 from pytest_operator.plugin import OpsTest
 from tenacity import (
     RetryError,
@@ -23,6 +24,7 @@ from ..helpers import (
     get_application_unit_ids,
     get_application_unit_ids_hostnames,
     get_application_unit_ids_ips,
+    get_leader_unit_ip,
     http_request,
     juju_version_major,
     run_action,
@@ -456,10 +458,11 @@ async def print_logs(ops_test: OpsTest, app: str, unit_id: int, msg: str) -> str
     return msg
 
 
-async def wait_for_backup(ops_test, leader_id):
+async def wait_for_backup_system_to_settle(ops_test, leader_id, unit_ip):
     """Waits the backup to finish and move to the finished state or throws a RetryException."""
     for attempt in Retrying(stop=stop_after_attempt(8), wait=wait_fixed(15)):
         with attempt:
+            # First, check if current backups are finished
             action = await run_action(
                 ops_test, leader_id, "list-backups", params={"output": "json"}
             )
@@ -467,17 +470,12 @@ async def wait_for_backup(ops_test, leader_id):
             # namespace(status='completed', response={'return-code': 0, 'backups': '{"1": ...}'})
             backups = json.loads(action.response["backups"])
             logger.debug(f"Backups recovered: {backups}")
-            if action.status == "completed" and len(backups) > 0:
+            if action.status != "completed" or len(backups) == 0:
+                raise Exception("Failed to retrieve backup list or list is empty")
+            else:
                 logger.debug(f"list-backups output: {action}")
-                return
 
-            raise Exception("Backup not finished yet")
-
-
-async def wait_for_restore(ops_test, unit_ip):
-    """Waits the backup to finish and move to the finished state or throws a RetryException."""
-    for attempt in Retrying(stop=stop_after_attempt(8), wait=wait_fixed(15)):
-        with attempt:
+            # Now, check if we have finished the restore
             indices_status = await http_request(
                 ops_test,
                 "GET",
@@ -487,7 +485,20 @@ async def wait_for_restore(ops_test, unit_ip):
                 # Now, check the status of each shard
                 for shard in info["shards"]:
                     if shard["type"] == "SNAPSHOT" and shard["stage"] != "DONE":
-                        raise Exception()
+                        raise Exception(f"Recovery failed for shard {shard}")
+
+            raise Exception("Backup system not settled yet")
+
+
+async def delete_backup(ops_test: OpsTest, backup_id: int) -> None:
+    """Deletes a backup."""
+    # Now, check if we have finished the restore
+    unit_ip = await get_leader_unit_ip(ops_test)
+    await http_request(
+        ops_test,
+        "DELETE",
+        f"https://{unit_ip}:9200/_snapshot/{S3_REPOSITORY}/{backup_id}",
+    )
 
 
 async def start_and_check_continuous_writes(ops_test: OpsTest, unit_ip: str, app: str) -> bool:
@@ -509,18 +520,25 @@ async def start_and_check_continuous_writes(ops_test: OpsTest, unit_ip: str, app
     return result.count > initial_count
 
 
-async def backup_cluster(ops_test: OpsTest, leader_id: int) -> str:
+async def create_backup(ops_test: OpsTest, leader_id: int, unit_ip: str) -> bool:
     """Runs the backup of the cluster."""
     action = await run_action(ops_test, leader_id, "create-backup")
     logger.debug(f"create-backup output: {action}")
 
-    await wait_for_backup(ops_test, leader_id)
-    return int(action.response["backup-id"])
+    await wait_for_backup_system_to_settle(ops_test, leader_id, unit_ip)
+    return action.status == "completed"
 
 
-async def restore_cluster(ops_test: OpsTest, backup_id: int, unit_ip: str, leader_id: int) -> bool:
+async def restore(ops_test: OpsTest, backup_id: int, unit_ip: str, leader_id: int) -> bool:
     action = await run_action(ops_test, leader_id, "restore", params={"backup-id": backup_id})
     logger.debug(f"restore output: {action}")
 
-    await wait_for_restore(ops_test, unit_ip)
+    await wait_for_backup_system_to_settle(ops_test, leader_id, unit_ip)
     return action.status == "completed"
+
+
+async def list_backups(ops_test: OpsTest, leader_id: int) -> Dict[str, str]:
+    action = await run_action(ops_test, leader_id, "list-backups", params={"output": "json"})
+    assert action.status == "completed"
+    backups = action.response["backups"]
+    return backups

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -534,7 +534,11 @@ async def create_backup(ops_test: OpsTest, leader_id: int, unit_ip: str) -> int:
 
 
 async def restore(ops_test: OpsTest, backup_id: int, unit_ip: str, leader_id: int) -> bool:
-    action = await run_action(ops_test, leader_id, "restore", params={"backup-id": backup_id})
+    """Restores a backup."""
+    id = backup_id
+    if not isinstance(backup_id, int):
+        id = int(backup_id)
+    action = await run_action(ops_test, leader_id, "restore", params={"backup-id": id})
     logger.debug(f"restore output: {action}")
 
     await wait_for_backup_system_to_settle(ops_test, leader_id, unit_ip)

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -514,8 +514,9 @@ async def start_and_check_continuous_writes(ops_test: OpsTest, unit_ip: str, app
     writer = ContinuousWrites(ops_test, app, initial_count=initial_count)
     await writer.start()
     time.sleep(10)
-    result = await writer.stop()
-    return result.count > initial_count
+    await assert_continuous_writes_consistency(ops_test, writer, app)
+    # Clear the writer manually, as we are not using the conftest c_writes_runner to do so
+    await writer.clear()
 
 
 async def create_backup(ops_test: OpsTest, leader_id: int, unit_ip: str) -> str:

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -544,19 +544,14 @@ async def list_backups(ops_test: OpsTest, leader_id: int) -> Dict[str, str]:
 
 
 async def assert_cwrites_backup_consistency(
-    ops_test: OpsTest, app: str, leader_id: int, unit_ip: str, backup_id: str, loss: float = 0.25
+    ops_test: OpsTest, app: str, leader_id: int, unit_ip: str, backup_id: str
 ) -> None:
-    """Ensures that continuous writes index has at least the value below.
-
-    assert new_count >= <current-doc-count> * (1 - loss) documents.
-    """
+    """Ensures that continuous writes index has at least the value below."""
     original_count = await index_docs_count(ops_test, app, unit_ip, ContinuousWrites.INDEX_NAME)
     # As stated on: https://discuss.elastic.co/t/how-to-parse-snapshot-dat-file/218888,
     # the only way to discover the documents in a backup is to recover it and check
     # on opensearch.
     # The logic below will run over each backup id, restore it and ensure continuous writes
-    # index loss is within the "loss" parameter.
     assert await restore(ops_test, backup_id, unit_ip, leader_id)
     new_count = await index_docs_count(ops_test, app, unit_ip, ContinuousWrites.INDEX_NAME)
-    # We expect that new_count has a loss of documents and the numbers are different.
-    assert new_count >= int(original_count * (1 - loss)) and new_count != original_count
+    assert new_count > 0 and new_count != original_count

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -566,5 +566,9 @@ async def assert_cwrites_backup_consistency(
     # index loss is within the "loss" parameter.
     assert await restore(ops_test, backup_id, unit_ip, leader_id)
     new_count = await index_docs_count(ops_test, app, unit_ip, ContinuousWrites.INDEX_NAME)
+    logger.info(
+        f"Testing restore for {ContinuousWrites.INDEX_NAME} - "
+        f"original count pre-restore: {original_count}, and now, new count: {new_count}"
+    )
     # We expect that new_count has a loss of documents and the numbers are different.
     assert new_count >= int(original_count * (1 - loss)) and new_count < original_count

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -553,12 +553,6 @@ async def assert_cwrites_backup_consistency(
     original_count = await index_docs_count(ops_test, app, unit_ip, ContinuousWrites.INDEX_NAME)
     logger.info(f"cwrites current count is: {original_count}")
 
-    # Now, remove the index to ensure we are not counting the same documents twice
-    resp = await http_request(
-        ops_test, "DELETE", f"https://{unit_ip}:9200/{ContinuousWrites.INDEX_NAME}"
-    )
-    logger.info(f"Index deletion response: {resp}")
-
     # As stated on: https://discuss.elastic.co/t/how-to-parse-snapshot-dat-file/218888,
     # the only way to discover the documents in a backup is to recover it and check
     # on opensearch.

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -474,7 +474,7 @@ async def wait_for_backup(ops_test, leader_id):
             raise Exception("Backup not finished yet")
 
 
-async def wait_restore_finish(ops_test, unit_ip):
+async def wait_for_restore(ops_test, unit_ip):
     """Waits the backup to finish and move to the finished state or throws a RetryException."""
     for attempt in Retrying(stop=stop_after_attempt(8), wait=wait_fixed(15)):
         with attempt:
@@ -512,7 +512,6 @@ async def start_and_check_continuous_writes(ops_test: OpsTest, unit_ip: str, app
 async def backup_cluster(ops_test: OpsTest, leader_id: int) -> int:
     """Runs the backup of the cluster."""
     action = await run_action(ops_test, leader_id, "create-backup")
-    assert action.status == "completed"
     logger.debug(f"create-backup output: {action}")
 
     await wait_for_backup(ops_test, leader_id)
@@ -523,5 +522,5 @@ async def restore_cluster(ops_test: OpsTest, backup_id: int, unit_ip: str, leade
     action = await run_action(ops_test, leader_id, "restore", params={"backup-id": backup_id})
     logger.debug(f"restore output: {action}")
 
-    await wait_restore_finish(ops_test, unit_ip)
+    await wait_for_restore(ops_test, unit_ip)
     return action.status == "completed"

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -552,7 +552,7 @@ async def list_backups(ops_test: OpsTest, leader_id: int) -> Dict[str, str]:
 
 
 async def assert_cwrites_backup_consistency(
-    ops_test: OpsTest, app: str, leader_id: int, unit_ip: str, backup_id: int, loss: float = 0.4
+    ops_test: OpsTest, app: str, leader_id: int, unit_ip: str, backup_id: int
 ) -> None:
     """Ensures that continuous writes index has at least the value below.
 
@@ -571,4 +571,5 @@ async def assert_cwrites_backup_consistency(
         f"original count pre-restore: {original_count}, and now, new count: {new_count}"
     )
     # We expect that new_count has a loss of documents and the numbers are different.
-    assert new_count >= int(original_count * (1 - loss)) and new_count < original_count
+    # Check if we have data but not all of it.
+    assert new_count > 0 and new_count < original_count

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -544,14 +544,19 @@ async def list_backups(ops_test: OpsTest, leader_id: int) -> Dict[str, str]:
 
 
 async def assert_cwrites_backup_consistency(
-    ops_test: OpsTest, app: str, leader_id: int, unit_ip: str, backup_id: str
+    ops_test: OpsTest, app: str, leader_id: int, unit_ip: str, backup_id: str, loss: float = 0.25
 ) -> None:
-    """Ensures that continuous writes index has at least the value below."""
+    """Ensures that continuous writes index has at least the value below.
+
+    assert new_count >= <current-doc-count> * (1 - loss) documents.
+    """
     original_count = await index_docs_count(ops_test, app, unit_ip, ContinuousWrites.INDEX_NAME)
     # As stated on: https://discuss.elastic.co/t/how-to-parse-snapshot-dat-file/218888,
     # the only way to discover the documents in a backup is to recover it and check
     # on opensearch.
     # The logic below will run over each backup id, restore it and ensure continuous writes
+    # index loss is within the "loss" parameter.
     assert await restore(ops_test, backup_id, unit_ip, leader_id)
     new_count = await index_docs_count(ops_test, app, unit_ip, ContinuousWrites.INDEX_NAME)
-    assert new_count > 0 and new_count != original_count
+    # We expect that new_count has a loss of documents and the numbers are different.
+    assert new_count >= int(original_count * (1 - loss)) and new_count != original_count

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -555,7 +555,21 @@ async def assert_cwrites_backup_consistency(
 
     assert new_count >= <current-doc-count> * (1 - loss) documents.
     """
-    original_count = await index_docs_count(ops_test, app, unit_ip, ContinuousWrites.INDEX_NAME)
+    try:
+        original_count = await index_docs_count(
+            ops_test, app, unit_ip, ContinuousWrites.INDEX_NAME
+        )
+        # clear current index for testing
+        resp = await http_request(
+            ops_test,
+            "DELETE",
+            f"https://{unit_ip}:9200/{ContinuousWrites.INDEX_NAME}",
+            json_resp=True,
+        )
+        logger.debug(f"Response: {resp}")
+    except Exception as e:
+        logger.warning(f"Index may not exist. Failed to clear index: {e}")
+        original_count = 0
     # As stated on: https://discuss.elastic.co/t/how-to-parse-snapshot-dat-file/218888,
     # the only way to discover the documents in a backup is to recover it and check
     # on opensearch.

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -551,7 +551,7 @@ async def list_backups(ops_test: OpsTest, leader_id: int) -> Dict[str, str]:
     return json.loads(action.response["backups"])
 
 
-async def assert_cwrites_backup_consistency(
+async def assert_restore_indices_and_compare_consistency(
     ops_test: OpsTest, app: str, leader_id: int, unit_ip: str, backup_id: int
 ) -> None:
     """Ensures that continuous writes index has at least the value below.

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -509,7 +509,7 @@ async def start_and_check_continuous_writes(ops_test: OpsTest, unit_ip: str, app
     return result.count > initial_count
 
 
-async def backup_cluster(ops_test: OpsTest, leader_id: int) -> int:
+async def backup_cluster(ops_test: OpsTest, leader_id: int) -> str:
     """Runs the backup of the cluster."""
     action = await run_action(ops_test, leader_id, "create-backup")
     logger.debug(f"create-backup output: {action}")

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -487,8 +487,6 @@ async def wait_for_backup_system_to_settle(ops_test, leader_id, unit_ip):
                     if shard["type"] == "SNAPSHOT" and shard["stage"] != "DONE":
                         raise Exception(f"Recovery failed for shard {shard}")
 
-            raise Exception("Backup system not settled yet")
-
 
 async def delete_backup(ops_test: OpsTest, backup_id: int) -> None:
     """Deletes a backup."""

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -551,8 +551,6 @@ async def assert_cwrites_backup_consistency(
     assert new_count >= <current-doc-count> * (1 - loss) documents.
     """
     original_count = await index_docs_count(ops_test, app, unit_ip, ContinuousWrites.INDEX_NAME)
-    logger.info(f"cwrites current count is: {original_count}")
-
     # As stated on: https://discuss.elastic.co/t/how-to-parse-snapshot-dat-file/218888,
     # the only way to discover the documents in a backup is to recover it and check
     # on opensearch.
@@ -560,6 +558,5 @@ async def assert_cwrites_backup_consistency(
     # index loss is within the "loss" parameter.
     assert await restore(ops_test, backup_id, unit_ip, leader_id)
     new_count = await index_docs_count(ops_test, app, unit_ip, ContinuousWrites.INDEX_NAME)
-    logger.info(f"Restored index count is: {new_count}")
     # We expect that new_count has a loss of documents and the numbers are different.
     assert new_count >= int(original_count * (1 - loss)) and new_count != original_count

--- a/tests/integration/ha/helpers_data.py
+++ b/tests/integration/ha/helpers_data.py
@@ -263,6 +263,7 @@ async def index_docs_count(
     ):
         with attempt:  # Raises RetryError if failed after "retries"
             resp = await http_request(ops_test, "GET", endpoint, app=app)
+            logger.debug(f"Index count response: {resp['count']}")
             if isinstance(resp["count"], int):
                 return resp["count"]
             return int(resp["count"])

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -303,7 +303,7 @@ async def test_remove_and_readd_s3_relation(
             leader_id,
             unit_ip=unit_ip,
         )
-    ) != ""
+    ) > 0
     # continuous writes checks
     await assert_continuous_writes_increasing(c_writes)
     await assert_continuous_writes_consistency(ops_test, c_writes, app)
@@ -391,10 +391,12 @@ async def test_restore_to_new_cluster(
             leader_id,
             unit_ip=unit_ip,
         )
-    ) != ""
+    ) > 0
     # continuous writes checks
     await assert_continuous_writes_increasing(writer)
     await assert_continuous_writes_consistency(ops_test, writer, app)
+    # This assert assures we have taken a new backup, after the last restore from the original
+    # cluster. That means the index is writable.
     await assert_cwrites_backup_consistency(ops_test, app, leader_id, unit_ip, backup_id)
     # Clear the writer manually, as we are not using the conftest c_writes_runner to do so
     await writer.clear()

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -38,6 +38,7 @@ from ..helpers import (
     http_request,
     run_action,
 )
+from ..helpers_deployments import wait_until
 from ..tls.test_tls import TLS_CERTIFICATES_APP_NAME
 from .helpers import (
     app_name,
@@ -469,9 +470,16 @@ async def test_wrong_s3_credentials(ops_test: OpsTest) -> None:
         app=S3_INTEGRATOR,
     )
     await ops_test.model.wait_for_idle(
-        apps=[app, S3_INTEGRATOR],
+        apps=[S3_INTEGRATOR],
         status="active",
         timeout=TIMEOUT,
+    )
+    await wait_until(
+        ops_test,
+        apps=[app],
+        apps_statuses=["blocked"],
+        units_statuses=["active"],
+        idle_period=30,
     )
 
     resp = await http_request(

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -400,6 +400,8 @@ async def test_restore_to_new_cluster(
     # continuous writes checks
     await assert_continuous_writes_consistency(ops_test, writer, app)
     await assert_cwrites_backup_consistency(ops_test, app, leader_id, unit_ip, backup_id)
+    # Clear the writer manually, as we are not using the conftest c_writes_runner to do so
+    await writer.clear()
 
 
 # -------------------------------------------------------------------------------------------
@@ -548,3 +550,5 @@ async def test_change_config_and_backup_restore(
         # continuous writes checks
         await assert_continuous_writes_consistency(ops_test, writer, app)
         await assert_cwrites_backup_consistency(ops_test, app, leader_id, unit_ip, backup_id)
+        # Clear the writer manually, as we are not using the conftest c_writes_runner to do so
+        await writer.clear()

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -44,7 +44,7 @@ from .helpers import (
     app_name,
     assert_continuous_writes_consistency,
     assert_continuous_writes_increasing,
-    assert_cwrites_backup_consistency,
+    assert_restore_indices_and_compare_consistency,
     create_backup,
     list_backups,
     restore,
@@ -244,7 +244,9 @@ async def test_create_backup_and_restore(
     # continuous writes checks
     await assert_continuous_writes_increasing(c_writes)
     await assert_continuous_writes_consistency(ops_test, c_writes, app)
-    await assert_cwrites_backup_consistency(ops_test, app, leader_id, unit_ip, backup_id)
+    await assert_restore_indices_and_compare_consistency(
+        ops_test, app, leader_id, unit_ip, backup_id
+    )
     global cwrites_backup_doc_count
     cwrites_backup_doc_count[backup_id] = await index_docs_count(
         ops_test,
@@ -310,7 +312,9 @@ async def test_remove_and_readd_s3_relation(
     # continuous writes checks
     await assert_continuous_writes_increasing(c_writes)
     await assert_continuous_writes_consistency(ops_test, c_writes, app)
-    await assert_cwrites_backup_consistency(ops_test, app, leader_id, unit_ip, backup_id)
+    await assert_restore_indices_and_compare_consistency(
+        ops_test, app, leader_id, unit_ip, backup_id
+    )
     global cwrites_backup_doc_count
     cwrites_backup_doc_count[backup_id] = await index_docs_count(
         ops_test,
@@ -414,7 +418,9 @@ async def test_restore_to_new_cluster(
     await assert_continuous_writes_consistency(ops_test, writer, app)
     # This assert assures we have taken a new backup, after the last restore from the original
     # cluster. That means the index is writable.
-    await assert_cwrites_backup_consistency(ops_test, app, leader_id, unit_ip, backup_id)
+    await assert_restore_indices_and_compare_consistency(
+        ops_test, app, leader_id, unit_ip, backup_id
+    )
     # Clear the writer manually, as we are not using the conftest c_writes_runner to do so
     await writer.clear()
 
@@ -565,6 +571,8 @@ async def test_change_config_and_backup_restore(
         # continuous writes checks
         await assert_continuous_writes_increasing(writer)
         await assert_continuous_writes_consistency(ops_test, writer, app)
-        await assert_cwrites_backup_consistency(ops_test, app, leader_id, unit_ip, backup_id)
+        await assert_restore_indices_and_compare_consistency(
+            ops_test, app, leader_id, unit_ip, backup_id
+        )
         # Clear the writer manually, as we are not using the conftest c_writes_runner to do so
         await writer.clear()

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -258,7 +258,8 @@ async def test_create_and_list_backups(
     # continuous writes checks
     await assert_continuous_writes_consistency(ops_test, c_writes, app)
     # Make sure we took a snapshot with data
-    for backup_id in list_backups(ops_test, leader_id).keys():
+    backups = await list_backups(ops_test, leader_id)
+    for backup_id in backups.keys():
         assert (
             await _backup_docs_count(ops_test, app, unit_ip, backup_id)[
                 ContinuousWrites.INDEX_NAME

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -390,8 +390,10 @@ async def test_restore_to_new_cluster(
     for backup_id in backups.keys():
         assert await restore(ops_test, backup_id, unit_ip, leader_id)
         count = await index_docs_count(ops_test, app, unit_ip, ContinuousWrites.INDEX_NAME)
-        logger.debug(f"Current count is {count}, expected {cwrites_backup_doc_count[backup_id]}")
+
+        # Ensure we have the same doc count as we had on the original cluster
         assert count == cwrites_backup_doc_count[backup_id]
+
         # restart the continuous writes and check the cluster is still accessible post restore
         assert await start_and_check_continuous_writes(ops_test, unit_ip, app)
 

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -315,15 +315,6 @@ async def test_remove_and_readd_s3_relation(
     # continuous writes checks
     await assert_continuous_writes_increasing(c_writes)
     await assert_continuous_writes_consistency(ops_test, c_writes, app)
-    # clear current index for testing
-    resp = await http_request(
-        ops_test,
-        "DELETE",
-        f"https://{unit_ip}:9200/{ContinuousWrites.INDEX_NAME}",
-        json_resp=True,
-    )
-    logger.debug(f"Response: {resp}")
-
     await assert_cwrites_backup_consistency(ops_test, app, leader_id, unit_ip, backup_id)
     global cwrites_backup_doc_count
     cwrites_backup_doc_count[backup_id] = await index_docs_count(
@@ -421,9 +412,9 @@ async def test_restore_to_new_cluster(
     # continuous writes checks
     await assert_continuous_writes_increasing(writer)
     await assert_continuous_writes_consistency(ops_test, writer, app)
+    await assert_cwrites_backup_consistency(ops_test, app, leader_id, unit_ip, backup_id)
     # Clear the writer manually, as we are not using the conftest c_writes_runner to do so
     await writer.clear()
-    await assert_cwrites_backup_consistency(ops_test, app, leader_id, unit_ip, backup_id)
 
 
 # -------------------------------------------------------------------------------------------
@@ -572,7 +563,6 @@ async def test_change_config_and_backup_restore(
         # continuous writes checks
         await assert_continuous_writes_increasing(writer)
         await assert_continuous_writes_consistency(ops_test, writer, app)
+        await assert_cwrites_backup_consistency(ops_test, app, leader_id, unit_ip, backup_id)
         # Clear the writer manually, as we are not using the conftest c_writes_runner to do so
         await writer.clear()
-
-        await assert_cwrites_backup_consistency(ops_test, app, leader_id, unit_ip, backup_id)

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -1,0 +1,568 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Tests for the OpenSearch charm with backups and restores.
+
+This test suite will test backup and restore functionality of the OpenSearch charm
+against every cloud provider currently supported. Tests are separated into groups
+that falls in 2x categories:
+* Per cloud provider tests: backup, restore, remove-readd relation and disaster recovery
+* All cloud providers tests: build, deploy, test expected API errors and switch configs
+                             between the clouds to ensure config changes are working as expected
+
+The latter test group is called "all". The former is a set of groups, each corresponding to a
+different cloud.
+"""
+
+import asyncio
+import logging
+import subprocess
+import time
+import uuid
+from pathlib import Path
+
+import boto3
+import pytest
+from pytest_operator.plugin import OpsTest
+
+from ..ha.continuous_writes import ContinuousWrites
+from ..ha.test_horizontal_scaling import IDLE_PERIOD
+from ..helpers import (
+    APP_NAME,
+    MODEL_CONFIG,
+    SERIES,
+    get_leader_unit_id,
+    get_leader_unit_ip,
+    http_request,
+    run_action,
+)
+from ..tls.test_tls import TLS_CERTIFICATES_APP_NAME
+from .helpers import (
+    app_name,
+    assert_continuous_writes_consistency,
+    backup_cluster,
+    restore_cluster,
+    start_and_check_continuous_writes,
+)
+from .helpers_data import index_docs_count
+
+logger = logging.getLogger(__name__)
+
+
+S3_REPO_NAME = "s3-repository"
+
+
+backups_by_cloud = {}
+value_before_backup, value_after_backup = None, None
+
+
+# This variable stores the backup_id of the very first test
+# This id will be reused throughout the different tests
+# Given we reuse the same id across different functions, we need to
+# store it in a common place. Besides, there are multiple tests
+# that will access the same clouds and potentially conflict with hard
+# coded backup_ids.
+global_backup_id = 0
+
+
+@pytest.fixture(scope="session")
+def cloud_configs(github_secrets, microceph):
+    # Add UUID to path to avoid conflict with tests running in parallel (e.g. multiple Juju
+    # versions on a PR, multiple PRs)
+    path = f"opensearch/{uuid.uuid4()}"
+
+    # Figure out the address of the LXD host itself, where tests are executed
+    # this is where microceph will be installed.
+    ip = subprocess.check_output(["hostname", "-I"]).decode().split()[0]
+    results = {
+        "microceph": {
+            "endpoint": f"http://{ip}",
+            "bucket": microceph.bucket,
+            "path": path,
+            "region": "default",
+        },
+    }
+    if "AWS_ACCESS_KEY" in github_secrets:
+        results["aws"] = {
+            "endpoint": "https://s3.amazonaws.com",
+            "bucket": "data-charms-testing",
+            "path": path,
+            "region": "us-east-1",
+        }
+    return results
+
+
+@pytest.fixture(scope="session")
+def cloud_credentials(github_secrets, microceph) -> dict[str, dict[str, str]]:
+    """Read cloud credentials."""
+    results = {
+        "microceph": {
+            "access-key": microceph.access_key_id,
+            "secret-key": microceph.secret_access_key,
+        },
+    }
+    if "AWS_ACCESS_KEY" in github_secrets:
+        results["aws"] = {
+            "access-key": github_secrets["AWS_ACCESS_KEY"],
+            "secret-key": github_secrets["AWS_SECRET_KEY"],
+        }
+    return results
+
+
+@pytest.fixture(scope="session", autouse=True)
+def clean_backups_from_buckets(github_secrets, cloud_configs, cloud_credentials):
+    """Teardown to clean up created backups from clouds."""
+    yield
+
+    creds = cloud_credentials.copy()
+    logger.info("Cleaning backups from cloud buckets")
+    for cloud_name, config in cloud_configs.items():
+        backup = backups_by_cloud.get(cloud_name)
+
+        if not backup:
+            continue
+
+        session = boto3.session.Session(
+            aws_access_key_id=creds[cloud_name]["access-key"],
+            aws_secret_access_key=creds[cloud_name]["secret-key"],
+            region_name=config["region"],
+        )
+        s3 = session.resource("s3", endpoint_url=config["endpoint"])
+        bucket = s3.Bucket(config["bucket"])
+
+        for f in backups_by_cloud[cloud_name]:
+            backup_path = str(Path(config["path"]) / Path(str(f)))
+            for bucket_object in bucket.objects.filter(Prefix=backup_path):
+                bucket_object.delete()
+
+
+async def _configure_s3(ops_test, config, credentials, app_name):
+    await ops_test.model.applications[S3_INTEGRATOR].set_config(config)
+    await run_action(
+        ops_test,
+        0,
+        "sync-s3-credentials",
+        params=credentials,
+        app=S3_INTEGRATOR,
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[app_name, S3_INTEGRATOR],
+        status="active",
+        timeout=TIMEOUT,
+    )
+
+
+S3_INTEGRATOR = "s3-integrator"
+S3_INTEGRATOR_CHANNEL = "latest/edge"
+TIMEOUT = 10 * 60
+
+
+@pytest.mark.parametrize(
+    "cloud_name",
+    [
+        (pytest.param("microceph", marks=pytest.mark.group("microceph"))),
+        (pytest.param("aws", marks=pytest.mark.group("aws"))),
+    ],
+)
+@pytest.mark.abort_on_fail
+@pytest.mark.skip_if_deployed
+async def test_build_and_deploy(ops_test: OpsTest, cloud_name) -> None:
+    """Build and deploy an HA cluster of OpenSearch and corresponding S3 integration."""
+    if await app_name(ops_test):
+        return
+
+    my_charm = await ops_test.build_charm(".")
+    await ops_test.model.set_config(MODEL_CONFIG)
+    # Deploy TLS Certificates operator.
+    config = {"ca-common-name": "CN_CA"}
+    await ops_test.model.deploy(TLS_CERTIFICATES_APP_NAME, channel="stable", config=config),
+
+    s3_charm = S3_INTEGRATOR
+    # Convert to integer as environ always returns string
+    app_num_units = 3
+    await asyncio.gather(
+        ops_test.model.deploy(s3_charm, channel=S3_INTEGRATOR_CHANNEL),
+        ops_test.model.deploy(my_charm, num_units=app_num_units, series=SERIES),
+    )
+
+    # Relate it to OpenSearch to set up TLS.
+    await ops_test.model.integrate(APP_NAME, TLS_CERTIFICATES_APP_NAME)
+    await ops_test.model.wait_for_idle(
+        apps=[TLS_CERTIFICATES_APP_NAME, APP_NAME],
+        status="active",
+        timeout=1400,
+        idle_period=IDLE_PERIOD,
+    )
+    # Credentials not set yet, this will move the opensearch to blocked state
+    # Credentials are set per test scenario
+    await ops_test.model.integrate(APP_NAME, S3_INTEGRATOR)
+
+
+@pytest.mark.parametrize(
+    "cloud_name",
+    [
+        (pytest.param("microceph", marks=pytest.mark.group("microceph"))),
+        (pytest.param("aws", marks=pytest.mark.group("aws"))),
+    ],
+)
+@pytest.mark.abort_on_fail
+async def test_backup_cluster(
+    ops_test: OpsTest,
+    c_writes: ContinuousWrites,
+    c_writes_runner,
+    cloud_configs,
+    cloud_credentials,
+    cloud_name,
+) -> None:
+    """Runs the backup process whilst writing to the cluster into 'noisy-index'."""
+    global global_backup_id
+
+    app = (await app_name(ops_test)) or APP_NAME
+    leader_id = await get_leader_unit_id(ops_test)
+    unit_ip = await get_leader_unit_ip(ops_test)
+    config = cloud_configs[cloud_name]
+
+    logger.info(f"Syncing credentials for {cloud_name}")
+    await _configure_s3(ops_test, config, cloud_credentials[cloud_name], app)
+
+    logger.info("Creating backup")
+    global_backup_id = await backup_cluster(
+        ops_test,
+        leader_id,
+    )
+    assert global_backup_id > 0
+    if cloud_name not in backups_by_cloud:
+        backups_by_cloud[cloud_name] = []
+    backups_by_cloud[cloud_name].append(global_backup_id)
+
+    # Comparing the number of docs without stopping c_writes
+    initial_count = await index_docs_count(ops_test, app, unit_ip, ContinuousWrites.INDEX_NAME)
+    time.sleep(5)
+    count = await index_docs_count(ops_test, app, unit_ip, ContinuousWrites.INDEX_NAME)
+    assert count > initial_count
+
+    # continuous writes checks
+    await assert_continuous_writes_consistency(ops_test, c_writes, app)
+
+
+@pytest.mark.parametrize(
+    "cloud_name",
+    [
+        (pytest.param("microceph", marks=pytest.mark.group("microceph"))),
+        (pytest.param("aws", marks=pytest.mark.group("aws"))),
+    ],
+)
+@pytest.mark.abort_on_fail
+async def test_restore_cluster(
+    ops_test: OpsTest, cloud_configs, cloud_credentials, cloud_name
+) -> None:
+    """Restores the cluster and tries to search for index."""
+    global global_backup_id
+
+    unit_ip = await get_leader_unit_ip(ops_test)
+    app = (await app_name(ops_test)) or APP_NAME
+    leader_id = await get_leader_unit_id(ops_test)
+    config = cloud_configs[cloud_name]
+
+    logger.info(f"Syncing credentials for {cloud_name}")
+    await _configure_s3(ops_test, config, cloud_credentials[cloud_name], app)
+
+    logger.info("Restoring backup")
+    assert await restore_cluster(
+        ops_test,
+        global_backup_id,  # backup_id
+        unit_ip,
+        leader_id,
+    )
+    assert await start_and_check_continuous_writes(ops_test, unit_ip, app)
+
+
+@pytest.mark.parametrize(
+    "cloud_name",
+    [
+        (pytest.param("microceph", marks=pytest.mark.group("microceph"))),
+        (pytest.param("aws", marks=pytest.mark.group("aws"))),
+    ],
+)
+@pytest.mark.abort_on_fail
+async def test_restore_cluster_after_app_destroyed(
+    ops_test: OpsTest, cloud_configs, cloud_credentials, cloud_name
+) -> None:
+    """Deletes the entire OpenSearch cluster and redeploys from scratch.
+
+    Restores the backup and then checks if the same TEST_BACKUP_INDEX is there.
+    """
+    global global_backup_id
+
+    app = (await app_name(ops_test)) or APP_NAME
+
+    logging.info("Destroying the application")
+    await ops_test.model.remove_application(app, block_until_done=True)
+    app_num_units = 3
+    my_charm = await ops_test.build_charm(".")
+    config = cloud_configs[cloud_name]
+
+    # Redeploy
+    await asyncio.gather(
+        ops_test.model.deploy(my_charm, num_units=app_num_units, series=SERIES),
+    )
+    # Relate it to OpenSearch to set up TLS.
+    await ops_test.model.integrate(APP_NAME, TLS_CERTIFICATES_APP_NAME)
+    await ops_test.model.integrate(APP_NAME, S3_INTEGRATOR)
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME],
+        status="active",
+        timeout=1400,
+        idle_period=IDLE_PERIOD,
+    )
+
+    leader_id = await get_leader_unit_id(ops_test)
+    leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
+
+    logger.info(f"Syncing credentials for {cloud_name}")
+    await _configure_s3(ops_test, config, cloud_credentials[cloud_name], app)
+
+    logger.info("Restoring backup")
+    assert await restore_cluster(
+        ops_test,
+        global_backup_id,  # backup_id
+        leader_unit_ip,
+        leader_id,
+    )
+
+    logger.info("Creating backup")
+    backup_id = await backup_cluster(
+        ops_test,
+        leader_id,
+    )
+    assert backup_id > 0
+    if cloud_name not in backups_by_cloud:
+        backups_by_cloud[cloud_name] = []
+    backups_by_cloud[cloud_name].append(backup_id)
+    assert await start_and_check_continuous_writes(ops_test, leader_unit_ip, app)
+
+
+@pytest.mark.parametrize(
+    "cloud_name",
+    [
+        (pytest.param("microceph", marks=pytest.mark.group("microceph"))),
+        (pytest.param("aws", marks=pytest.mark.group("aws"))),
+    ],
+)
+@pytest.mark.abort_on_fail
+async def test_remove_and_readd_s3_relation(
+    ops_test: OpsTest, cloud_configs, cloud_credentials, cloud_name
+) -> None:
+    """Removes and re-adds the s3-credentials relation to test backup and restore."""
+    global global_backup_id
+
+    app = (await app_name(ops_test)) or APP_NAME
+    leader_id = await get_leader_unit_id(ops_test)
+    unit_ip = await get_leader_unit_ip(ops_test)
+    config = cloud_configs[cloud_name]
+
+    logger.info("Remove s3-credentials relation")
+    # Remove relation
+    await ops_test.model.applications[app].destroy_relation(
+        "s3-credentials", f"{S3_INTEGRATOR}:s3-credentials"
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[app],
+        status="active",
+        timeout=1400,
+        idle_period=IDLE_PERIOD,
+    )
+
+    logger.info("Re-add s3-credentials relation")
+    await ops_test.model.integrate(APP_NAME, S3_INTEGRATOR)
+    await ops_test.model.wait_for_idle(
+        apps=[app],
+        status="active",
+        timeout=1400,
+        idle_period=IDLE_PERIOD,
+    )
+
+    logger.info(f"Syncing credentials for {cloud_name}")
+    await _configure_s3(ops_test, config, cloud_credentials[cloud_name], app)
+
+    logger.info("Creating backup")
+    backup_id = await backup_cluster(
+        ops_test,
+        leader_id,
+    )
+    assert backup_id > 0
+    if cloud_name not in backups_by_cloud:
+        backups_by_cloud[cloud_name] = []
+    backups_by_cloud[cloud_name].append(backup_id)
+
+    for id in [global_backup_id, backup_id]:
+        logger.info(f"Restoring backup-id: {id}")
+        assert await restore_cluster(
+            ops_test,
+            id,  # backup_id of the 1st backup and then the latest backup
+            unit_ip,
+            leader_id,
+        )
+        assert await start_and_check_continuous_writes(ops_test, unit_ip, app)
+
+
+# -------------------------------------------------------------------------------------------
+# Tests for the "all" group
+#
+# This group will iterate over each cloud, update its credentials via config and rerun
+# the backup and restore tests.
+# -------------------------------------------------------------------------------------------
+
+
+@pytest.mark.group("all")
+@pytest.mark.abort_on_fail
+@pytest.mark.skip_if_deployed
+async def test_build_deploy_and_test_status(ops_test: OpsTest) -> None:
+    """Build, deploy and test status of an HA cluster of OpenSearch and corresponding backups.
+
+    This test group will iterate over each cloud, update its credentials via config and rerun
+    the backup and restore tests.
+    """
+    if await app_name(ops_test):
+        return
+
+    my_charm = await ops_test.build_charm(".")
+    await ops_test.model.set_config(MODEL_CONFIG)
+    # Deploy TLS Certificates operator.
+    config = {"ca-common-name": "CN_CA"}
+    await ops_test.model.deploy(TLS_CERTIFICATES_APP_NAME, channel="stable", config=config),
+
+    s3_charm = S3_INTEGRATOR
+    # Convert to integer as environ always returns string
+    app_num_units = 3
+    await asyncio.gather(
+        ops_test.model.deploy(s3_charm, channel=S3_INTEGRATOR_CHANNEL),
+        ops_test.model.deploy(my_charm, num_units=app_num_units, series=SERIES),
+    )
+
+    # Relate it to OpenSearch to set up TLS.
+    await ops_test.model.integrate(APP_NAME, TLS_CERTIFICATES_APP_NAME)
+    await ops_test.model.wait_for_idle(
+        apps=[TLS_CERTIFICATES_APP_NAME, APP_NAME],
+        status="active",
+        timeout=1400,
+        idle_period=IDLE_PERIOD,
+    )
+    # Credentials not set yet, this will move the opensearch to blocked state
+    # Credentials are set per test scenario
+    await ops_test.model.integrate(APP_NAME, S3_INTEGRATOR)
+
+
+@pytest.mark.group("all")
+@pytest.mark.abort_on_fail
+async def test_repo_missing_message(ops_test: OpsTest) -> None:
+    """Check the repo is missing."""
+    unit_ip = await get_leader_unit_ip(ops_test)
+    resp = await http_request(
+        ops_test, "GET", f"https://{unit_ip}:9200/_snapshot/{S3_REPO_NAME}", json_resp=True
+    )
+    logger.info(f"Response: {resp}")
+    assert resp["status"] == 404
+    assert "repository_missing_exception" in resp["error"]["type"]
+
+
+@pytest.mark.group("all")
+@pytest.mark.abort_on_fail
+async def test_repo_is_misconfigured(ops_test: OpsTest) -> None:
+    """Check the repo is misconfigured."""
+    unit_ip = await get_leader_unit_ip(ops_test)
+    app = (await app_name(ops_test)) or APP_NAME
+
+    config = {
+        "endpoint": "http://localhost",
+        "bucket": "error",
+        "path": "/",
+        "region": "default",
+    }
+    credentials = {
+        "access-key": "error",
+        "secret-key": "error",
+    }
+
+    # Not using _configure_s3 as this method will cause opensearch to block
+    await ops_test.model.applications[S3_INTEGRATOR].set_config(config)
+    await run_action(
+        ops_test,
+        0,
+        "sync-s3-credentials",
+        params=credentials,
+        app=S3_INTEGRATOR,
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[S3_INTEGRATOR],
+        status="active",
+        timeout=TIMEOUT,
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[app],
+        timeout=TIMEOUT,
+    )
+
+    resp = await http_request(
+        ops_test, "GET", f"https://{unit_ip}:9200/_snapshot/{S3_REPO_NAME}/_all", json_resp=True
+    )
+    logger.info(f"Response: {resp}")
+    assert resp["status"] == 500
+    assert "repository_exception" in resp["error"]["type"]
+    assert "Could not determine repository generation from root blobs" in resp["error"]["reason"]
+
+
+@pytest.mark.group("all")
+@pytest.mark.abort_on_fail
+async def test_backup_and_switch_configs(
+    ops_test: OpsTest,
+    cloud_configs,
+    cloud_credentials,
+) -> None:
+    """Run for each cloud and update the cluster config."""
+    unit_ip = await get_leader_unit_ip(ops_test)
+    app = (await app_name(ops_test)) or APP_NAME
+    leader_id = await get_leader_unit_id(ops_test)
+
+    initial_count = 0
+    for cloud_name in cloud_configs.keys():
+        logger.info(
+            f"Index {ContinuousWrites.INDEX_NAME} has {initial_count} documents, starting there"
+        )
+        # Start the ContinuousWrites here instead of bringing as a fixture because we want to do
+        # it for every cloud config we have and we have to stop it before restore, right down.
+        writer = ContinuousWrites(ops_test, app, initial_count=initial_count)
+        await writer.start()
+        time.sleep(10)
+
+        logger.info(f"Syncing credentials for {cloud_name}")
+        config = cloud_configs[cloud_name]
+        await _configure_s3(ops_test, config, cloud_credentials[cloud_name], app)
+
+        logger.info("Creating backup")
+        backup_id = await backup_cluster(
+            ops_test,
+            leader_id,
+        )
+        assert backup_id > 0
+        if cloud_name not in backups_by_cloud:
+            backups_by_cloud[cloud_name] = []
+        backups_by_cloud[cloud_name].append(backup_id)
+
+        # Stop the continuous writes for the restore
+        result = await writer.stop()
+        assert result.count > initial_count
+
+        logger.info("Restoring backup")
+        assert await restore_cluster(
+            ops_test,
+            backup_id,
+            unit_ip,
+            leader_id,
+        )
+        # Start and stop, check if it still works.
+        assert await start_and_check_continuous_writes(ops_test, unit_ip, app)
+
+        # Restart the initial count to be used in the next iteration
+        initial_count = await index_docs_count(ops_test, app, unit_ip, ContinuousWrites.INDEX_NAME)

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -378,6 +378,7 @@ async def test_restore_to_new_cluster(
 
     # Now, try a backup & restore with continuous writes
     logger.info("Final stage of DR test: try a backup & restore with continuous writes")
+    count = await index_docs_count(ops_test, app, unit_ip, ContinuousWrites.INDEX_NAME)
     writer: ContinuousWrites = ContinuousWrites(ops_test, app, initial_count=count)
     await writer.start()
     time.sleep(10)
@@ -439,7 +440,11 @@ async def test_build_deploy_and_test_status(ops_test: OpsTest) -> None:
 @pytest.mark.group("all")
 @pytest.mark.abort_on_fail
 async def test_repo_missing_message(ops_test: OpsTest) -> None:
-    """Check the repo is missing."""
+    """Check the repo is missing error returned by OpenSearch.
+
+    We use the message format to monitor the cluster status. We need to know if this
+    message pattern changed between releases of OpenSearch.
+    """
     unit_ip = await get_leader_unit_ip(ops_test)
     resp = await http_request(
         ops_test, "GET", f"https://{unit_ip}:9200/_snapshot/{S3_REPOSITORY}", json_resp=True

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -43,6 +43,7 @@ from ..tls.test_tls import TLS_CERTIFICATES_APP_NAME
 from .helpers import (
     app_name,
     assert_continuous_writes_consistency,
+    assert_continuous_writes_increasing,
     assert_cwrites_backup_consistency,
     create_backup,
     list_backups,
@@ -237,7 +238,17 @@ async def test_create_backup_and_restore(
         )
     ) != ""
     # continuous writes checks
+    await assert_continuous_writes_increasing(c_writes)
     await assert_continuous_writes_consistency(ops_test, c_writes, app)
+    # clear current index for testing
+    resp = await http_request(
+        ops_test,
+        "DELETE",
+        f"https://{unit_ip}:9200/{ContinuousWrites.INDEX_NAME}",
+        json_resp=True,
+    )
+    logger.debug(f"Response: {resp}")
+
     await assert_cwrites_backup_consistency(ops_test, app, leader_id, unit_ip, backup_id)
     global cwrites_backup_doc_count
     cwrites_backup_doc_count[backup_id] = await index_docs_count(
@@ -302,7 +313,17 @@ async def test_remove_and_readd_s3_relation(
         )
     ) != ""
     # continuous writes checks
+    await assert_continuous_writes_increasing(c_writes)
     await assert_continuous_writes_consistency(ops_test, c_writes, app)
+    # clear current index for testing
+    resp = await http_request(
+        ops_test,
+        "DELETE",
+        f"https://{unit_ip}:9200/{ContinuousWrites.INDEX_NAME}",
+        json_resp=True,
+    )
+    logger.debug(f"Response: {resp}")
+
     await assert_cwrites_backup_consistency(ops_test, app, leader_id, unit_ip, backup_id)
     global cwrites_backup_doc_count
     cwrites_backup_doc_count[backup_id] = await index_docs_count(
@@ -398,10 +419,11 @@ async def test_restore_to_new_cluster(
         )
     ) != ""
     # continuous writes checks
+    await assert_continuous_writes_increasing(writer)
     await assert_continuous_writes_consistency(ops_test, writer, app)
-    await assert_cwrites_backup_consistency(ops_test, app, leader_id, unit_ip, backup_id)
     # Clear the writer manually, as we are not using the conftest c_writes_runner to do so
     await writer.clear()
+    await assert_cwrites_backup_consistency(ops_test, app, leader_id, unit_ip, backup_id)
 
 
 # -------------------------------------------------------------------------------------------
@@ -548,7 +570,9 @@ async def test_change_config_and_backup_restore(
             )
         ) != ""
         # continuous writes checks
+        await assert_continuous_writes_increasing(writer)
         await assert_continuous_writes_consistency(ops_test, writer, app)
-        await assert_cwrites_backup_consistency(ops_test, app, leader_id, unit_ip, backup_id)
         # Clear the writer manually, as we are not using the conftest c_writes_runner to do so
         await writer.clear()
+
+        await assert_cwrites_backup_consistency(ops_test, app, leader_id, unit_ip, backup_id)

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -20,7 +20,7 @@ import logging
 import subprocess
 import time
 import uuid
-from typing import Any, Dict, Generator
+from typing import Any, Dict
 
 import boto3
 import pytest
@@ -58,7 +58,7 @@ TIMEOUT = 10 * 60
 BackupsPath = f"opensearch/{uuid.uuid4()}"
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def cloud_configs(
     github_secrets: Dict[str, str], microceph: Dict[str, str]
 ) -> Dict[str, Dict[str, str]]:
@@ -83,7 +83,7 @@ def cloud_configs(
     return results
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def cloud_credentials(
     github_secrets: Dict[str, str], microceph: Dict[str, str]
 ) -> Dict[str, Dict[str, str]]:
@@ -115,12 +115,12 @@ async def _backup_docs_count(ops_test: OpsTest, app: str, unit_ip: str, backup_i
     }
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="module", autouse=True)
 def remove_backups(
     ops_test: OpsTest,
     cloud_configs: Dict[str, Dict[str, str]],
     cloud_credentials: Dict[str, Dict[str, str]],
-) -> Generator[Any, Any, Any]:
+):
     """Remove previously created backups from the cloud-corresponding bucket."""
     yield
 

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -387,9 +387,7 @@ async def test_restore_to_new_cluster(
         f"https://{unit_ip}:9200/{ContinuousWrites.INDEX_NAME}",
         json_resp=True,
     )
-    assert await restore(ops_test, next(iter(backups)), unit_ip, leader_id)
-    count = await index_docs_count(ops_test, app, unit_ip, ContinuousWrites.INDEX_NAME)
-    writer: ContinuousWrites = ContinuousWrites(ops_test, app, initial_count=count)
+    writer: ContinuousWrites = ContinuousWrites(ops_test, app)
     await writer.start()
     time.sleep(10)
     assert (

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -387,8 +387,9 @@ async def test_restore_to_new_cluster(
         f"https://{unit_ip}:9200/{ContinuousWrites.INDEX_NAME}",
         json_resp=True,
     )
-    # Now restart from scratch
-    writer: ContinuousWrites = ContinuousWrites(ops_test, app)
+    assert await restore(ops_test, next(iter(backups)), unit_ip, leader_id)
+    count = await index_docs_count(ops_test, app, unit_ip, ContinuousWrites.INDEX_NAME)
+    writer: ContinuousWrites = ContinuousWrites(ops_test, app, initial_count=count)
     await writer.start()
     time.sleep(10)
     assert (

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -204,9 +204,9 @@ async def test_build_and_deploy(ops_test: OpsTest, cloud_name: Dict[str, Dict[st
     await ops_test.model.set_config(MODEL_CONFIG)
     # Deploy TLS Certificates operator.
     config = {"ca-common-name": "CN_CA"}
-    await ops_test.model.deploy(TLS_CERTIFICATES_APP_NAME, channel="stable", config=config),
 
     await asyncio.gather(
+        ops_test.model.deploy(TLS_CERTIFICATES_APP_NAME, channel="stable", config=config),
         ops_test.model.deploy(S3_INTEGRATOR, channel=S3_INTEGRATOR_CHANNEL),
         ops_test.model.deploy(my_charm, num_units=3, series=SERIES),
     )
@@ -483,14 +483,10 @@ async def test_build_deploy_and_test_status(ops_test: OpsTest) -> None:
     await ops_test.model.set_config(MODEL_CONFIG)
     # Deploy TLS Certificates operator.
     config = {"ca-common-name": "CN_CA"}
-    await ops_test.model.deploy(TLS_CERTIFICATES_APP_NAME, channel="stable", config=config),
-
-    s3_charm = S3_INTEGRATOR
-    # Convert to integer as environ always returns string
-    app_num_units = 3
     await asyncio.gather(
-        ops_test.model.deploy(s3_charm, channel=S3_INTEGRATOR_CHANNEL),
-        ops_test.model.deploy(my_charm, num_units=app_num_units, series=SERIES),
+        ops_test.model.deploy(TLS_CERTIFICATES_APP_NAME, channel="stable", config=config),
+        ops_test.model.deploy(S3_INTEGRATOR, channel=S3_INTEGRATOR_CHANNEL),
+        ops_test.model.deploy(my_charm, num_units=3, series=SERIES),
     )
 
     # Relate it to OpenSearch to set up TLS.
@@ -547,12 +543,8 @@ async def test_wrong_s3_credentials(ops_test: OpsTest) -> None:
         app=S3_INTEGRATOR,
     )
     await ops_test.model.wait_for_idle(
-        apps=[S3_INTEGRATOR],
+        apps=[app, S3_INTEGRATOR],
         status="active",
-        timeout=TIMEOUT,
-    )
-    await ops_test.model.wait_for_idle(
-        apps=[app],
         timeout=TIMEOUT,
     )
 


### PR DESCRIPTION
Re adds the backup testing infra + AWS testing for backup, as described in [DPE-3660](https://warthogs.atlassian.net/browse/DPE-3660), on top of the new CI testing infra.

It is broken in two types of tests:
1. Per cloud test: backup, restore, relation removal/readd, disaster recovery
2. All clouds: test configuration changes and backup / restore, test expected API call responses

The tests will use different groups, so they can run in parallel.

[DPE-3660]: https://warthogs.atlassian.net/browse/DPE-3660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ