### PR TITLE
[DPE-3647] Pin charm to snap v2.11.1

### DIFF
--- a/lib/charms/opensearch/v0/constants_charm.py
+++ b/lib/charms/opensearch/v0/constants_charm.py
@@ -92,3 +92,6 @@ COSPort = "9200"
 # Opensearch Users
 OpenSearchUsers = {"admin", "monitor"}
 OpenSearchRoles = set()
+
+# Opensearch Snap revision
+OPENSEARCH_SNAP_REVISION = 39

--- a/src/opensearch.py
+++ b/src/opensearch.py
@@ -15,6 +15,7 @@ from datetime import datetime
 from pathlib import Path
 
 import requests
+from charms.opensearch.v0.constants_charm import OPENSEARCH_SNAP_REVISION
 from charms.opensearch.v0.opensearch_distro import OpenSearchDistribution, Paths
 from charms.opensearch.v0.opensearch_exceptions import (
     OpenSearchCmdError,
@@ -32,9 +33,6 @@ from tenacity import Retrying, retry, stop_after_attempt, wait_exponential, wait
 from utils import extract_tarball
 
 logger = logging.getLogger(__name__)
-
-
-OPENSEARCH_SNAP_REVISION = 39
 
 
 class OpenSearchSnap(OpenSearchDistribution):

--- a/src/opensearch.py
+++ b/src/opensearch.py
@@ -34,7 +34,7 @@ from utils import extract_tarball
 logger = logging.getLogger(__name__)
 
 
-OPENSEARCH_SNAP_REVISION = 37
+OPENSEARCH_SNAP_REVISION = 39
 
 
 class OpenSearchSnap(OpenSearchDistribution):

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -29,7 +29,6 @@ from .helpers_deployments import Status, get_application_units, get_unit_hostnam
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
 
-EXPECTED_SNAP_REVISION = 37
 SERIES = "jammy"
 UNIT_IDS = [0, 1, 2]
 IDLE_PERIOD = 75

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -25,7 +25,6 @@ from .helpers import (
 from .helpers_deployments import wait_until
 from .tls.test_tls import TLS_CERTIFICATES_APP_NAME
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -7,9 +7,8 @@ import subprocess
 
 import pytest
 import yaml
+from charms.opensearch.v0.constants_charm import OPENSEARCH_SNAP_REVISION
 from pytest_operator.plugin import OpsTest
-
-from opensearch import OPENSEARCH_SNAP_REVISION
 
 from .helpers import (
     APP_NAME,

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -11,7 +11,6 @@ from pytest_operator.plugin import OpsTest
 
 from .helpers import (
     APP_NAME,
-    EXPECTED_SNAP_REVISION,
     MODEL_CONFIG,
     SERIES,
     get_admin_secrets,
@@ -23,6 +22,8 @@ from .helpers import (
 )
 from .helpers_deployments import wait_until
 from .tls.test_tls import TLS_CERTIFICATES_APP_NAME
+
+from opensearch import OPENSEARCH_SNAP_REVISION
 
 logger = logging.getLogger(__name__)
 
@@ -170,5 +171,5 @@ async def test_check_pinned_revision(ops_test: OpsTest) -> None:
         ).replace("\r\n", "\n")
     )["installed"].split()
     logger.info(f"Installed snap: {installed_info}")
-    assert installed_info[1] == f"({EXPECTED_SNAP_REVISION})"
+    assert installed_info[1] == f"({OPENSEARCH_SNAP_REVISION})"
     assert installed_info[3] == "held"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -9,6 +9,8 @@ import pytest
 import yaml
 from pytest_operator.plugin import OpsTest
 
+from opensearch import OPENSEARCH_SNAP_REVISION
+
 from .helpers import (
     APP_NAME,
     MODEL_CONFIG,
@@ -23,7 +25,6 @@ from .helpers import (
 from .helpers_deployments import wait_until
 from .tls.test_tls import TLS_CERTIFICATES_APP_NAME
 
-from opensearch import OPENSEARCH_SNAP_REVISION
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Pins the charm to snap v2.11.1. Also, moves the snap revision constant to a lib, so both src/opensearch.py and integration tests can access the same value.