### PR TITLE
[DPE-4285] Fix Backup Large Deployments CI

### DIFF
--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -311,7 +311,7 @@ async def test_large_deployment_build_and_deploy(
         ops_test.model.deploy(
             my_charm,
             application_name="main",
-            num_units=3,
+            num_units=1,
             series=SERIES,
             config=main_orchestrator_conf,
         ),
@@ -347,11 +347,12 @@ async def test_large_deployment_build_and_deploy(
         units_statuses=["active"],
         wait_for_exact_units={
             TLS_CERTIFICATES_APP_NAME: 1,
-            "main": 3,
+            "main": 1,
             "failover": 2,
             APP_NAME: 1,
         },
         idle_period=IDLE_PERIOD,
+        timeout=3600,
     )
 
     # Credentials not set yet, this will move the opensearch to blocked state

--- a/tests/integration/plugins/test_plugins.py
+++ b/tests/integration/plugins/test_plugins.py
@@ -192,12 +192,12 @@ async def test_knn_enabled_disabled(ops_test):
             timeout=3400,
             idle_period=IDLE_PERIOD,
         )
-    
+
         await asyncio.sleep(60)
-    
+
         config = await ops_test.model.applications[APP_NAME].get_config()
         assert config["plugin_opensearch_knn"]["value"] is False
-    
+
         await ops_test.model.applications[APP_NAME].set_config({"plugin_opensearch_knn": "True"})
         await wait_until(
             ops_test,

--- a/tests/integration/plugins/test_plugins.py
+++ b/tests/integration/plugins/test_plugins.py
@@ -181,45 +181,49 @@ async def test_knn_enabled_disabled(ops_test):
     assert config["plugin_opensearch_knn"]["default"] is True
     assert config["plugin_opensearch_knn"]["value"] is True
 
-    await ops_test.model.applications[APP_NAME].set_config({"plugin_opensearch_knn": "False"})
-    await wait_until(
-        ops_test,
-        apps=[APP_NAME],
-        apps_statuses=["active"],
-        units_statuses=["active"],
-        wait_for_exact_units={APP_NAME: 3},
-        timeout=3400,
-        idle_period=IDLE_PERIOD,
-    )
+    async with ops_test.fast_forward():
+        await ops_test.model.applications[APP_NAME].set_config({"plugin_opensearch_knn": "False"})
+        await wait_until(
+            ops_test,
+            apps=[APP_NAME],
+            apps_statuses=["active"],
+            units_statuses=["active"],
+            wait_for_exact_units={APP_NAME: 3},
+            timeout=3400,
+            idle_period=IDLE_PERIOD,
+        )
+    
+        await asyncio.sleep(60)
+    
+        config = await ops_test.model.applications[APP_NAME].get_config()
+        assert config["plugin_opensearch_knn"]["value"] is False
+    
+        await ops_test.model.applications[APP_NAME].set_config({"plugin_opensearch_knn": "True"})
+        await wait_until(
+            ops_test,
+            apps=[APP_NAME],
+            apps_statuses=["active"],
+            units_statuses=["active"],
+            wait_for_exact_units={APP_NAME: 3},
+            timeout=3400,
+            idle_period=IDLE_PERIOD,
+        )
 
-    await asyncio.sleep(60)
+        config = await ops_test.model.applications[APP_NAME].get_config()
+        assert config["plugin_opensearch_knn"]["value"] is True
 
-    config = await ops_test.model.applications[APP_NAME].get_config()
-    assert config["plugin_opensearch_knn"]["value"] is False
+        # Wait 5 minutes to have the restart really kicking in...
+        await asyncio.sleep(300)
 
-    await ops_test.model.applications[APP_NAME].set_config({"plugin_opensearch_knn": "True"})
-    await wait_until(
-        ops_test,
-        apps=[APP_NAME],
-        apps_statuses=["active"],
-        units_statuses=["active"],
-        wait_for_exact_units={APP_NAME: 3},
-        timeout=3400,
-        idle_period=IDLE_PERIOD,
-    )
-    await asyncio.sleep(60)
-
-    config = await ops_test.model.applications[APP_NAME].get_config()
-    assert config["plugin_opensearch_knn"]["value"] is True
-    await wait_until(
-        ops_test,
-        apps=[APP_NAME],
-        apps_statuses=["active"],
-        units_statuses=["active"],
-        wait_for_exact_units={APP_NAME: 3},
-        timeout=3400,
-        idle_period=IDLE_PERIOD,
-    )
+        await wait_until(
+            ops_test,
+            apps=[APP_NAME],
+            apps_statuses=["active"],
+            units_statuses=["active"],
+            wait_for_exact_units={APP_NAME: 3},
+            timeout=3400,
+            idle_period=IDLE_PERIOD,
+        )
 
 
 @pytest.mark.group(1)

--- a/tests/integration/plugins/test_plugins.py
+++ b/tests/integration/plugins/test_plugins.py
@@ -189,11 +189,11 @@ async def test_knn_enabled_disabled(ops_test):
             apps_statuses=["active"],
             units_statuses=["active"],
             wait_for_exact_units={APP_NAME: 3},
-            timeout=3400,
-            idle_period=IDLE_PERIOD,
+            timeout=3600,
+            idle_period=120,
         )
 
-        await asyncio.sleep(60)
+        await asyncio.sleep(120)
 
         config = await ops_test.model.applications[APP_NAME].get_config()
         assert config["plugin_opensearch_knn"]["value"] is False
@@ -205,15 +205,15 @@ async def test_knn_enabled_disabled(ops_test):
             apps_statuses=["active"],
             units_statuses=["active"],
             wait_for_exact_units={APP_NAME: 3},
-            timeout=3400,
-            idle_period=IDLE_PERIOD,
+            timeout=3600,
+            idle_period=120,
         )
 
         config = await ops_test.model.applications[APP_NAME].get_config()
         assert config["plugin_opensearch_knn"]["value"] is True
 
         # Wait 5 minutes to have the restart really kicking in...
-        await asyncio.sleep(300)
+        await asyncio.sleep(120)
 
         await wait_until(
             ops_test,
@@ -221,8 +221,8 @@ async def test_knn_enabled_disabled(ops_test):
             apps_statuses=["active"],
             units_statuses=["active"],
             wait_for_exact_units={APP_NAME: 3},
-            timeout=3400,
-            idle_period=IDLE_PERIOD,
+            timeout=3600,
+            idle_period=120,
         )
 
 


### PR DESCRIPTION
Two main fixes post latest large deployments updates:
* DPE-4285: fix the backups for large deployments
* Ensure the enable/disable KNN tests in `test_plugins.py` will have all its restarts resolved at the end of the test itself