### PR TITLE
[Backup] Add error handling to _request

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_backups.py
+++ b/lib/charms/opensearch/v0/opensearch_backups.py
@@ -700,7 +700,7 @@ class OpenSearchBackup(Object):
             return False
         return True
 
-    def _request(self, *args, **kwargs) -> str | None:
+    def _request(self, *args, **kwargs) -> dict[str, Any] | None:
         """Returns the output of OpenSearchDistribution.request() or throws an error.
 
         Request method can return one of many: Union[Dict[str, any], List[any], int]

--- a/lib/charms/opensearch/v0/opensearch_backups.py
+++ b/lib/charms/opensearch/v0/opensearch_backups.py
@@ -555,6 +555,7 @@ class OpenSearchBackup(Object):
         if state != BackupServiceState.SUCCESS:
             logger.error(f"Failed to setup backup service with state {state}")
             self.charm.status.set(BlockedStatus(BackupSetupFailed), app=True)
+            self.charm.status.clear(BackupConfigureStart)
             return
         self.charm.status.clear(BackupSetupFailed, app=True)
         self.charm.status.clear(BackupConfigureStart)
@@ -720,10 +721,8 @@ class OpenSearchBackup(Object):
         try:
             result = self.charm.opensearch.request(*args, **kwargs)
         except OpenSearchHttpError as e:
-            if not e.response_text:
-                return None
-            return e.response_text
-        return result
+            return e.response_body if e.response_body else None
+        return result if isinstance(result, dict) else None
 
     def get_service_status(  # noqa: C901
         self, response: dict[str, Any] | None

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -545,6 +545,7 @@ async def test_wrong_s3_credentials(ops_test: OpsTest) -> None:
         apps=[app],
         apps_statuses=["blocked"],
         units_statuses=["active"],
+        wait_for_exact_units=3,
         idle_period=30,
     )
 


### PR DESCRIPTION
Updates the backup lib to consider the new error handling with `OpenSearchHttpError` and `request()` method.

Also removes a lingering "MaintenanceStatus" if we have a configuration error in the backups.