### PR TITLE
[DPE-4836] Add support for yellow status on pre-checks

### DIFF
--- a/src/machine_upgrade.py
+++ b/src/machine_upgrade.py
@@ -163,7 +163,11 @@ class Upgrade(upgrade.Upgrade):
                     else:
                         # Run pre-upgrade check
                         # (in case user forgot to run pre-upgrade-check action)
-                        self.pre_upgrade_check()
+
+                        # We accept yellow status here, as some replicas may have been unassigned
+                        # as this unit is down but cannot be allocated somewhere else due to
+                        # upgrade settings (only primaries are allowed)
+                        self.pre_upgrade_check(yellow_allowed=True)
                         logger.debug("Pre-upgrade check after `juju refresh` successful")
                 elif index == 1:
                     # User confirmation needed to resume upgrade (i.e. upgrade second unit)

--- a/src/machine_upgrade.py
+++ b/src/machine_upgrade.py
@@ -163,11 +163,7 @@ class Upgrade(upgrade.Upgrade):
                     else:
                         # Run pre-upgrade check
                         # (in case user forgot to run pre-upgrade-check action)
-
-                        # We accept yellow status here, as some replicas may have been unassigned
-                        # as this unit is down but cannot be allocated somewhere else due to
-                        # upgrade settings (only primaries are allowed)
-                        self.pre_upgrade_check(yellow_allowed=True)
+                        self.pre_upgrade_check()
                         logger.debug("Pre-upgrade check after `juju refresh` successful")
                 elif index == 1:
                     # User confirmation needed to resume upgrade (i.e. upgrade second unit)

--- a/src/upgrade.py
+++ b/src/upgrade.py
@@ -246,7 +246,7 @@ class Upgrade(abc.ABC):
         Only applies to machine charm
         """
 
-    def pre_upgrade_check(self) -> None:
+    def pre_upgrade_check(self, yellow_allowed: bool = False) -> None:
         """Check if this app is ready to upgrade
 
         Runs before any units are upgraded
@@ -273,7 +273,10 @@ class Upgrade(abc.ABC):
                 local_app_only=False,
                 wait_for_green_first=True,
             )
-            if health != HealthColors.GREEN:
+            allowed_states = [HealthColors.GREEN]
+            if yellow_allowed:
+                allowed_states.append(HealthColors.YELLOW, HealthColors.YELLOW_TEMP)
+            if health not in allowed_states:
                 raise PrecheckFailed(f"Cluster health is {health} instead of green")
 
             online_nodes = ClusterTopology.nodes(

--- a/src/upgrade.py
+++ b/src/upgrade.py
@@ -258,6 +258,14 @@ class Upgrade(abc.ABC):
 
         Can run on leader or non-leader unit
 
+        If the cluster is in the middle of the upgrade, we may have some replicas being
+        unassigned but cannot rellocated due to cluster routing set only for primaries.
+        For that, we use yellow_allowed=True, so we can tolerate unassigned replicas
+        after a given unit is stopped.
+
+        Args:
+            yellow_allowed: allows the check to pass if the cluster is in YELLOW status
+
         Raises:
             PrecheckFailed: App is not ready to upgrade
 

--- a/src/upgrade.py
+++ b/src/upgrade.py
@@ -277,7 +277,7 @@ class Upgrade(abc.ABC):
             if self.in_progress and not self._charm.opensearch.is_node_up():
                 # If the cluster is in the middle of the upgrade, we may have some replicas being
                 # unassigned but cannot rellocate as cluster routing is set only for primaries.
-                # For that, we use self.in_progress and distro's is_started, so we can tolerate
+                # For that, we use self.in_progress and distro's is_node_up, so we can tolerate
                 # unassigned replicas after this unit has been stopped.
                 allowed_states.extend([HealthColors.YELLOW, HealthColors.YELLOW_TEMP])
             if health not in allowed_states:

--- a/src/upgrade.py
+++ b/src/upgrade.py
@@ -277,8 +277,8 @@ class Upgrade(abc.ABC):
             if self.in_progress and not self._charm.opensearch.is_started():
                 # If the cluster is in the middle of the upgrade, we may have some replicas being
                 # unassigned but cannot rellocate as cluster routing is set only for primaries.
-                # For that, we use self.in_progress and , so we can tolerate unassigned replicas
-        after a given unit is stopped.
+                # For that, we use self.in_progress and distro's is_started, so we can tolerate
+                # unassigned replicas after this unit has been stopped.
                 allowed_states.extend([HealthColors.YELLOW, HealthColors.YELLOW_TEMP])
             if health not in allowed_states:
                 raise PrecheckFailed(f"Cluster health is {health} instead of green")

--- a/src/upgrade.py
+++ b/src/upgrade.py
@@ -246,7 +246,7 @@ class Upgrade(abc.ABC):
         Only applies to machine charm
         """
 
-    def pre_upgrade_check(self, yellow_allowed: bool = False) -> None:
+    def pre_upgrade_check(self) -> None:
         """Check if this app is ready to upgrade
 
         Runs before any units are upgraded
@@ -260,11 +260,8 @@ class Upgrade(abc.ABC):
 
         If the cluster is in the middle of the upgrade, we may have some replicas being
         unassigned but cannot rellocated due to cluster routing set only for primaries.
-        For that, we use yellow_allowed=True, so we can tolerate unassigned replicas
+        For that, we use self.in_progress, so we can tolerate unassigned replicas
         after a given unit is stopped.
-
-        Args:
-            yellow_allowed: allows the check to pass if the cluster is in YELLOW status
 
         Raises:
             PrecheckFailed: App is not ready to upgrade
@@ -282,7 +279,7 @@ class Upgrade(abc.ABC):
                 wait_for_green_first=True,
             )
             allowed_states = [HealthColors.GREEN]
-            if yellow_allowed:
+            if self.in_progress:
                 allowed_states.append(HealthColors.YELLOW, HealthColors.YELLOW_TEMP)
             if health not in allowed_states:
                 raise PrecheckFailed(f"Cluster health is {health} instead of green")

--- a/src/upgrade.py
+++ b/src/upgrade.py
@@ -280,7 +280,7 @@ class Upgrade(abc.ABC):
             )
             allowed_states = [HealthColors.GREEN]
             if self.in_progress:
-                allowed_states.append(HealthColors.YELLOW, HealthColors.YELLOW_TEMP)
+                allowed_states.extend([HealthColors.YELLOW, HealthColors.YELLOW_TEMP])
             if health not in allowed_states:
                 raise PrecheckFailed(f"Cluster health is {health} instead of green")
 

--- a/src/upgrade.py
+++ b/src/upgrade.py
@@ -274,7 +274,7 @@ class Upgrade(abc.ABC):
                 wait_for_green_first=True,
             )
             allowed_states = [HealthColors.GREEN]
-            if self.in_progress and not self._charm.opensearch.is_started():
+            if self.in_progress and not self._charm.opensearch.is_node_up():
                 # If the cluster is in the middle of the upgrade, we may have some replicas being
                 # unassigned but cannot rellocate as cluster routing is set only for primaries.
                 # For that, we use self.in_progress and distro's is_started, so we can tolerate


### PR DESCRIPTION
Currently, pre_upgrade_checks only accept GREEN status before finishing the upgrade of a given unit. That is correct if the user is running the pre-upgrade-checks action.

However, if the cluster is in the middle of the upgrade, we should expect some of the shard replicas to be unassigned until the upgrade ends.

Closes #350
