### PR TITLE
[DPE-4192] Update test_opensearch_tls

### DIFF
--- a/tests/unit/lib/test_opensearch_tls.py
+++ b/tests/unit/lib/test_opensearch_tls.py
@@ -33,6 +33,8 @@ class TestOpenSearchTLS(unittest.TestCase):
     def setUp(self, _put_admin_user) -> None:
         self.harness = Harness(OpenSearchOperatorCharm)
         self.addCleanup(self.harness.cleanup)
+        self.harness.add_network("1.1.1.1", endpoint=PeerRelationName)
+        self.harness.add_network("1.1.1.1", endpoint=TLS_RELATION)
         self.harness.begin()
 
         self.charm = self.harness.charm


### PR DESCRIPTION
There was a recent update on the ops framework and it now explicitly checks for the `_TestModelBackend.networks` for networks set. If no networks are set, it will "create" one: `192.0.2.0`.

This PR adds the network 1.1.1.1 to resolve this issue in the TLS.

Closes #250