### PR TITLE
[DPE-4224] Remove relation_{joined,changed}.emit() calls

### DIFF
--- a/lib/charms/opensearch/v0/helper_charm.py
+++ b/lib/charms/opensearch/v0/helper_charm.py
@@ -6,8 +6,6 @@ import re
 import typing
 from datetime import datetime
 
-from charms.data_platform_libs.v0.data_interfaces import Scope
-from charms.opensearch.v0.constants_charm import PeerRelationName
 from charms.opensearch.v0.helper_enums import BaseStrEnum
 from ops import CharmBase
 from ops.model import ActiveStatus, StatusBase
@@ -118,12 +116,3 @@ def relation_departure_reason(charm: CharmBase, relation_name: str) -> RelDepart
         return RelDepartureReason.SCALE_DOWN
 
     return RelDepartureReason.REL_BROKEN
-
-
-def trigger_leader_peer_rel_changed(charm: CharmBase) -> None:
-    """Force trigger a peer rel changed event by leader."""
-    if not charm.unit.is_leader():
-        return
-
-    charm.peers_data.put(Scope.APP, "triggered", datetime.now().timestamp())
-    charm.on[PeerRelationName].relation_changed.emit(charm.model.get_relation(PeerRelationName))

--- a/lib/charms/opensearch/v0/helper_charm.py
+++ b/lib/charms/opensearch/v0/helper_charm.py
@@ -4,7 +4,6 @@
 """Utility functions for charms related operations."""
 import re
 import typing
-from datetime import datetime
 
 from charms.opensearch.v0.helper_enums import BaseStrEnum
 from ops import CharmBase

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -238,9 +238,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         self.framework.observe(self.on.set_password_action, self._on_set_password_action)
         self.framework.observe(self.on.get_password_action, self._on_get_password_action)
 
-        # There is an explosion of _on_peer_relation_changed calls at the startup.
-        # As this corresponds to a local peer relation (not the peer-cluster), we can safely
-        # abandon repeated events.
+        # Ensure that only one instance of the `_on_peer_relation_changed` handler exists in the deferred event queue
         self._is_peer_rel_changed_deferred = False
 
     @property

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -241,7 +241,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         # There is an explosion of _on_peer_relation_changed calls at the startup.
         # As this corresponds to a local peer relation (not the peer-cluster), we can safely
         # abandon repeated events.
-        self._local_peer_relation_changed_has_deferred = False
+        self._is_peer_rel_changed_deferred = False
 
     @property
     @abc.abstractmethod
@@ -434,14 +434,14 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             and self.opensearch.is_node_up()
             and self.health.apply() in [HealthColors.UNKNOWN, HealthColors.YELLOW_TEMP]
         ):
-            if self._local_peer_relation_changed_has_deferred:
+            if self._is_peer_rel_changed_deferred:
                 # We had already tried this event before and deferred. Retry on the next
                 # hook call.
                 return
             # we defer because we want the temporary status to be updated
             event.defer()
             # From now on, we will abandon the event if we need to defer it
-            self._local_peer_relation_changed_has_deferred = True
+            self._is_peer_rel_changed_deferred = True
 
         for relation in self.model.relations.get(ClientRelationName, []):
             self.opensearch_provider.update_endpoints(relation)

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -238,7 +238,8 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         self.framework.observe(self.on.set_password_action, self._on_set_password_action)
         self.framework.observe(self.on.get_password_action, self._on_get_password_action)
 
-        # Ensure that only one instance of the `_on_peer_relation_changed` handler exists in the deferred event queue
+        # Ensure that only one instance of the `_on_peer_relation_changed` handler exists
+        # in the deferred event queue
         self._is_peer_rel_changed_deferred = False
 
     @property

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -440,7 +440,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
                 return
             # we defer because we want the temporary status to be updated
             event.defer()
-            # From now on, we will abandon the event if we need to defer it
+            # If the handler is called again within this Juju hook, we will abandon the event
             self._is_peer_rel_changed_deferred = True
 
         for relation in self.model.relations.get(ClientRelationName, []):

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -226,7 +226,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             self.on[PeerRelationName].relation_joined, self._on_peer_relation_joined
         )
         self.framework.observe(
-            self.on[PeerRelationName].relation_changed, self.peer_relation_changed
+            self.on[PeerRelationName].relation_changed, self._on_peer_relation_changed
         )
         self.framework.observe(
             self.on[PeerRelationName].relation_departed, self._on_peer_relation_departed
@@ -238,7 +238,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         self.framework.observe(self.on.set_password_action, self._on_set_password_action)
         self.framework.observe(self.on.get_password_action, self._on_get_password_action)
 
-        # There is an explosion of peer_relation_changed calls at the startup.
+        # There is an explosion of _on_peer_relation_changed calls at the startup.
         # As this corresponds to a local peer relation (not the peer-cluster), we can safely
         # abandon repeated events.
         self._local_peer_relation_changed_has_deferred = False
@@ -427,7 +427,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         else:
             event.defer()
 
-    def peer_relation_changed(self, event: RelationChangedEvent):
+    def _on_peer_relation_changed(self, event: RelationChangedEvent):
         """Handle peer relation changes."""
         if (
             self.unit.is_leader()
@@ -605,8 +605,6 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             # we need to alert the leader that it must recompute the node roles for any unit whose
             # roles were changed while the current unit was cut-off from the rest of the network
             self._on_peer_relation_joined(event)
-            if event.deferred:
-                return
 
         previous_deployment_desc = self.opensearch_peer_cm.deployment_desc()
         if self.unit.is_leader():

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -435,8 +435,8 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             and self.health.apply() in [HealthColors.UNKNOWN, HealthColors.YELLOW_TEMP]
         ):
             if self._is_peer_rel_changed_deferred:
-                # We had already tried this event before and deferred. Retry on the next
-                # hook call.
+                # We already deferred this event during this Juju event. Retry on the next
+                # Juju event.
                 return
             # we defer because we want the temporary status to be updated
             event.defer()

--- a/lib/charms/opensearch/v0/opensearch_peer_clusters.py
+++ b/lib/charms/opensearch/v0/opensearch_peer_clusters.py
@@ -64,7 +64,7 @@ class OpenSearchPeerClustersManager:
         self._charm = charm
         self._opensearch = charm.opensearch
 
-    def run(self, event=None) -> None:
+    def run(self) -> None:
         """Init, or updates / recomputes current peer cluster related config if applies."""
         user_config = self._user_config()
         if not (current_deployment_desc := self.deployment_desc()):
@@ -87,10 +87,6 @@ class OpenSearchPeerClustersManager:
             self._charm.peers_data.put_object(
                 Scope.APP, "deployment-description", deployment_desc.to_dict()
             )
-
-            if deployment_desc.start == StartMode.WITH_GENERATED_ROLES:
-                # role generation logic
-                self._charm.peer_relation_changed(event)
 
         self.apply_status_if_needed(deployment_desc)
 

--- a/lib/charms/opensearch/v0/opensearch_peer_clusters.py
+++ b/lib/charms/opensearch/v0/opensearch_peer_clusters.py
@@ -64,7 +64,7 @@ class OpenSearchPeerClustersManager:
         self._charm = charm
         self._opensearch = charm.opensearch
 
-    def run(self) -> None:
+    def run(self, event=None) -> None:
         """Init, or updates / recomputes current peer cluster related config if applies."""
         user_config = self._user_config()
         if not (current_deployment_desc := self.deployment_desc()):
@@ -90,9 +90,7 @@ class OpenSearchPeerClustersManager:
 
             if deployment_desc.start == StartMode.WITH_GENERATED_ROLES:
                 # role generation logic
-                self._charm.on[PeerRelationName].relation_changed.emit(
-                    self._charm.model.get_relation(PeerRelationName)
-                )
+                self._charm.peer_relation_changed(event)
 
         self.apply_status_if_needed(deployment_desc)
 

--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -137,9 +137,6 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
 
         self.refresh_relation_data(event)
 
-        # TODO: is the below still needed
-        # self.charm.trigger_leader_peer_rel_changed()
-
     def _on_peer_cluster_relation_changed(self, event: RelationChangedEvent):
         """Event received by all units in sub-cluster when a new sub-cluster joins the relation."""
         if not self.charm.unit.is_leader():
@@ -415,7 +412,6 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
 
     def _on_peer_cluster_relation_joined(self, event: RelationJoinedEvent):
         """Event received when a new main-failover cluster unit joins the fleet."""
-        # self.charm.trigger_leader_peer_rel_changed()
         pass
 
     def _on_peer_cluster_relation_changed(self, event: RelationChangedEvent):


### PR DESCRIPTION
We should replace calls to `relation_{joined,changed}.emit()` by their end-method's handler. Otherwise we will face situations like #265, where a deferred event constantly gets called up, generates new events which also get deferred and end in a snow ball of deferrals.

Closes #265 