### PR TITLE
[DPE-4421] Release stale node locks

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_locking.py
+++ b/lib/charms/opensearch/v0/opensearch_locking.py
@@ -187,7 +187,6 @@ class OpenSearchNodeLock(ops.Object):
     """
 
     OPENSEARCH_INDEX = ".charm_node_lock"
-    _ENDPOINT_NAME = "node-lock-fallback"
 
     def __init__(self, charm: "opensearch_base_charm.OpenSearchBaseCharm"):
         super().__init__(charm, "opensearch-node-lock")


### PR DESCRIPTION
## Issue
https://github.com/canonical/opensearch-operator/issues/309

## Solution
Also release stale locks in the opensearch database from units no longer existing when releasing the lock a unit is currently holding.