### PR TITLE
[DPE-4729] network.host should have a single IP

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_config.py
+++ b/lib/charms/opensearch/v0/opensearch_config.py
@@ -132,7 +132,7 @@ class OpenSearchConfig:
         self._opensearch.config.put(self.CONFIG_YML, "cluster.name", f"{cluster_name}")
         self._opensearch.config.put(self.CONFIG_YML, "node.name", unit_name)
         self._opensearch.config.put(
-            self.CONFIG_YML, "network.host", ["_site_"] + self._opensearch.network_hosts
+            self.CONFIG_YML, "network.host", self._opensearch.network_hosts
         )
 
         self._opensearch.config.put(self.CONFIG_YML, "node.roles", roles)
@@ -235,7 +235,7 @@ class OpenSearchConfig:
             # Unit not configured yet
             return False
 
-        hosts = set(["_site_"] + self._opensearch.network_hosts)
+        hosts = set(self._opensearch.network_hosts)
         if old_hosts != hosts:
             logger.info(f"Updating network.host from: {old_hosts} - to: {hosts}")
             self._opensearch.config.put(self.CONFIG_YML, "network.host", hosts)


### PR DESCRIPTION
On a multi-space deployment, we may end up on a conflict where OpenSearch will select a different IP from what is originally set for the `peers*` relations.

That happens because `_site_` is being passed.

This PR removes the `_site_` and narrows down the list of possible values for `network.host` to a single IP value.

Closes: #334
