### PR TITLE
[DPE-4769] Add hardware-observe support

### DIFF
--- a/lib/charms/opensearch/v0/constants_charm.py
+++ b/lib/charms/opensearch/v0/constants_charm.py
@@ -108,7 +108,7 @@ KibanaserverUser = "kibanaserver"
 KibanaserverRole = "kibana_server"
 
 # Opensearch Snap revision
-OPENSEARCH_SNAP_REVISION = 51  # Keep in sync with `workload_version` file
+OPENSEARCH_SNAP_REVISION = 53  # Keep in sync with `workload_version` file
 
 # User-face Backup ID format
 OPENSEARCH_BACKUP_ID_FORMAT = "%Y-%m-%dT%H:%M:%SZ"


### PR DESCRIPTION
New snap version 53 adds support for hugepages read on sysfs. This charm bumps the snap version so we can start using it on the charm deployments.