### PR TITLE
Apply missing status clearing

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -586,10 +586,6 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
                 HealthColors.IGNORE,
             ]:
                 event.defer()
-            else:
-                deployment_desc = self.opensearch_peer_cm.deployment_desc()
-                # check if peer status needs to be cleaned
-                self.opensearch_peer_cm.apply_status_if_needed(deployment_desc)
 
             if health == HealthColors.UNKNOWN:
                 return

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -375,7 +375,9 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             return True
 
         if self.unit.is_leader():
-            self.opensearch_peer_cm.apply_status_if_needed(deployment_desc)
+            self.opensearch_peer_cm.apply_status_if_needed(
+                deployment_desc, show_status_only_once=False
+            )
 
         return False
 

--- a/lib/charms/opensearch/v0/opensearch_peer_clusters.py
+++ b/lib/charms/opensearch/v0/opensearch_peer_clusters.py
@@ -313,7 +313,7 @@ class OpenSearchPeerClustersManager:
         ]
         if deployment_desc.state.message not in blocked_status_messages:
             for message in blocked_status_messages:
-                self._charm.status.clear(message)
+                self._charm.status.clear(message, app=True)
             return
 
         self._charm.app.status = BlockedStatus(deployment_desc.state.message)

--- a/lib/charms/opensearch/v0/opensearch_peer_clusters.py
+++ b/lib/charms/opensearch/v0/opensearch_peer_clusters.py
@@ -139,6 +139,8 @@ class OpenSearchPeerClustersManager:
             Scope.APP, "deployment-description", new_deployment_desc.to_dict()
         )
 
+        self.apply_status_if_needed(new_deployment_desc)
+
     def _user_config(self):
         """Build a user provided config object."""
         return PeerClusterConfig(

--- a/lib/charms/opensearch/v0/opensearch_peer_clusters.py
+++ b/lib/charms/opensearch/v0/opensearch_peer_clusters.py
@@ -127,6 +127,7 @@ class OpenSearchPeerClustersManager:
             config.cluster_name = data.cluster_name
             pending_directives.remove(Directive.INHERIT_CLUSTER_NAME)
 
+        pending_directives.append(Directive.SHOW_STATUS)
         new_deployment_desc = DeploymentDescription(
             config=config,
             pending_directives=pending_directives,

--- a/lib/charms/opensearch/v0/opensearch_peer_clusters.py
+++ b/lib/charms/opensearch/v0/opensearch_peer_clusters.py
@@ -127,6 +127,8 @@ class OpenSearchPeerClustersManager:
             config.cluster_name = data.cluster_name
             pending_directives.remove(Directive.INHERIT_CLUSTER_NAME)
 
+        pending_directives.append(Directive.SHOW_STATUS)
+
         new_deployment_desc = DeploymentDescription(
             config=config,
             pending_directives=pending_directives,
@@ -162,6 +164,7 @@ class OpenSearchPeerClustersManager:
                 deployment_state = DeploymentState(
                     value=State.BLOCKED_WAITING_FOR_RELATION, message=PClusterNoRelation
                 )
+
                 directives.append(Directive.SHOW_STATUS)
 
             directives.append(Directive.WAIT_FOR_PEER_CLUSTER_RELATION)

--- a/lib/charms/opensearch/v0/opensearch_peer_clusters.py
+++ b/lib/charms/opensearch/v0/opensearch_peer_clusters.py
@@ -127,8 +127,6 @@ class OpenSearchPeerClustersManager:
             config.cluster_name = data.cluster_name
             pending_directives.remove(Directive.INHERIT_CLUSTER_NAME)
 
-        pending_directives.append(Directive.SHOW_STATUS)
-
         new_deployment_desc = DeploymentDescription(
             config=config,
             pending_directives=pending_directives,
@@ -288,7 +286,9 @@ class OpenSearchPeerClustersManager:
         return True
 
     def apply_status_if_needed(
-        self, deployment_desc: Optional[DeploymentDescription] = None
+        self,
+        deployment_desc: Optional[DeploymentDescription] = None,
+        show_status_only_once: bool = True,
     ) -> None:
         """Resolve and applies corresponding status from the deployment state."""
         if not (deployment_desc := deployment_desc or self.deployment_desc()):
@@ -298,7 +298,8 @@ class OpenSearchPeerClustersManager:
             return
 
         # remove show_status directive which is applied below
-        self.clear_directive(Directive.SHOW_STATUS)
+        if show_status_only_once:
+            self.clear_directive(Directive.SHOW_STATUS)
 
         blocked_status_messages = [
             CMRoleRemovalForbidden,


### PR DESCRIPTION
## Issue
When the peer cluster relation is completely healthy at once, we should ensure that error messages previously applied from outside the relation have also been cleared.