### PR TITLE
[DPE-3568] Remove the large github runner

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -48,6 +48,7 @@ jobs:
           - charm-integration
           - tls-integration
           - client-integration
+          - h-scaling-integration
           - ha-base-integration
           - ha-networking-integration
           - ha-multi-clusters-integration
@@ -55,9 +56,6 @@ jobs:
           - plugins-integration
 #          - ha-backup-integration
         runner: ["ubuntu-22.04"]
-        include:
-          - tox-environments: h-scaling-integration
-            runner: "Ubuntu_4C_16G"
     name: ${{ matrix.tox-environments }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 360


### PR DESCRIPTION
## Issue
This PR implements [DPE-3568](https://warthogs.atlassian.net/browse/DPE-3568), namely this PR removes the GH enterprise runner.


[DPE-3568]: https://warthogs.atlassian.net/browse/DPE-3568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ