### PR TITLE
Make check_plugin_manager_ready more large-deployment friendly

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_plugin_manager.py
+++ b/lib/charms/opensearch/v0/opensearch_plugin_manager.py
@@ -136,15 +136,11 @@ class OpenSearchPluginManager:
 
     def check_plugin_manager_ready(self) -> bool:
         """Checks if the plugin manager is ready to run."""
-        return (
-            self._charm.opensearch.is_node_up()
-            and self._charm.health.apply()
-            in [
-                HealthColors.GREEN,
-                HealthColors.YELLOW,
-                HealthColors.IGNORE,
-            ]
-        )
+        return self._charm.opensearch.is_node_up() and self._charm.health.apply() in [
+            HealthColors.GREEN,
+            HealthColors.YELLOW,
+            HealthColors.IGNORE,
+        ]
 
     def run(self) -> bool:
         """Runs a check on each plugin: install, execute config changes or remove.

--- a/lib/charms/opensearch/v0/opensearch_plugin_manager.py
+++ b/lib/charms/opensearch/v0/opensearch_plugin_manager.py
@@ -137,7 +137,8 @@ class OpenSearchPluginManager:
     def check_plugin_manager_ready(self) -> bool:
         """Checks if the plugin manager is ready to run."""
         return (
-            self._charm.opensearch.is_node_up()
+            self._charm.peers_data.get(Scope.APP, "security_index_initialised", False)
+            and self._charm.opensearch.is_node_up()
             and len(
                 [
                     x

--- a/lib/charms/opensearch/v0/opensearch_plugin_manager.py
+++ b/lib/charms/opensearch/v0/opensearch_plugin_manager.py
@@ -139,7 +139,10 @@ class OpenSearchPluginManager:
         return (
             self._charm.opensearch.is_node_up()
             and len(
-                [x for x in self._charm._get_nodes(True) if x.startswith(self._charm.app.name)]
+                [
+                    x for x in self._charm._get_nodes(True)
+                    if x.name.startswith(self._charm.app.name)
+                ]
             )
             == self._charm.app.planned_units()
             and self._charm.health.apply()

--- a/lib/charms/opensearch/v0/opensearch_plugin_manager.py
+++ b/lib/charms/opensearch/v0/opensearch_plugin_manager.py
@@ -142,7 +142,7 @@ class OpenSearchPluginManager:
                 [
                     x
                     for x in self._charm._get_nodes(True)
-                    if x.name.startswith(self._charm.app.name)
+                    if "-".join(x.name.split("-")[:-1]) == self._charm.app.name
                 ]
             )
             == self._charm.app.planned_units()

--- a/lib/charms/opensearch/v0/opensearch_plugin_manager.py
+++ b/lib/charms/opensearch/v0/opensearch_plugin_manager.py
@@ -138,11 +138,11 @@ class OpenSearchPluginManager:
         """Checks if the plugin manager is ready to run."""
         return (
             self._charm.opensearch.is_node_up()
-            and len(self._charm._get_nodes(True)) == self._charm.app.planned_units()
             and self._charm.health.apply()
             in [
                 HealthColors.GREEN,
                 HealthColors.YELLOW,
+                HealthColors.IGNORE,
             ]
         )
 

--- a/lib/charms/opensearch/v0/opensearch_plugin_manager.py
+++ b/lib/charms/opensearch/v0/opensearch_plugin_manager.py
@@ -136,11 +136,17 @@ class OpenSearchPluginManager:
 
     def check_plugin_manager_ready(self) -> bool:
         """Checks if the plugin manager is ready to run."""
-        return self._charm.opensearch.is_node_up() and self._charm.health.apply() in [
-            HealthColors.GREEN,
-            HealthColors.YELLOW,
-            HealthColors.IGNORE,
-        ]
+        return (
+            self._charm.opensearch.is_node_up() 
+            and len(
+                [x for x in self._charm._get_nodes(True) if x.startswith(self._charm.app.name)]
+            ) == self._charm.app.planned_units()
+            and self._charm.health.apply() in [
+                HealthColors.GREEN,
+                HealthColors.YELLOW,
+                HealthColors.IGNORE,
+            ]
+        )
 
     def run(self) -> bool:
         """Runs a check on each plugin: install, execute config changes or remove.

--- a/lib/charms/opensearch/v0/opensearch_plugin_manager.py
+++ b/lib/charms/opensearch/v0/opensearch_plugin_manager.py
@@ -137,7 +137,7 @@ class OpenSearchPluginManager:
     def check_plugin_manager_ready(self) -> bool:
         """Checks if the plugin manager is ready to run."""
         return (
-            self._charm.opensearch.is_node_up() 
+            self._charm.opensearch.is_node_up()
             and len(
                 [x for x in self._charm._get_nodes(True) if x.startswith(self._charm.app.name)]
             ) == self._charm.app.planned_units()

--- a/lib/charms/opensearch/v0/opensearch_plugin_manager.py
+++ b/lib/charms/opensearch/v0/opensearch_plugin_manager.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from charms.opensearch.v0.helper_cluster import ClusterTopology
 from charms.opensearch.v0.opensearch_exceptions import OpenSearchCmdError
 from charms.opensearch.v0.opensearch_health import HealthColors
+from charms.opensearch.v0.opensearch_internal_data import Scope
 from charms.opensearch.v0.opensearch_keystore import OpenSearchKeystore
 from charms.opensearch.v0.opensearch_plugins import (
     OpenSearchBackupPlugin,

--- a/lib/charms/opensearch/v0/opensearch_plugin_manager.py
+++ b/lib/charms/opensearch/v0/opensearch_plugin_manager.py
@@ -140,8 +140,10 @@ class OpenSearchPluginManager:
             self._charm.opensearch.is_node_up()
             and len(
                 [x for x in self._charm._get_nodes(True) if x.startswith(self._charm.app.name)]
-            ) == self._charm.app.planned_units()
-            and self._charm.health.apply() in [
+            )
+            == self._charm.app.planned_units()
+            and self._charm.health.apply()
+            in [
                 HealthColors.GREEN,
                 HealthColors.YELLOW,
                 HealthColors.IGNORE,

--- a/lib/charms/opensearch/v0/opensearch_plugin_manager.py
+++ b/lib/charms/opensearch/v0/opensearch_plugin_manager.py
@@ -140,7 +140,8 @@ class OpenSearchPluginManager:
             self._charm.opensearch.is_node_up()
             and len(
                 [
-                    x for x in self._charm._get_nodes(True)
+                    x
+                    for x in self._charm._get_nodes(True)
                     if x.name.startswith(self._charm.app.name)
                 ]
             )

--- a/tests/unit/lib/test_ml_plugins.py
+++ b/tests/unit/lib/test_ml_plugins.py
@@ -6,6 +6,7 @@ import unittest
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import charms
+from charms.opensearch.v0.models import Node
 from charms.opensearch.v0.opensearch_health import HealthColors
 from charms.opensearch.v0.opensearch_plugins import OpenSearchKnn, PluginState
 from ops.testing import Harness
@@ -98,7 +99,16 @@ class TestOpenSearchKNN(unittest.TestCase):
         self.plugin_manager._opensearch_config.add_plugin = MagicMock()
         self.charm.status = MagicMock()
         mock_is_node_up.return_value = True
-        self.charm._get_nodes = MagicMock(return_value=[f"{self.charm.app.name}-0"])
+        self.charm._get_nodes = MagicMock(
+            return_value=[
+                Node(
+                    name=f"{self.charm.app.name}-0",
+                    roles=["cluster_manager"],
+                    ip="1.1.1.1",
+                    app_name=self.charm.app.name
+                ),
+            ]
+        )
         self.charm.planned_units = MagicMock(return_value=1)
         mock_lock_acquired.return_value = False
 

--- a/tests/unit/lib/test_ml_plugins.py
+++ b/tests/unit/lib/test_ml_plugins.py
@@ -105,7 +105,7 @@ class TestOpenSearchKNN(unittest.TestCase):
                     name=f"{self.charm.app.name}-0",
                     roles=["cluster_manager"],
                     ip="1.1.1.1",
-                    app_name=self.charm.app.name
+                    app_name=self.charm.app.name,
                 ),
             ]
         )

--- a/tests/unit/lib/test_ml_plugins.py
+++ b/tests/unit/lib/test_ml_plugins.py
@@ -98,7 +98,7 @@ class TestOpenSearchKNN(unittest.TestCase):
         self.plugin_manager._opensearch_config.add_plugin = MagicMock()
         self.charm.status = MagicMock()
         mock_is_node_up.return_value = True
-        self.charm._get_nodes = MagicMock(return_value=[1])
+        self.charm._get_nodes = MagicMock(return_value=[f"{self.charm.app.name}-0"])
         self.charm.planned_units = MagicMock(return_value=1)
         mock_lock_acquired.return_value = False
 

--- a/tests/unit/lib/test_ml_plugins.py
+++ b/tests/unit/lib/test_ml_plugins.py
@@ -106,6 +106,7 @@ class TestOpenSearchKNN(unittest.TestCase):
                     roles=["cluster_manager"],
                     ip="1.1.1.1",
                     app_name=self.charm.app.name,
+                    unit_number=0,
                 ),
             ]
         )


### PR DESCRIPTION
If we are running in a large deployments, we cannot assume anymore that `_get_nodes()` == `planned_units` for any given cluster.

Besides, the charm health may apply to certain nodes and not others. Given this is dealing with plugins, we add the HealthColors.IGNORE as an option.
