### PR TITLE
Ensure OpenSearch lock is written to all nodes before using

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_locking.py
+++ b/lib/charms/opensearch/v0/opensearch_locking.py
@@ -288,7 +288,8 @@ class OpenSearchNodeLock(ops.Object):
                     # any number of shard copies but still succeed on the primary. The `_shards`
                     # section of the write operation’s response reveals the number of shard copies
                     # on which replication succeeded/failed."
-                    # from https://www.elastic.co/guide/en/elasticsearch/reference/8.13/docs-index_.html#index-wait-for-active-shards
+                    # from
+                    # https://www.elastic.co/guide/en/elasticsearch/reference/8.13/docs-index_.html#index-wait-for-active-shards
                     if response["_shards"]["failed"] > 0:
                         logger.error("Failed to write OpenSearch lock document to all nodes")
                         return False


### PR DESCRIPTION
By checking that opensearch lock is replicated to all nodes, we should avoid edge cases where we have 2+ online nodes and then a node has a network cut & only sees 1 online node, doesn't have the lock replicated, and requests the peer databag lock since it thinks no unit has the opensearch lock

~~Potentially fixes~~ no effect on #243

@Mehdi-Bendriss reproduced the issue in #243 and found:
- unit 0 was cluster manager
- unit 1 (the one scaling down) had primary shard

which means the issue should not be related to a failing cluster manager election with 2 -> 1 units
so it's most likely that the lock document was not replicated to unit 0

Context: https://chat.canonical.com/canonical/pl/oc797xcddpn53giu6gtfp4sboo