### PR TITLE
Wait until after peer relation joined before acquiring lock

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -1287,7 +1287,13 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         try:
             nodes = self._get_nodes(self.opensearch.is_node_up())
             if len(nodes) < self.app.planned_units():
+                if self._is_peer_rel_changed_deferred:
+                    # We already deferred this event during this Juju event. Retry on the next
+                    # Juju event.
+                    return
                 event.defer()
+                # If the handler is called again within this Juju hook, we will abandon the event
+                self._is_peer_rel_changed_deferred = True
                 return
 
             self._compute_and_broadcast_updated_topology(nodes)

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -428,6 +428,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
 
     def _on_peer_relation_changed(self, event: RelationChangedEvent):
         """Handle peer relation changes."""
+        logger.warning(f"FOO: {event.relation.data=}")
         if (
             self.unit.is_leader()
             and self.opensearch.is_node_up()

--- a/lib/charms/opensearch/v0/opensearch_locking.py
+++ b/lib/charms/opensearch/v0/opensearch_locking.py
@@ -5,11 +5,12 @@
 import json
 import logging
 import os
+import random
 import typing
 
 import ops
-from charms.opensearch.v0.constants_charm import PeerRelationName
 from charms.opensearch.v0.helper_cluster import ClusterTopology
+from charms.opensearch.v0.helper_networking import units_ips
 from charms.opensearch.v0.opensearch_exceptions import OpenSearchHttpError
 
 if typing.TYPE_CHECKING:
@@ -224,7 +225,7 @@ class OpenSearchNodeLock(ops.Object):
             host = None
         if (
             self._charm.app.planned_units() > 1
-            and (relation := self._charm.model.get_relation(PeerRelationName))
+            and (relation := self._charm.model.get_relation(_PeerRelationLock._ENDPOINT_NAME))
             and not relation.units
         ):
             # On initial startup (e.g. scaling up, on the new unit), `self._charm.alt_hosts` will
@@ -242,7 +243,12 @@ class OpenSearchNodeLock(ops.Object):
             # nodes were online.
             logger.debug("[Node lock] Waiting for peer units before acquiring lock")
             return False
-        alt_hosts = [host for host in self._charm.alt_hosts if self._opensearch.is_node_up(host)]
+        alt_hosts = [
+            host
+            for host in units_ips(self._charm, _PeerRelationLock._ENDPOINT_NAME)
+            if self._opensearch.is_node_up(host)
+        ]
+        random.shuffle(alt_hosts)
         if host or alt_hosts:
             logger.debug("[Node lock] 1+ opensearch nodes online")
             try:


### PR DESCRIPTION
## Issue
During initial startup (i.e. scale-up), a unit will request a lock via the peer databag until it gets a peer-relation-joined event and learns that other units of OpenSearch are online

## Solution
Wait until after the first peer-relation-joined event before trying to acquire lock (so that if [enough] units of opensearch are online, we request the opensearch lock instead of peer databag lock)
