### PR TITLE
[DPE-4557] fix timeout when initializing the security index

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -1042,15 +1042,18 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         self.status.set(WaitingStatus(ServiceIsStopping))
 
         if self.opensearch.is_node_up():
-            nodes = self._get_nodes(True)
-            # do not add exclusions if it's the last unit to stop
-            # otherwise cluster manager election will be blocked when starting up again
-            # and re-using storage
-            if len(nodes) > 1:
-                # TODO: we should probably NOT have any exclusion on restart
-                # https://chat.canonical.com/canonical/pl/bgndmrfxr7fbpgmwpdk3hin93c
-                # 1. Add current node to the voting + alloc exclusions
-                self.opensearch_exclusions.add_current()
+            try:
+                nodes = self._get_nodes(True)
+                # do not add exclusions if it's the last unit to stop
+                # otherwise cluster manager election will be blocked when starting up again
+                # and re-using storage
+                if len(nodes) > 1:
+                    # TODO: we should probably NOT have any exclusion on restart
+                    # https://chat.canonical.com/canonical/pl/bgndmrfxr7fbpgmwpdk3hin93c
+                    # 1. Add current node to the voting + alloc exclusions
+                    self.opensearch_exclusions.add_current()
+            except OpenSearchHttpError:
+                logger.debug("Failed to get online nodes, voting and alloc exclusions not added")
 
         # TODO: should block until all shards move addressed in PR DPE-2234
 

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -1042,10 +1042,14 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         self.status.set(WaitingStatus(ServiceIsStopping))
 
         if self.opensearch.is_node_up():
-            # TODO: we should probably NOT have any exclusion on restart
-            # https://chat.canonical.com/canonical/pl/bgndmrfxr7fbpgmwpdk3hin93c
-            # 1. Add current node to the voting + alloc exclusions
-            self.opensearch_exclusions.add_current()
+            nodes = self._get_nodes(True)
+            # do not add exclusions if it's the last unit
+            # otherwise cluster manager election will be blocked when starting again re-using storage
+            if len(nodes) > 1:
+                # TODO: we should probably NOT have any exclusion on restart
+                # https://chat.canonical.com/canonical/pl/bgndmrfxr7fbpgmwpdk3hin93c
+                # 1. Add current node to the voting + alloc exclusions
+                self.opensearch_exclusions.add_current()
 
         # TODO: should block until all shards move addressed in PR DPE-2234
 

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -1043,8 +1043,9 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
 
         if self.opensearch.is_node_up():
             nodes = self._get_nodes(True)
-            # do not add exclusions if it's the last unit
-            # otherwise cluster manager election will be blocked when starting again re-using storage
+            # do not add exclusions if it's the last unit to stop
+            # otherwise cluster manager election will be blocked when starting up again
+            # and re-using storage
             if len(nodes) > 1:
                 # TODO: we should probably NOT have any exclusion on restart
                 # https://chat.canonical.com/canonical/pl/bgndmrfxr7fbpgmwpdk3hin93c


### PR DESCRIPTION
## Issue
https://github.com/canonical/opensearch-operator/issues/320

## Solution
When the last unit in a cluster is stopping, it adds the `voting_config_exclusion`, but doesn't delete it anymore (because all units are already stopped). It is then persisting on disk. If the storage is reused and the first new unit starts, it may happen that the new unit can't become cluster manager because it's not possible to reach quorum.

Therefore the last unit stopping should not add a voting exclusion.