### PR TITLE
Add HTTPError information to debug log

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_exceptions.py
+++ b/lib/charms/opensearch/v0/opensearch_exceptions.py
@@ -81,9 +81,11 @@ class OpenSearchHttpError(OpenSearchError):
         except (json.JSONDecodeError, TypeError):
             self.response_body = {}
         self.response_code = response_code
-        super().__init__(
-            f"HTTP error {self.response_code=}\n{self.response_body=}\n{self.response_text=}"
-        )
+        if self.response_body:
+            message = f"HTTP error {self.response_code=}\n{self.response_body=}"
+        else:
+            message = f"HTTP error {self.response_code=}\n{self.response_text=}"
+        super().__init__(message)
 
 
 class OpenSearchHAError(OpenSearchError):


### PR DESCRIPTION
Add HTTP response code, json, and text to Exception message so that it's printed in the debug log