### PR TITLE
DPE-2333 show open ports

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -721,7 +721,7 @@ class OpenSearchBaseCharm(CharmBase):
             return
         self.peers_data.delete(Scope.UNIT, "started")
         if self.opensearch.is_started():
-            self.unit.open_port('tcp', 9200)
+            self.unit.open_port("tcp", 9200)
             try:
                 self._post_start_init(event)
             except (OpenSearchHttpError, OpenSearchNotFullyReadyError):

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -721,6 +721,7 @@ class OpenSearchBaseCharm(CharmBase):
             return
         self.peers_data.delete(Scope.UNIT, "started")
         if self.opensearch.is_started():
+            self.unit.set_ports(9200)
             try:
                 self._post_start_init(event)
             except (OpenSearchHttpError, OpenSearchNotFullyReadyError):

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -721,7 +721,7 @@ class OpenSearchBaseCharm(CharmBase):
             return
         self.peers_data.delete(Scope.UNIT, "started")
         if self.opensearch.is_started():
-            self.unit.set_ports(9200)
+            self.unit.open_port('tcp', 9200)
             try:
                 self._post_start_init(event)
             except (OpenSearchHttpError, OpenSearchNotFullyReadyError):

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -721,7 +721,6 @@ class OpenSearchBaseCharm(CharmBase):
             return
         self.peers_data.delete(Scope.UNIT, "started")
         if self.opensearch.is_started():
-            self.unit.open_port("tcp", 9200)
             try:
                 self._post_start_init(event)
             except (OpenSearchHttpError, OpenSearchNotFullyReadyError):
@@ -816,6 +815,8 @@ class OpenSearchBaseCharm(CharmBase):
 
         # clear waiting to start status
         self.status.clear(WaitingToStart)
+
+        self.unit.open_port("tcp", 9200)
 
         # update the peer cluster rel data with new IP in case of main cluster manager
         if self.opensearch_peer_cm.deployment_desc().typ != DeploymentType.OTHER:


### PR DESCRIPTION
## Issue
When starting opensearch, port 9200 was not shown as open port in `juju status` or `juju show-unit`, as described in https://github.com/canonical/opensearch-operator/issues/104

## Solution
After startup of opensearch was completed, `self.unit.open_port`is called to set tcp port 9200 as open for the unit.

It is now displayed in `juju status`:
```
Model       Controller  Cloud/Region         Version  SLA          Timestamp
opensearch  opensearch  localhost/localhost  3.1.8    unsupported  09:24:11Z

App                        Version  Status  Scale  Charm                      Channel  Rev  Exposed  Message
opensearch                          active      1  opensearch                            7  no       
tls-certificates-operator           active      1  tls-certificates-operator  stable    22  no       

Unit                          Workload  Agent  Machine  Public address  Ports     Message
opensearch/5*                 active    idle   6        10.183.254.77   9200/tcp  
[...]
```