### PR TITLE
[DPE-4553][DPE-4208][DPE-3970] Extend large deployments to test_plugins.py &&  Fix dashboards

### DIFF
--- a/lib/charms/opensearch/v0/constants_charm.py
+++ b/lib/charms/opensearch/v0/constants_charm.py
@@ -114,4 +114,12 @@ OPENSEARCH_SNAP_REVISION = 51  # Keep in sync with `workload_version` file
 OPENSEARCH_BACKUP_ID_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 # Roles that we can add as tags to prometheus data
-COS_TAGGABLE_ROLES = ["data", "cluster_manager", "voting", "cluster_manager_elegible", "ml"]
+COS_TAGGABLE_ROLES = [
+    "data",
+    "cluster_manager",
+    "voting",
+    "coordinating_only",
+    "ingest",
+    "cluster_manager_elegible",
+    "ml",
+]

--- a/lib/charms/opensearch/v0/constants_charm.py
+++ b/lib/charms/opensearch/v0/constants_charm.py
@@ -112,3 +112,6 @@ OPENSEARCH_SNAP_REVISION = 51  # Keep in sync with `workload_version` file
 
 # User-face Backup ID format
 OPENSEARCH_BACKUP_ID_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
+# Roles that we can add as tags to prometheus data
+COS_TAGGABLE_ROLES = ["data", "cluster_manager", "voting", "cluster_manager_elegible", "ml"]

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -1552,15 +1552,16 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         """Return the labels for the prometheus scrape."""
         if not self.opensearch.roles:
             return {
-                "unrecognized": "unrecognized",
+                "roles": "unrecognized",
             }
-        tags = {}
-        for role in self.opensearch.roles:
-            if role in COS_TAGGABLE_ROLES:
-                tags[role] = role
-            else:
-                tags["unrecognized"] = "unrecognized"
-        return tags
+        return {
+            "roles": ",".join(
+                [
+                    role if role in COS_TAGGABLE_ROLES else "unrecognized"
+                    for role in self.opensearch.roles
+                ]
+            )
+        }
 
     def _scrape_config(self) -> List[Dict]:
         """Generates the scrape config as needed."""

--- a/src/grafana_dashboards/opensearch.json
+++ b/src/grafana_dashboards/opensearch.json
@@ -2679,11 +2679,6 @@
           },
           {
             "selected": false,
-            "text": "cluster_manager_elegible",
-            "value": "cluster_manager_elegible"
-          },
-          {
-            "selected": false,
             "text": "ml",
             "value": "ml"
           },
@@ -2693,7 +2688,7 @@
             "value": "unrecognized"
           }
         ],
-        "query": "data, cluster_manager, voting, cluster_manager_elegible, ml, unrecognized",
+        "query": "data, cluster_manager, voting, coordinating_only, ingest, ml, unrecognized",
         "refresh": 0,
         "type": "custom"
       },

--- a/src/grafana_dashboards/opensearch.json
+++ b/src/grafana_dashboards/opensearch.json
@@ -1085,7 +1085,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "1000 * increase(opensearch_indices_indexing_index_time_seconds{cluster=\"$cluster\", node=~\"$node\"}[$__rate_interval]) / increase(opensearch_indices_indexing_index_count{cluster=\"$cluster\", node=~\"$node\"}[$__rate_interval])",
+              "expr": "1000 * rate(opensearch_indices_indexing_index_time_seconds{cluster=\"$cluster\", node=~\"$node\"}[$__rate_interval]) / rate(opensearch_indices_indexing_index_count{cluster=\"$cluster\", node=~\"$node\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}}",

--- a/src/grafana_dashboards/opensearch.json
+++ b/src/grafana_dashboards/opensearch.json
@@ -712,7 +712,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "opensearch_os_cpu_percent{cluster=\"$cluster\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}",
+              "expr": "opensearch_os_cpu_percent{cluster=\"$cluster\", roles=~\".*($role).*\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}}",
@@ -798,7 +798,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "opensearch_os_mem_used_bytes{cluster=\"$cluster\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}",
+              "expr": "opensearch_os_mem_used_bytes{cluster=\"$cluster\", roles=~\".*($role).*\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}}",
@@ -884,7 +884,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "1 - opensearch_fs_path_available_bytes{cluster=\"$cluster\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"} / opensearch_fs_path_total_bytes{cluster=\"$cluster\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}",
+              "expr": "1 - opensearch_fs_path_available_bytes{cluster=\"$cluster\", roles=~\".*($role).*\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"} / opensearch_fs_path_total_bytes{cluster=\"$cluster\", roles=~\".*($role).*\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}} - {{path}}",
@@ -999,7 +999,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(opensearch_indices_indexing_index_count{cluster=\"$cluster\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])",
+              "expr": "rate(opensearch_indices_indexing_index_count{cluster=\"$cluster\", roles=~\".*($role).*\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}}",
@@ -1085,7 +1085,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "1000 * rate(opensearch_indices_indexing_index_time_seconds{cluster=\"$cluster\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval]) / rate(opensearch_indices_indexing_index_count{cluster=\"$cluster\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])",
+              "expr": "1000 * delta(opensearch_indices_indexing_index_time_seconds{cluster=\"$cluster\", roles=~\".*($role).*\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval]) / delta(opensearch_indices_indexing_index_count{cluster=\"$cluster\", roles=~\".*($role).*\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}}",
@@ -1095,7 +1095,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Indexing latency (avg in millisecs / doc)",
+          "title": "Indexing latency / doc (in millisecs)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1171,7 +1171,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(opensearch_indices_search_query_count{cluster=\"$cluster\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])",
+              "expr": "rate(opensearch_indices_search_query_count{cluster=\"$cluster\", roles=~\".*($role).*\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}}",
@@ -1257,7 +1257,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "1000 * rate(opensearch_indices_search_query_time_seconds{cluster=\"$cluster\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval]) / rate(opensearch_indices_search_query_count{cluster=\"$cluster\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])",
+              "expr": "1000 * rate(opensearch_indices_search_query_time_seconds{cluster=\"$cluster\", roles=~\".*($role).*\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval]) / rate(opensearch_indices_search_query_count{cluster=\"$cluster\", roles=~\".*($role).*\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}}",
@@ -1343,7 +1343,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "opensearch_indices_doc_number{cluster=\"$cluster\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}",
+              "expr": "opensearch_indices_doc_number{cluster=\"$cluster\", roles=~\".*($role).*\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}}",
@@ -1429,7 +1429,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(opensearch_indices_doc_deleted_number{cluster=\"$cluster\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])",
+              "expr": "rate(opensearch_indices_doc_deleted_number{cluster=\"$cluster\", roles=~\".*($role).*\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}}",
@@ -1515,7 +1515,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(opensearch_indices_merges_total_docs_count{cluster=\"$cluster\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])",
+              "expr": "rate(opensearch_indices_merges_total_docs_count{cluster=\"$cluster\", roles=~\".*($role).*\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}}",
@@ -1615,7 +1615,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "opensearch_indices_fielddata_memory_size_bytes{cluster=\"$cluster\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}",
+              "expr": "opensearch_indices_fielddata_memory_size_bytes{cluster=\"$cluster\", roles=~\".*($role).*\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}}",
@@ -1701,7 +1701,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(opensearch_indices_fielddata_evictions_count{cluster=\"$cluster\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])",
+              "expr": "rate(opensearch_indices_fielddata_evictions_count{cluster=\"$cluster\", roles=~\".*($role).*\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}}",
@@ -1787,7 +1787,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "opensearch_indices_querycache_cache_size_bytes{cluster=\"$cluster\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}",
+              "expr": "opensearch_indices_querycache_cache_size_bytes{cluster=\"$cluster\", roles=~\".*($role).*\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}}",
@@ -1873,7 +1873,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(opensearch_indices_querycache_evictions_count{cluster=\"$cluster\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])",
+              "expr": "rate(opensearch_indices_querycache_evictions_count{cluster=\"$cluster\", roles=~\".*($role).*\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}}",
@@ -1959,7 +1959,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(opensearch_indices_querycache_hit_count{cluster=\"$cluster\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])",
+              "expr": "rate(opensearch_indices_querycache_hit_count{cluster=\"$cluster\", roles=~\".*($role).*\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}}",
@@ -2045,7 +2045,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(opensearch_indices_querycache_miss_number{cluster=\"$cluster\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])",
+              "expr": "rate(opensearch_indices_querycache_miss_number{cluster=\"$cluster\", roles=~\".*($role).*\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}}",
@@ -2145,7 +2145,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(opensearch_indices_indexing_throttle_time_seconds{cluster=\"$cluster\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])",
+              "expr": "rate(opensearch_indices_indexing_throttle_time_seconds{cluster=\"$cluster\", roles=~\".*($role).*\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}}",
@@ -2231,7 +2231,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(opensearch_indices_merges_total_throttled_time_seconds{cluster=\"$cluster\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])",
+              "expr": "rate(opensearch_indices_merges_total_throttled_time_seconds{cluster=\"$cluster\", roles=~\".*($role).*\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}}",
@@ -2331,7 +2331,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "opensearch_jvm_mem_heap_used_bytes{cluster=\"$cluster\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}",
+              "expr": "opensearch_jvm_mem_heap_used_bytes{cluster=\"$cluster\", roles=~\".*($role).*\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}} - heap used",
@@ -2417,7 +2417,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(opensearch_jvm_gc_collection_count{cluster=\"$cluster\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])",
+              "expr": "rate(opensearch_jvm_gc_collection_count{cluster=\"$cluster\", roles=~\".*($role).*\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}} - {{gc}}",
@@ -2503,7 +2503,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(opensearch_jvm_gc_collection_time_seconds{cluster=\"$cluster\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])",
+              "expr": "rate(opensearch_jvm_gc_collection_time_seconds{cluster=\"$cluster\", roles=~\".*($role).*\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{juju_model}}.{{juju_unit}} - {{gc}}",
@@ -2626,6 +2626,64 @@
           }
         ],
         "query": "15s, 30s, 1m, 5m, 1h, 6h, 1d",
+        "refresh": 0,
+        "type": "custom"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "prometheus",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Role",
+        "multi": true,
+        "name": "role",
+        "options": [
+          {
+            "selected": true,
+            "text": "All",
+            "value": "$__all"
+          },
+          {
+            "selected": false,
+            "text": "data",
+            "value": "data"
+          },
+          {
+            "selected": false,
+            "text": "cluster_manager",
+            "value": "cluster_manager"
+          },
+          {
+            "selected": false,
+            "text": "voting",
+            "value": "voting"
+          },
+          {
+            "selected": false,
+            "text": "cluster_manager_elegible",
+            "value": "cluster_manager_elegible"
+          },
+          {
+            "selected": false,
+            "text": "ml",
+            "value": "ml"
+          },
+          {
+            "selected": false,
+            "text": "unrecognized",
+            "value": "unrecognized"
+          }
+        ],
+        "query": "data, cluster_manager, voting, cluster_manager_elegible, ml, unrecognized",
         "refresh": 0,
         "type": "custom"
       },

--- a/src/grafana_dashboards/opensearch.json
+++ b/src/grafana_dashboards/opensearch.json
@@ -999,7 +999,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(opensearch_indices_indexing_index_count{cluster=\"$cluster\", node=~\"$node\"}[$interval])",
+              "expr": "rate(opensearch_indices_indexing_index_count{cluster=\"$cluster\", node=~\"$node\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}}",
@@ -1085,7 +1085,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(opensearch_indices_indexing_index_time_seconds{cluster=\"$cluster\", node=~\"$node\"}[$interval]) / rate(opensearch_indices_indexing_index_count{cluster=\"$cluster\", node=~\"$node\"}[$interval])",
+              "expr": "1000 * increase(opensearch_indices_indexing_index_time_seconds{cluster=\"$cluster\", node=~\"$node\"}[$__rate_interval]) / increase(opensearch_indices_indexing_index_count{cluster=\"$cluster\", node=~\"$node\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}}",
@@ -1095,7 +1095,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Indexing latency",
+          "title": "Indexing latency (avg in millisecs / doc)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1171,7 +1171,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(opensearch_indices_search_query_count{cluster=\"$cluster\", node=~\"$node\"}[$interval])",
+              "expr": "rate(opensearch_indices_search_query_count{cluster=\"$cluster\", node=~\"$node\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}}",
@@ -1257,7 +1257,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(opensearch_indices_search_query_time_seconds{cluster=\"$cluster\", node=~\"$node\"}[$interval]) / rate(opensearch_indices_search_query_count{cluster=\"$cluster\", node=~\"$node\"}[$interval])",
+              "expr": "1000 * rate(opensearch_indices_search_query_time_seconds{cluster=\"$cluster\", node=~\"$node\"}[$__rate_interval]) / rate(opensearch_indices_search_query_count{cluster=\"$cluster\", node=~\"$node\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}}",
@@ -1267,7 +1267,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Search latency",
+          "title": "Search latency (avg in millisecs / query)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1429,7 +1429,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(opensearch_indices_doc_deleted_number{cluster=\"$cluster\", node=~\"$node\"}[$interval])",
+              "expr": "rate(opensearch_indices_doc_deleted_number{cluster=\"$cluster\", node=~\"$node\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}}",
@@ -1515,7 +1515,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(opensearch_indices_merges_total_docs_count{cluster=\"$cluster\",node=~\"$node\"}[$interval])",
+              "expr": "rate(opensearch_indices_merges_total_docs_count{cluster=\"$cluster\",node=~\"$node\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}}",
@@ -1701,7 +1701,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(opensearch_indices_fielddata_evictions_count{cluster=\"$cluster\", node=~\"$node\"}[$interval])",
+              "expr": "rate(opensearch_indices_fielddata_evictions_count{cluster=\"$cluster\", node=~\"$node\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}}",
@@ -1873,7 +1873,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(opensearch_indices_querycache_evictions_count{cluster=\"$cluster\", node=~\"$node\"}[$interval])",
+              "expr": "rate(opensearch_indices_querycache_evictions_count{cluster=\"$cluster\", node=~\"$node\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}}",
@@ -1883,7 +1883,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Query cache evictions",
+          "title": "Query cache evictions rate",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1959,7 +1959,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(opensearch_indices_querycache_hit_count{cluster=\"$cluster\", node=~\"$node\"}[$interval])",
+              "expr": "rate(opensearch_indices_querycache_hit_count{cluster=\"$cluster\", node=~\"$node\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}}",
@@ -1969,7 +1969,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Query cache hits",
+          "title": "Query cache hits rate",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -2045,7 +2045,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(opensearch_indices_querycache_miss_number{cluster=\"$cluster\", node=~\"$node\"}[$interval])",
+              "expr": "rate(opensearch_indices_querycache_miss_number{cluster=\"$cluster\", node=~\"$node\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}}",
@@ -2055,7 +2055,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Query cache misses",
+          "title": "Query cache misses rate",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -2145,7 +2145,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(opensearch_indices_indexing_throttle_time_seconds{cluster=\"$cluster\", node=~\"$node\"}[$interval])",
+              "expr": "rate(opensearch_indices_indexing_throttle_time_seconds{cluster=\"$cluster\", node=~\"$node\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}}",
@@ -2231,7 +2231,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(opensearch_indices_merges_total_throttled_time_seconds{cluster=\"$cluster\", node=~\"$node\"}[$interval])",
+              "expr": "rate(opensearch_indices_merges_total_throttled_time_seconds{cluster=\"$cluster\", node=~\"$node\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}}",
@@ -2417,7 +2417,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(opensearch_jvm_gc_collection_count{cluster=\"$cluster\",node=~\"$node\"}[$interval])",
+              "expr": "rate(opensearch_jvm_gc_collection_count{cluster=\"$cluster\",node=~\"$node\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}} - {{gc}}",
@@ -2503,7 +2503,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "rate(opensearch_jvm_gc_collection_time_seconds{cluster=\"$cluster\", node=~\"$node\"}[$interval])",
+              "expr": "rate(opensearch_jvm_gc_collection_time_seconds{cluster=\"$cluster\", node=~\"$node\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}} - {{gc}}",

--- a/src/grafana_dashboards/opensearch.json
+++ b/src/grafana_dashboards/opensearch.json
@@ -295,7 +295,7 @@
               "value": "null"
             }
           ],
-          "valueName": "avg"
+          "valueName": "current"
         },
         {
           "cacheTimeout": null,
@@ -375,7 +375,7 @@
               "value": "null"
             }
           ],
-          "valueName": "avg"
+          "valueName": "current"
         },
         {
           "cacheTimeout": null,
@@ -455,7 +455,7 @@
               "value": "null"
             }
           ],
-          "valueName": "avg"
+          "valueName": "current"
         }
       ],
       "repeat": null,
@@ -1085,7 +1085,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "1000 * delta(opensearch_indices_indexing_index_time_seconds{cluster=\"$cluster\", roles=~\".*($role).*\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval]) / delta(opensearch_indices_indexing_index_count{cluster=\"$cluster\", roles=~\".*($role).*\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])",
+              "expr": "1000 * rate(opensearch_indices_indexing_index_time_seconds{cluster=\"$cluster\", roles=~\".*($role).*\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}}",
@@ -1095,7 +1095,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Indexing latency / doc (in millisecs)",
+          "title": "Indexing latency for new docs (in millisecs)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -1257,7 +1257,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "1000 * rate(opensearch_indices_search_query_time_seconds{cluster=\"$cluster\", roles=~\".*($role).*\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval]) / rate(opensearch_indices_search_query_count{cluster=\"$cluster\", roles=~\".*($role).*\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])",
+              "expr": "1000 * rate(opensearch_indices_search_query_time_seconds{cluster=\"$cluster\", roles=~\".*($role).*\", juju_model_uuid=~\"$juju_model_uuid\", juju_model=~\"$juju_model\", juju_application=~\"$juju_application\", juju_unit=~\"$juju_unit\"}[$__rate_interval])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{node}}",
@@ -1267,7 +1267,7 @@
           "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
-          "title": "Search latency (avg in millisecs / query)",
+          "title": "Search latency (avg in millisecs)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -2666,6 +2666,16 @@
             "selected": false,
             "text": "voting",
             "value": "voting"
+          },
+          {
+            "selected": false,
+            "text": "coordinating_only",
+            "value": "coordinating_only"
+          },
+          {
+            "selected": false,
+            "text": "ingest",
+            "value": "ingest"
           },
           {
             "selected": false,

--- a/src/grafana_dashboards/opensearch.json
+++ b/src/grafana_dashboards/opensearch.json
@@ -2774,6 +2774,6 @@
     ]
   },
   "timezone": "browser",
-  "title": "OpenSearch",
+  "title": "Charmed OpenSearch",
   "version": 0
 }

--- a/tests/integration/plugins/test_plugins.py
+++ b/tests/integration/plugins/test_plugins.py
@@ -252,20 +252,11 @@ async def test_large_deployment_build_and_deploy(ops_test: OpsTest, deploy_type:
 @pytest.mark.parametrize("deploy_type", DEPLOY_LARGE_ONLY_CLOUD_GROUP_MARKS)
 @pytest.mark.abort_on_fail
 async def test_large_deployment_prometheus_exporter_cos_relation(ops_test, deploy_type: str):
-    await ops_test.model.deploy(COS_APP_NAME, channel="edge"),
-    await ops_test.model.integrate("failover", COS_APP_NAME)
-    await ops_test.model.integrate("main", COS_APP_NAME)
-    await ops_test.model.integrate(APP_NAME, COS_APP_NAME)
-
-    await _wait_for_units(ops_test, deploy_type)
-
     # Check that the correct settings were successfully communicated to grafana-agent
-    cos_leader_id = await get_leader_unit_id(ops_test, COS_APP_NAME)
-    cos_leader_name = f"{COS_APP_NAME}/{cos_leader_id}"
     leader_id = await get_leader_unit_id(ops_test, APP_NAME)
     leader_name = f"{APP_NAME}/{leader_id}"
     relation_data_raw = await get_unit_relation_data(
-        ops_test, cos_leader_name, leader_name, COS_RELATION_NAME, "config"
+        ops_test, f"{COS_APP_NAME}/0", leader_name, COS_RELATION_NAME, "config"
     )
     relation_data = json.loads(relation_data_raw)["metrics_scrape_jobs"][0]
     secret = await get_secret_by_label(ops_test, "opensearch:app:monitor-password")
@@ -324,14 +315,15 @@ async def test_prometheus_monitor_user_password_change(ops_test, deploy_type: st
     # Relation data is updated
     # In both large and small deployments, we want to check if the relation data is updated
     # on the data node: "opensearch"
-    cos_leader_id = await get_leader_unit_id(ops_test, COS_APP_NAME)
-    cos_leader_name = f"{COS_APP_NAME}/{cos_leader_id}"
     leader_id = await get_leader_unit_id(ops_test, APP_NAME)
     leader_name = f"{APP_NAME}/{leader_id}"
+
+    # We're not sure which grafana-agent is sitting with APP_NAME in large deployments
     relation_data_raw = await get_unit_relation_data(
-        ops_test, cos_leader_name, leader_name, COS_RELATION_NAME, "config"
+        ops_test, f"{COS_APP_NAME}/0", leader_name, COS_RELATION_NAME, "config"
     )
     relation_data = json.loads(relation_data_raw)["metrics_scrape_jobs"][0]["basic_auth"]
+
     assert relation_data["username"] == "monitor"
     assert relation_data["password"] == new_password
 

--- a/tests/integration/plugins/test_plugins.py
+++ b/tests/integration/plugins/test_plugins.py
@@ -262,8 +262,10 @@ async def test_large_deployment_prometheus_exporter_cos_relation(ops_test, deplo
 
     leader_id = await get_leader_unit_id(ops_test, APP_NAME)
     leader_name = f"{APP_NAME}/{leader_id}"
+
+    cos_leader_id = await get_leader_unit_id(ops_test, COS_APP_NAME)
     relation_data_raw = await get_unit_relation_data(
-        ops_test, f"{COS_APP_NAME}/0", leader_name, COS_RELATION_NAME, "config"
+        ops_test, f"{COS_APP_NAME}/{cos_leader_id}", leader_name, COS_RELATION_NAME, "config"
     )
     relation_data = json.loads(relation_data_raw)["metrics_scrape_jobs"][0]
     secret = await get_secret_by_label(ops_test, "opensearch:app:monitor-password")
@@ -326,8 +328,9 @@ async def test_prometheus_monitor_user_password_change(ops_test, deploy_type: st
     leader_name = f"{APP_NAME}/{leader_id}"
 
     # We're not sure which grafana-agent is sitting with APP_NAME in large deployments
+    cos_leader_id = await get_leader_unit_id(ops_test, COS_APP_NAME)
     relation_data_raw = await get_unit_relation_data(
-        ops_test, f"{COS_APP_NAME}/0", leader_name, COS_RELATION_NAME, "config"
+        ops_test, f"{COS_APP_NAME}/{cos_leader_id}", leader_name, COS_RELATION_NAME, "config"
     )
     relation_data = json.loads(relation_data_raw)["metrics_scrape_jobs"][0]["basic_auth"]
 

--- a/tests/integration/plugins/test_plugins.py
+++ b/tests/integration/plugins/test_plugins.py
@@ -262,7 +262,7 @@ async def test_large_deployment_build_and_deploy(ops_test: OpsTest, deploy_type:
     await ops_test.model.integrate(APP_NAME, TLS_CERTIFICATES_APP_NAME)
 
     await _wait_for_units(ops_test, deploy_type)
-    set_watermark(ops_test, APP_NAME)
+    await set_watermark(ops_test, APP_NAME)
 
 
 @pytest.mark.parametrize("deploy_type", DEPLOY_LARGE_ONLY_CLOUD_GROUP_MARKS)

--- a/tests/integration/plugins/test_plugins.py
+++ b/tests/integration/plugins/test_plugins.py
@@ -354,7 +354,7 @@ async def test_prometheus_monitor_user_password_change(ops_test, deploy_type: st
     assert relation_data["password"] == new_password
 
 
-@pytest.mark.parametrize("deploy_type", DEPLOY_CLOUD_GROUP_MARKS)
+@pytest.mark.parametrize("deploy_type", DEPLOY_SMALL_ONLY_CLOUD_GROUP_MARKS)
 @pytest.mark.abort_on_fail
 async def test_knn_enabled_disabled(ops_test, deploy_type: str):
     config = await ops_test.model.applications[APP_NAME].get_config()
@@ -377,7 +377,7 @@ async def test_knn_enabled_disabled(ops_test, deploy_type: str):
         await _wait_for_units(ops_test, deploy_type)
 
 
-@pytest.mark.parametrize("deploy_type", DEPLOY_CLOUD_GROUP_MARKS)
+@pytest.mark.parametrize("deploy_type", DEPLOY_SMALL_ONLY_CLOUD_GROUP_MARKS)
 @pytest.mark.abort_on_fail
 async def test_knn_search_with_hnsw_faiss(ops_test: OpsTest, deploy_type: str) -> None:
     """Uploads data and runs a query search against the FAISS KNNEngine."""
@@ -421,7 +421,7 @@ async def test_knn_search_with_hnsw_faiss(ops_test: OpsTest, deploy_type: str) -
     assert len(docs) == 2
 
 
-@pytest.mark.parametrize("deploy_type", DEPLOY_CLOUD_GROUP_MARKS)
+@pytest.mark.parametrize("deploy_type", DEPLOY_SMALL_ONLY_CLOUD_GROUP_MARKS)
 @pytest.mark.abort_on_fail
 async def test_knn_search_with_hnsw_nmslib(ops_test: OpsTest, deploy_type: str) -> None:
     """Uploads data and runs a query search against the NMSLIB KNNEngine."""
@@ -465,7 +465,7 @@ async def test_knn_search_with_hnsw_nmslib(ops_test: OpsTest, deploy_type: str) 
     assert len(docs) == 2
 
 
-@pytest.mark.parametrize("deploy_type", DEPLOY_CLOUD_GROUP_MARKS)
+@pytest.mark.parametrize("deploy_type", DEPLOY_SMALL_ONLY_CLOUD_GROUP_MARKS)
 @pytest.mark.abort_on_fail
 async def test_knn_training_search(ops_test: OpsTest, deploy_type: str) -> None:
     """Tests the entire cycle of KNN plugin.

--- a/tests/integration/plugins/test_plugins.py
+++ b/tests/integration/plugins/test_plugins.py
@@ -253,6 +253,13 @@ async def test_large_deployment_build_and_deploy(ops_test: OpsTest, deploy_type:
 @pytest.mark.abort_on_fail
 async def test_large_deployment_prometheus_exporter_cos_relation(ops_test, deploy_type: str):
     # Check that the correct settings were successfully communicated to grafana-agent
+    await ops_test.model.deploy(COS_APP_NAME, channel="edge"),
+    await ops_test.model.integrate("failover", COS_APP_NAME)
+    await ops_test.model.integrate("main", COS_APP_NAME)
+    await ops_test.model.integrate(APP_NAME, COS_APP_NAME)
+
+    await _wait_for_units(ops_test, deploy_type)
+
     leader_id = await get_leader_unit_id(ops_test, APP_NAME)
     leader_name = f"{APP_NAME}/{leader_id}"
     relation_data_raw = await get_unit_relation_data(

--- a/tests/integration/relations/helpers.py
+++ b/tests/integration/relations/helpers.py
@@ -99,7 +99,16 @@ async def get_unit_relation_data(
         raise ValueError(
             f"no relation data could be grabbed on relation with endpoint {relation_name}"
         )
-    return relation_data[0]["related-units"].get(target_unit_name, {}).get("data", {}).get(key, {})
+    # Consider the case we are dealing with subordinate charms, e.g. grafana-agent
+    # The field "relation-units" is structured slightly different.
+    for idx in range(len(relation_data)):
+        if target_unit_name in relation_data[idx]["related-units"]:
+            break
+    else:
+        return {}
+    return (
+        relation_data[idx]["related-units"].get(target_unit_name, {}).get("data", {}).get(key, {})
+    )
 
 
 def wait_for_relation_joined_between(

--- a/tests/unit/lib/test_backups.py
+++ b/tests/unit/lib/test_backups.py
@@ -659,7 +659,6 @@ class TestBackups(unittest.TestCase):
         mock_status.return_value = PluginState.ENABLED
         self.harness.remove_relation_unit(self.s3_rel_id, "s3-integrator/0")
         self.harness.remove_relation(self.s3_rel_id)
-        mock_request.called_once_with("GET", "/_snapshot/_status")
         mock_execute_s3_broken_calls.assert_called_once()
         assert (
             mock_apply_config.call_args[0][0].__dict__


### PR DESCRIPTION
Renames our dashboard to "Charmed OpenSearch". This PR addresses the following needs in our COS integration for large deployments:
1) **Fixes data node integration with COS**: COSAgentProvider was not tracking peer-cluster-* events, which means it was not receiving changes done to the COSUser by the main orchestrator
2) **Add integration tests to COS**: large deployments integration tests for COS were missing, this PR makes `test_plugins` more flexible, so it can run both small and large deployments
3) **Manage user passwords**: large deployments will now answer to `set-password` action and `MAIN_ORCHESTRATOR` propagates the new password value down to the other apps
4) **Adds Role to Dashboard**: adds "Roles" as a dropdown option to Grafana dashboard, allowing to filter each cluster also by OpenSearch "construct" node role.

## Empty Dashboard Fix

Some dashboards are being set with `$interval`, which defaults to `1m` and does not allow to run the actual calculation. This PR fixes it by using [__rate_interval](https://grafana.com/blog/2020/09/28/new-in-grafana-7.2-__rate_interval-for-prometheus-rate-queries-that-just-work/) instead, which is a fixed period of X sample times for any `rate()` calculations.

### Before
![Screenshot from 2024-06-13 20-42-30](https://github.com/canonical/opensearch-operator/assets/31036845/b030d6bf-ad06-494b-a170-6154eccbc1f1)

### After
![Screenshot from 2024-06-13 20-42-42](https://github.com/canonical/opensearch-operator/assets/31036845/72c2265c-7a3b-4cf3-963e-b464f697368e)


This is a graph for `rate()`, which means we want to compare sample deltas over a window of time. The later graph makes more sense in this case.