### PR TITLE
[DPE-3578] clear backup status

### DIFF
--- a/lib/charms/opensearch/v0/constants_charm.py
+++ b/lib/charms/opensearch/v0/constants_charm.py
@@ -58,9 +58,11 @@ PClusterWrongNodesCountForQuorum = (
     "Even number of members in quorum if current unit started. Add or remove 1 unit."
 )
 PluginConfigError = "Unexpected error during plugin configuration, check the logs"
+BackupSetupFailed = "Backup setup failed, check logs for details"
 
 # Wait status
 RequestUnitServiceOps = "Requesting lock on operation: {}"
+BackupDeferRelBrokenAsInProgress = "Backup service cannot be stopped: backup in progress."
 
 
 # Maintenance statuses
@@ -73,7 +75,9 @@ WaitingForOtherUnitServiceOps = "Waiting for other units to complete the ops on 
 NewIndexRequested = "new index {index} requested"
 RestoreInProgress = "Restore in progress..."
 PluginConfigStart = "Plugin configuration started."
-
+BackupSetupStart = "Backup setup started."
+BackupConfigureStart = "Configuring backup service..."
+BackupInDisabling = "Disabling backup service..."
 
 # Relation Interfaces
 ClientRelationName = "opensearch-client"

--- a/lib/charms/opensearch/v0/constants_charm.py
+++ b/lib/charms/opensearch/v0/constants_charm.py
@@ -57,6 +57,7 @@ PClusterWrongRolesProvided = "Cannot start cluster with current set of roles."
 PClusterWrongNodesCountForQuorum = (
     "Even number of members in quorum if current unit started. Add or remove 1 unit."
 )
+PluginConfigError = "Unexpected error during plugin configuration, check the logs"
 
 # Wait status
 RequestUnitServiceOps = "Requesting lock on operation: {}"

--- a/lib/charms/opensearch/v0/opensearch_backups.py
+++ b/lib/charms/opensearch/v0/opensearch_backups.py
@@ -50,16 +50,17 @@ import math
 from typing import Any, Dict, List, Set, Tuple
 
 from charms.data_platform_libs.v0.s3 import S3Requirer
-from charms.opensearch.v0.constants_charm import RestoreInProgress
+from charms.opensearch.v0.constants_charm import PluginConfigError, RestoreInProgress
 from charms.opensearch.v0.helper_cluster import ClusterState, IndexStateEnum
 from charms.opensearch.v0.helper_enums import BaseStrEnum
 from charms.opensearch.v0.opensearch_exceptions import (
     OpenSearchError,
     OpenSearchHttpError,
+    OpenSearchNotFullyReadyError,
 )
 from charms.opensearch.v0.opensearch_plugins import (
     OpenSearchBackupPlugin,
-    OpenSearchPluginRelationClusterNotReadyError,
+    OpenSearchPluginError,
     PluginState,
 )
 from ops.charm import ActionEvent
@@ -488,15 +489,22 @@ class OpenSearchBackup(Object):
             if self.charm.plugin_manager.status(plugin) == PluginState.ENABLED:
                 self.charm.plugin_manager.apply_config(plugin.disable())
             self.charm.plugin_manager.apply_config(plugin.config())
+        except OpenSearchNotFullyReadyError:
+            logger.warning("s3-changed: cluster not ready yet")
+            event.defer()
+            return
+        except OpenSearchPluginError as e:
+            # This is only possible if we could not apply keys to the store.
+            # That is generally transient.
+            logger.error(e)
+            event.defer()
+            return
         except OpenSearchError as e:
-            if isinstance(e, OpenSearchPluginRelationClusterNotReadyError):
-                self.charm.status.set(WaitingStatus("s3-changed: cluster not ready yet"))
-            else:
-                self.charm.status.set(
-                    BlockedStatus("Unexpected error during plugin configuration, check the logs")
-                )
-                # There was an unexpected error, log it and block the unit
-                logger.error(e)
+            self.charm.status.set(
+                BlockedStatus("Unexpected error during plugin configuration, check the logs")
+            )
+            # There was an unexpected error, log it and block the unit
+            logger.error(e)
             event.defer()
             return
 
@@ -583,18 +591,21 @@ class OpenSearchBackup(Object):
             plugin = self.charm.plugin_manager.get_plugin(OpenSearchBackupPlugin)
             if self.charm.plugin_manager.status(plugin) == PluginState.ENABLED:
                 self.charm.plugin_manager.apply_config(plugin.disable())
-        except OpenSearchError as e:
-            if isinstance(e, OpenSearchPluginRelationClusterNotReadyError):
-                self.charm.status.set(WaitingStatus("s3-broken event: cluster not ready yet"))
-            else:
-                self.charm.status.set(
-                    BlockedStatus("Unexpected error during plugin configuration, check the logs")
-                )
-                # There was an unexpected error, log it and block the unit
-                logger.error(e)
+        except OpenSearchNotFullyReadyError:
+            logger.warning("s3-credentials: cluster not ready yet")
             event.defer()
             return
-        self.charm.status.set(ActiveStatus())
+        except OpenSearchPluginError as e:
+            logger.error(e)
+            event.defer()
+            return
+        except OpenSearchError as e:
+            self.charm.status.set(BlockedStatus(PluginConfigError))
+            # There was an unexpected error, log it and block the unit
+            logger.error(e)
+            event.defer()
+            return
+        self.charm.status.clear(PluginConfigError)
 
     def _execute_s3_broken_calls(self):
         """Executes the s3 broken API calls."""

--- a/lib/charms/opensearch/v0/opensearch_backups.py
+++ b/lib/charms/opensearch/v0/opensearch_backups.py
@@ -497,20 +497,13 @@ class OpenSearchBackup(Object):
             if self.charm.plugin_manager.status(plugin) == PluginState.ENABLED:
                 self.charm.plugin_manager.apply_config(plugin.disable())
             self.charm.plugin_manager.apply_config(plugin.config())
-        except OpenSearchNotFullyReadyError:
-            logger.warning("s3-changed: cluster not ready yet")
-            event.defer()
-            return
-        except OpenSearchPluginError as e:
-            # This is only possible if we could not apply keys to the store.
-            # That is generally transient.
-            logger.error(e)
-            event.defer()
-            return
         except OpenSearchError as e:
-            self.charm.status.set(BlockedStatus(PluginConfigError))
-            # There was an unexpected error, log it and block the unit
-            logger.error(e)
+            if isinstance(e, OpenSearchNotFullyReadyError):
+                logger.warning("s3-changed: cluster not ready yet")
+            else:
+                self.charm.status.set(BlockedStatus(PluginConfigError))
+                # There was an unexpected error, log it and block the unit
+                logger.error(e)
             event.defer()
             return
 
@@ -599,18 +592,13 @@ class OpenSearchBackup(Object):
             plugin = self.charm.plugin_manager.get_plugin(OpenSearchBackupPlugin)
             if self.charm.plugin_manager.status(plugin) == PluginState.ENABLED:
                 self.charm.plugin_manager.apply_config(plugin.disable())
-        except OpenSearchNotFullyReadyError:
-            logger.warning("s3-credentials: cluster not ready yet")
-            event.defer()
-            return
-        except OpenSearchPluginError as e:
-            logger.error(e)
-            event.defer()
-            return
         except OpenSearchError as e:
-            self.charm.status.set(BlockedStatus(PluginConfigError))
-            # There was an unexpected error, log it and block the unit
-            logger.error(e)
+            if isinstance(e, OpenSearchNotFullyReadyError):
+                logger.warning("s3-changed: cluster not ready yet")
+            else:
+                self.charm.status.set(BlockedStatus(PluginConfigError))
+                # There was an unexpected error, log it and block the unit
+                logger.error(e)
             event.defer()
             return
         self.charm.status.clear(BackupInDisabling)

--- a/lib/charms/opensearch/v0/opensearch_backups.py
+++ b/lib/charms/opensearch/v0/opensearch_backups.py
@@ -66,11 +66,7 @@ from charms.opensearch.v0.opensearch_exceptions import (
     OpenSearchHttpError,
     OpenSearchNotFullyReadyError,
 )
-from charms.opensearch.v0.opensearch_plugins import (
-    OpenSearchBackupPlugin,
-    OpenSearchPluginError,
-    PluginState,
-)
+from charms.opensearch.v0.opensearch_plugins import OpenSearchBackupPlugin, PluginState
 from ops.charm import ActionEvent
 from ops.framework import EventBase, Object
 from ops.model import BlockedStatus, MaintenanceStatus, WaitingStatus

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -75,10 +75,7 @@ from charms.opensearch.v0.opensearch_peer_clusters import (
     StartMode,
 )
 from charms.opensearch.v0.opensearch_plugin_manager import OpenSearchPluginManager
-from charms.opensearch.v0.opensearch_plugins import (
-    OpenSearchPluginError,
-    OpenSearchPluginRelationClusterNotReadyError,
-)
+from charms.opensearch.v0.opensearch_plugins import OpenSearchPluginError
 from charms.opensearch.v0.opensearch_relation_provider import OpenSearchProvider
 from charms.opensearch.v0.opensearch_secrets import OpenSearchSecrets
 from charms.opensearch.v0.opensearch_tls import OpenSearchTLS
@@ -502,7 +499,7 @@ class OpenSearchBaseCharm(CharmBase):
                 self.on[self.service_manager.name].acquire_lock.emit(
                     callback_override="_restart_opensearch"
                 )
-        except OpenSearchPluginRelationClusterNotReadyError:
+        except OpenSearchNotFullyReadyError:
             logger.warning("Plugin management: cluster not ready yet at config changed")
             event.defer()
             return

--- a/lib/charms/opensearch/v0/opensearch_plugin_manager.py
+++ b/lib/charms/opensearch/v0/opensearch_plugin_manager.py
@@ -163,6 +163,10 @@ class OpenSearchPluginManager:
                         restart_needed,
                     ]
                 )
+            except OpenSearchPluginMissingConfigError as e:
+                # This is a more serious issue, as we are missing some input from
+                # the user. The charm should block.
+                raise e
             except OpenSearchPluginError as e:
                 err_msgs.append(str(e))
 

--- a/lib/charms/opensearch/v0/opensearch_plugins.py
+++ b/lib/charms/opensearch/v0/opensearch_plugins.py
@@ -472,7 +472,7 @@ class OpenSearchBackupPlugin(OpenSearchPlugin):
         """
         if not self._extra_config.get("access-key") or not self._extra_config.get("secret-key"):
             logger.error("Missing AWS access-key and secret-key configuration")
-            return
+            return OpenSearchPluginConfig()
         return OpenSearchPluginConfig(
             # Try to remove the previous values
             secret_entries_to_del=[

--- a/lib/charms/opensearch/v0/opensearch_plugins.py
+++ b/lib/charms/opensearch/v0/opensearch_plugins.py
@@ -294,15 +294,12 @@ logger = logging.getLogger(__name__)
 class OpenSearchPluginError(OpenSearchError):
     """Exception thrown when an opensearch plugin is invalid."""
 
-    def __init__(self, msg):
-        super().__init__(msg)
-
 
 class OpenSearchPluginMissingDepsError(OpenSearchPluginError):
     """Exception thrown when an opensearch plugin misses installed dependencies."""
 
     def __init__(self, name, deps):
-        super().__init__(f"Failed to install plugin: {name} - missing dependencies {deps}")
+        self.name = name
         self.deps = deps
 
 
@@ -310,14 +307,14 @@ class OpenSearchPluginInstallError(OpenSearchPluginError):
     """Exception thrown when opensearch plugin installation fails."""
 
     def __init__(self, name):
-        super().__init__("Failed to install plugin: {}".format(name))
+        self.name = name
 
 
 class OpenSearchPluginRemoveError(OpenSearchPluginError):
     """Exception thrown when opensearch plugin removal fails."""
 
     def __init__(self, name):
-        super().__init__("Failed to remove plugin: {}".format(name))
+        self.name = name
 
 
 class OpenSearchPluginMissingConfigError(OpenSearchPluginError):
@@ -327,7 +324,7 @@ class OpenSearchPluginMissingConfigError(OpenSearchPluginError):
     """
 
     def __init__(self, name, configs: List[str]):
-        super().__init__(f"Plugin {name} is missing configs: {configs}")
+        self.name = name
         self.configs = configs
 
 

--- a/lib/charms/opensearch/v0/opensearch_plugins.py
+++ b/lib/charms/opensearch/v0/opensearch_plugins.py
@@ -468,7 +468,8 @@ class OpenSearchBackupPlugin(OpenSearchPlugin):
         )
         """
         if not self._extra_config.get("access-key") or not self._extra_config.get("secret-key"):
-            raise OpenSearchPluginMissingConfigError("Plugin {} missing: {}".format(
+            raise OpenSearchPluginMissingConfigError(
+                "Plugin {} missing: {}".format(
                     self.name,
                     [
                         conf

--- a/lib/charms/opensearch/v0/opensearch_plugins.py
+++ b/lib/charms/opensearch/v0/opensearch_plugins.py
@@ -31,6 +31,18 @@ MISSING (not installed yet) > INSTALLED (plugin installed, but not configured ye
 ENABLED (configuration has been applied) > WAITING_FOR_UPGRADE (if an upgrade is needed)
 > ENABLED (back to enabled state once upgrade has been applied)
 
+WHERE PLUGINS ARE USED:
+Plugins are managed in the OpenSearchPluginManager class, which is called by the charm;
+and also in the code that manages the relations, e.g. OpenSearchBackups. The latter may
+access one or more plugins directly to retrieve information for their own relations.
+
+ERROR HANDLING:
+Plugins can raise errors that subclass OpenSearchPluginError. In the case of the charm,
+these errors are handled by the plugin manager and the charm at config-changed. In this
+case, plugin manager receives the error and prepares a status message to be returned to the
+charm. The charm will then set the status message at the end of config-changed.
+
+
 ========================================================================================
 
                              STEPS TO ADD A NEW PLUGIN
@@ -80,10 +92,14 @@ class MyPlugin(OpenSearchPlugin):
 
         # If using the self._extra_config, or any other dict to build the class below
         # let the KeyError happen and the plugin manager will capture it.
-        return OpenSearchPluginConfig(
-            config_entries_on_add={...}, # Key-value pairs to be added to opensearch.yaml
-            secret_entries_on_add={...}  # Key-value pairs to be added to keystore
-        )
+        try:
+            return OpenSearchPluginConfig(
+                config_entries_on_add={...}, # Key-value pairs to be added to opensearch.yaml
+                secret_entries_on_add={...}  # Key-value pairs to be added to keystore
+            )
+        except MyPluginError as e:
+            # If we want to set the status message with str(e), then raise it with:
+            raise e
 
     def disable(self) -> Tuple[OpenSearchPluginConfig, OpenSearchPluginConfig]:
         # Use the self._extra_config to retrieve any extra configuration.
@@ -278,12 +294,8 @@ logger = logging.getLogger(__name__)
 class OpenSearchPluginError(OpenSearchError):
     """Exception thrown when an opensearch plugin is invalid."""
 
-
-class OpenSearchPluginRelationClusterNotReadyError(OpenSearchPluginError):
-    """Exception thrown when making API calls and cluster is not yet ready.
-
-    This exception in specific should be handled by classes managing the relations of plugins.
-    """
+    def __init__(self, msg):
+        super().__init__(msg)
 
 
 class OpenSearchPluginMissingDepsError(OpenSearchPluginError):
@@ -458,6 +470,9 @@ class OpenSearchBackupPlugin(OpenSearchPlugin):
             secret_entries_to_del = [...]|{...},
         )
         """
+        if not self._extra_config.get("access-key") or not self._extra_config.get("secret-key"):
+            logger.error("Missing AWS access-key and secret-key configuration")
+            return
         return OpenSearchPluginConfig(
             # Try to remove the previous values
             secret_entries_to_del=[

--- a/lib/charms/opensearch/v0/opensearch_plugins.py
+++ b/lib/charms/opensearch/v0/opensearch_plugins.py
@@ -298,23 +298,13 @@ class OpenSearchPluginError(OpenSearchError):
 class OpenSearchPluginMissingDepsError(OpenSearchPluginError):
     """Exception thrown when an opensearch plugin misses installed dependencies."""
 
-    def __init__(self, name, deps):
-        self.name = name
-        self.deps = deps
-
 
 class OpenSearchPluginInstallError(OpenSearchPluginError):
     """Exception thrown when opensearch plugin installation fails."""
 
-    def __init__(self, name):
-        self.name = name
-
 
 class OpenSearchPluginRemoveError(OpenSearchPluginError):
     """Exception thrown when opensearch plugin removal fails."""
-
-    def __init__(self, name):
-        self.name = name
 
 
 class OpenSearchPluginMissingConfigError(OpenSearchPluginError):
@@ -322,10 +312,6 @@ class OpenSearchPluginMissingConfigError(OpenSearchPluginError):
 
     The plugin itself should raise a KeyError, to avoid burden in the plugin development.
     """
-
-    def __init__(self, name, configs: List[str]):
-        self.name = name
-        self.configs = configs
 
 
 class OpenSearchPluginEventScope(BaseStrEnum):

--- a/lib/charms/opensearch/v0/opensearch_plugins.py
+++ b/lib/charms/opensearch/v0/opensearch_plugins.py
@@ -471,8 +471,10 @@ class OpenSearchBackupPlugin(OpenSearchPlugin):
         )
         """
         if not self._extra_config.get("access-key") or not self._extra_config.get("secret-key"):
-            logger.error("Missing AWS access-key and secret-key configuration")
-            return OpenSearchPluginConfig()
+            raise OpenSearchPluginMissingConfigError(
+                "Missing AWS access-key and secret-key configuration"
+            )
+
         return OpenSearchPluginConfig(
             # Try to remove the previous values
             secret_entries_to_del=[

--- a/lib/charms/opensearch/v0/opensearch_plugins.py
+++ b/lib/charms/opensearch/v0/opensearch_plugins.py
@@ -468,13 +468,14 @@ class OpenSearchBackupPlugin(OpenSearchPlugin):
         )
         """
         if not self._extra_config.get("access-key") or not self._extra_config.get("secret-key"):
-            raise OpenSearchPluginMissingConfigError(
-                self.name,
-                [
-                    conf
-                    for conf in ["access-key", "secret-key"]
-                    if not self._extra_config.get(conf)
-                ],
+            raise OpenSearchPluginMissingConfigError("Plugin {} missing: {}".format(
+                    self.name,
+                    [
+                        conf
+                        for conf in ["access-key", "secret-key"]
+                        if not self._extra_config.get(conf)
+                    ],
+                )
             )
 
         return OpenSearchPluginConfig(

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -147,8 +147,6 @@ def microceph():
                 uceph,
                 "-c",
                 "latest/edge",
-                "-d",
-                "/dev/sdc",
                 "-a",
                 "accesskey",
                 "-s",

--- a/tests/unit/lib/test_backups.py
+++ b/tests/unit/lib/test_backups.py
@@ -25,7 +25,7 @@ from charms.opensearch.v0.opensearch_plugins import (
     OpenSearchPluginError,
     PluginState,
 )
-from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
+from ops.model import MaintenanceStatus
 from ops.testing import Harness
 
 from charm import OpenSearchOperatorCharm
@@ -436,19 +436,11 @@ def test_on_s3_broken_steps(
         harness.charm.backup._execute_s3_broken_calls.assert_not_called()
     elif test_type == "apply-config-error" or test_type == "apply-config-error-not-leader":
         event.defer.assert_called()
-        # harness.charm.status.set.call_args_list == [
-        #     call(MaintenanceStatus("Disabling backup service...")),
-        #     call(BlockedStatus("Unexpected error during plugin configuration, check the logs")),
-        # ]
         harness.charm.status.set.assert_any_call(MaintenanceStatus("Disabling backup service..."))
-        harness.charm.status.set.assert_any_call(
-            BlockedStatus("Unexpected error during plugin configuration, check the logs")
-        )
         harness.charm.backup._execute_s3_broken_calls.assert_called_once()
     elif test_type == "success":
         event.defer.assert_not_called()
         harness.charm.status.set.assert_any_call(MaintenanceStatus("Disabling backup service..."))
-        harness.charm.status.set.assert_any_call(ActiveStatus())
         harness.charm.backup._execute_s3_broken_calls.assert_called_once()
 
 

--- a/tests/unit/lib/test_ml_plugins.py
+++ b/tests/unit/lib/test_ml_plugins.py
@@ -70,14 +70,14 @@ class TestOpenSearchKNN(unittest.TestCase):
     @patch("charms.opensearch.v0.helper_conf_setter.YamlConfigSetter.put")
     def test_disable_via_config_change(
         self,
-        mock_put,
-        mock_load,
+        _,
+        __,
         mock_is_started,
         mock_status,
         mock_is_enabled,
         mock_version,
         mock_acquire_lock,
-        deployment_desc,
+        ___,
     ) -> None:
         """Tests entire config_changed event with KNN plugin."""
         mock_status.return_value = PluginState.ENABLED

--- a/tests/unit/lib/test_plugins.py
+++ b/tests/unit/lib/test_plugins.py
@@ -190,10 +190,7 @@ class TestOpenSearchPlugin(unittest.TestCase):
             test_plugin = self.plugin_manager.plugins[0]
             self.plugin_manager._install_if_needed(test_plugin)
         except OpenSearchPluginMissingDepsError as e:
-            assert (
-                str(e)
-                == "('test', ['test-plugin-dependency'])"
-            )
+            assert str(e) == "('test', ['test-plugin-dependency'])"
             succeeded = True
         # Check if we had any other exception
         assert succeeded is True
@@ -403,9 +400,7 @@ class TestOpenSearchBackupPlugin(unittest.TestCase):
         try:
             plugin.config()
         except OpenSearchPluginMissingConfigError as e:
-            assert (
-                str(e) == "('repository-s3', ['access-key', 'secret-key'])"
-            )
+            assert str(e) == "('repository-s3', ['access-key', 'secret-key'])"
         else:
             assert False
 

--- a/tests/unit/lib/test_plugins.py
+++ b/tests/unit/lib/test_plugins.py
@@ -190,7 +190,7 @@ class TestOpenSearchPlugin(unittest.TestCase):
             test_plugin = self.plugin_manager.plugins[0]
             self.plugin_manager._install_if_needed(test_plugin)
         except OpenSearchPluginMissingDepsError as e:
-            assert str(e) == "Plugin test missing: ['test-plugin-dependency']"
+            assert str(e) == "('test', ['test-plugin-dependency'])"
             succeeded = True
         # Check if we had any other exception
         assert succeeded is True
@@ -400,7 +400,7 @@ class TestOpenSearchBackupPlugin(unittest.TestCase):
         try:
             plugin.config()
         except OpenSearchPluginMissingConfigError as e:
-            assert str(e) == "('repository-s3', ['access-key', 'secret-key'])"
+            assert str(e) == "Plugin repository-s3 missing: ['access-key', 'secret-key']"
         else:
             assert False
 

--- a/tests/unit/lib/test_plugins.py
+++ b/tests/unit/lib/test_plugins.py
@@ -190,7 +190,7 @@ class TestOpenSearchPlugin(unittest.TestCase):
             test_plugin = self.plugin_manager.plugins[0]
             self.plugin_manager._install_if_needed(test_plugin)
         except OpenSearchPluginMissingDepsError as e:
-            assert str(e) == "('test', ['test-plugin-dependency'])"
+            assert str(e) == "Plugin test missing: ['test-plugin-dependency']"
             succeeded = True
         # Check if we had any other exception
         assert succeeded is True

--- a/tests/unit/lib/test_plugins.py
+++ b/tests/unit/lib/test_plugins.py
@@ -154,7 +154,7 @@ class TestOpenSearchPlugin(unittest.TestCase):
             test_plugin = self.plugin_manager.plugins[0]
             self.plugin_manager._install_if_needed(test_plugin)
         except OpenSearchPluginInstallError as e:
-            assert str(e) == "Failed to install plugin: test"
+            assert str(e) == "test"
             succeeded = True
         finally:
             # We may reach this point because of another exception, check it:
@@ -192,7 +192,7 @@ class TestOpenSearchPlugin(unittest.TestCase):
         except OpenSearchPluginMissingDepsError as e:
             assert (
                 str(e)
-                == "Failed to install plugin: test - missing dependencies ['test-plugin-dependency']"
+                == "('test', ['test-plugin-dependency'])"
             )
             succeeded = True
         # Check if we had any other exception
@@ -404,7 +404,7 @@ class TestOpenSearchBackupPlugin(unittest.TestCase):
             plugin.config()
         except OpenSearchPluginMissingConfigError as e:
             assert (
-                str(e) == "Plugin repository-s3 is missing configs: ['access-key', 'secret-key']"
+                str(e) == "('repository-s3', ['access-key', 'secret-key'])"
             )
         else:
             assert False


### PR DESCRIPTION
Move the status messages in `opensearch_backup` module to comply with `charm.status.{set,clear}`. All text has been moved to `constant_charms.py`.

This PR also simplifies the exception structure, where the plugins should log their own errors if that is not supposed to come back to the plugin manager and the charm itself. The exception `OpenSearchPluginClusterNotReadyError` has been abandoned in favor of the default exception for the same type of error in `constant_exceptions`.

Tests have been updated accordingly.
