### PR TITLE
[DPE-4654] create keystore password if not exists

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -440,6 +440,7 @@ class OpenSearchTLS(Object):
         keytool = f"sudo {self.jdk_path}/bin/keytool"
 
         admin_secrets = self.charm.secrets.get_object(Scope.APP, CertType.APP_ADMIN.val)
+        self._create_keystore_pwd_if_not_exists(Scope.APP, CertType.APP_ADMIN, "ca")
 
         if not (secrets.get("ca-cert", {}) and admin_secrets.get("keystore-password-ca", {})):
             logging.error("CA cert not found, quitting.")
@@ -494,6 +495,12 @@ class OpenSearchTLS(Object):
         """Add key and cert to keystore."""
         cert_name = cert_type.val
         store_path = f"{self.certs_path}/{cert_type}.p12"
+
+        # if the TLS certificate is available before the keystore-password, create it anyway
+        if cert_type == CertType.APP_ADMIN:
+            self._create_keystore_pwd_if_not_exists(Scope.APP, cert_type, cert_type.val)
+        else:
+            self._create_keystore_pwd_if_not_exists(Scope.UNIT, cert_type, cert_type.val)
 
         if not secrets.get("key"):
             logging.error("TLS key not found, quitting.")

--- a/tests/unit/lib/test_opensearch_tls.py
+++ b/tests/unit/lib/test_opensearch_tls.py
@@ -183,20 +183,31 @@ class TestOpenSearchTLS(unittest.TestCase):
         _request_certificate.assert_called()
 
     @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS._request_certificate")
+    @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS._create_keystore_pwd_if_not_exists")
     @patch("charm.OpenSearchOperatorCharm.on_tls_conf_set")
     @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS.store_new_ca")
     @patch("charm.OpenSearchOperatorCharm._put_or_update_internal_user_leader")
     def test_on_certificate_available(
-        self, _, on_tls_conf_set, _request_certificate, store_new_ca
+        self,
+        _,
+        on_tls_conf_set,
+        _request_certificate,
+        store_new_ca,
+        _create_keystore_pwd_if_not_exists,
     ):
         """Test _on_certificate_available event."""
         csr = "csr_12345"
         cert = "cert_12345"
         chain = ["chain_12345"]
         ca = "ca_12345"
+        keystore_password = "keystore_12345"
         secret_key = CertType.UNIT_TRANSPORT.val
 
-        self.secret_store.put_object(Scope.UNIT, secret_key, {"csr": csr})
+        self.secret_store.put_object(
+            Scope.UNIT,
+            secret_key,
+            {"csr": csr, "keystore-password-unit-transport": keystore_password},
+        )
 
         event_mock = MagicMock(
             certificate_signing_request=csr, chain=chain, certificate=cert, ca=ca
@@ -205,7 +216,13 @@ class TestOpenSearchTLS(unittest.TestCase):
 
         self.assertDictEqual(
             self.secret_store.get_object(Scope.UNIT, secret_key),
-            {"csr": csr, "chain": chain[0], "cert": cert, "ca-cert": ca},
+            {
+                "csr": csr,
+                "chain": chain[0],
+                "cert": cert,
+                "ca-cert": ca,
+                "keystore-password-unit-transport": keystore_password,
+            },
         )
 
         on_tls_conf_set.assert_called()


### PR DESCRIPTION
## Issue
If the `on_certificate_available` hook is run before the `on_relation_created` (for the TLS relation), it may happen that the keystore password is not yet available and the creation of keystore or truststore fails (as seen in [this](https://github.com/canonical/opensearch-operator/actions/runs/9853942720/job/27205887472) integration test run).

## Solution
Create the keystore password also on the actions triggered by `on_certificate_available`, namely when the ca is stored or when the TLS certs are stored.