### PR TITLE
Pin lxd to 5.20 in integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,6 +77,8 @@ jobs:
       artifact-prefix: packed-charm-cache-true
       cloud: lxd
       juju-snap-channel: 3.3/stable
+      # Workaround for https://github.com/canonical/opensearch-operator/issues/227
+      lxd-snap-channel: 5.20/stable
     secrets:
       integration-test: |
         {


### PR DESCRIPTION
Workaround for https://github.com/canonical/opensearch-operator/issues/227