### PR TITLE
Added status badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # OpenSearch Operator
+[![Charmhub](https://charmhub.io/opensearch/badge.svg)](https://charmhub.io/opensearch)
+[![Release](https://github.com/canonical/opensearch-operator/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/opensearch-operator/actions/workflows/release.yaml)
+[![Tests](https://github.com/canonical/opensearch-operator/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/canonical/opensearch-operator/actions/workflows/ci.yaml)
+[![Docs](https://github.com/canonical/opensearch-operator/actions/workflows/sync_docs.yaml/badge.svg)](https://github.com/canonical/opensearch-operator/actions/workflows/sync_docs.yaml)
 
 ## Description
 


### PR DESCRIPTION
## Issue
This repo's status is not displayed in the [Charm Engineering Releases](https://releases.juju.is/?team=Data) overview.

## Solution
Added workflow badges for 
* CharmHub
* Release
* Tests (ci.yaml)
* Docs