### PR TITLE
[DPE-4306] resume-upgrade does not work on leader as highest unit

### DIFF
--- a/src/machine_upgrade.py
+++ b/src/machine_upgrade.py
@@ -173,14 +173,12 @@ class Upgrade(upgrade.Upgrade):
             state = self._peer_relation.data[unit].get("state")
             if state:
                 state = upgrade.UnitState(state)
-            if (
-                self._unit_workload_container_versions.get(unit.name)
-                != self._app_workload_container_version
-                or state not in [
-                    upgrade.UnitState.HEALTHY,
-                    upgrade.UnitState.UPGRADING,
-                ]
-            ):
+            if self._unit_workload_container_versions.get(
+                unit.name
+            ) != self._app_workload_container_version or state not in [
+                upgrade.UnitState.HEALTHY,
+                upgrade.UnitState.UPGRADING,
+            ]:
                 # Waiting for higher number units to upgrade
                 return False
         return False

--- a/src/machine_upgrade.py
+++ b/src/machine_upgrade.py
@@ -176,7 +176,10 @@ class Upgrade(upgrade.Upgrade):
             if (
                 self._unit_workload_container_versions.get(unit.name)
                 != self._app_workload_container_version
-                or state not in [upgrade.UnitState.HEALTHY, upgrade.UnitState.UPGRADING]
+                or state not in [
+                    upgrade.UnitState.HEALTHY,
+                    upgrade.UnitState.UPGRADING,
+                ]
             ):
                 # Waiting for higher number units to upgrade
                 return False

--- a/src/machine_upgrade.py
+++ b/src/machine_upgrade.py
@@ -176,7 +176,7 @@ class Upgrade(upgrade.Upgrade):
             if (
                 self._unit_workload_container_versions.get(unit.name)
                 != self._app_workload_container_version
-                or state is not upgrade.UnitState.HEALTHY
+                or state not in [upgrade.UnitState.HEALTHY, upgrade.UnitState.UPGRADING]
             ):
                 # Waiting for higher number units to upgrade
                 return False

--- a/src/machine_upgrade.py
+++ b/src/machine_upgrade.py
@@ -108,7 +108,7 @@ class Upgrade(upgrade.Upgrade):
                 self._unit_workload_container_versions.get(unit.name)
                 != self._app_workload_container_version
             )
-            unhealthy = state is not upgrade.UnitState.HEALTHY
+            unhealthy = state not in [upgrade.UnitState.HEALTHY, upgrade.UnitState.UPGRADING]
             if outdated or unhealthy:
                 if outdated:
                     message = "Highest number unit has not upgraded yet. Upgrade will not resume."


### PR DESCRIPTION
If the leader happens to be the unit with highest id, then the `resume-upgrade` will fail.

This PR broadens the health check to also consider `UnitState.UPGRADING` status as valid healthy status.

Closes #303
