### PR TITLE
[DPE-4521] Reload TLS certs without restarting

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -743,8 +743,8 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             self.opensearch_config.set_admin_tls_conf(current_secrets)
 
         # In case of renewal of the unit transport layer cert - restart opensearch
-        if renewal and self.is_admin_user_configured() and self.is_tls_fully_configured():
-            self._restart_opensearch_event.emit()
+#        if renewal and self.is_admin_user_configured() and self.is_tls_fully_configured():
+#            self._restart_opensearch_event.emit()
 
     def on_tls_relation_broken(self, _: RelationBrokenEvent):
         """As long as all certificates are produced, we don't do anything."""

--- a/lib/charms/opensearch/v0/opensearch_config.py
+++ b/lib/charms/opensearch/v0/opensearch_config.py
@@ -175,6 +175,12 @@ class OpenSearchConfig:
             "plugins.security.unsupported.restapi.allow_securityconfig_modification",
             True,
         )
+        # enable hot reload of TLS certs (without restarting the node)
+        self._opensearch.config.put(
+            self.CONFIG_YML,
+            "plugins.security.ssl_cert_reload_enabled",
+            True,
+        )
 
     def remove_temporary_data_role(self):
         """Remove the data role that was added temporarily to the first dedicated CM node."""


### PR DESCRIPTION
## Issue
Currently the OpenSearch application is restarted when TLS certificates are provided (with the `on.certificate_available` handler). This could be simplified by using the "hot reload" API OpenSearch provides for renewing the TLS certs.

## Solution
- activate the `plugins.security.ssl_cert_reload_enabled` setting
- when TLS conf is set, query the API instead of restarting OpenSearch