### PR TITLE
DPE-2119-fix-snap-issue-when-reusing-storage

### DIFF
--- a/lib/charms/opensearch/v0/constants_charm.py
+++ b/lib/charms/opensearch/v0/constants_charm.py
@@ -101,7 +101,7 @@ KibanaserverUser = "kibanaserver"
 KibanaserverRole = "kibana_server"
 
 # Opensearch Snap revision
-OPENSEARCH_SNAP_REVISION = 40  # Keep in sync with `workload_version` file
+OPENSEARCH_SNAP_REVISION = 47  # Keep in sync with `workload_version` file
 
 # User-face Backup ID format
 OPENSEARCH_BACKUP_ID_FORMAT = "%Y-%m-%dT%H:%M:%SZ"


### PR DESCRIPTION
## Issue
When attaching an existing storage to a new unit, 2 issues happen:

- Snap install failed because of permissions / ownership of directories 
- snap_common gets completely deleted

## Solution
- bump snap version, use the fixed one
- enhance test coverage for integration tests