### PR TITLE
[DPE-4654] do not log command args

### DIFF
--- a/lib/charms/opensearch/v0/helper_charm.py
+++ b/lib/charms/opensearch/v0/helper_charm.py
@@ -175,7 +175,7 @@ def run_cmd(command: str, args: str = None) -> SimpleNamespace:
 
     # only log the command and no arguments to avoid logging sensitive information
     command = mask_sensitive_information(command_with_args)
-    logger.info(f"Executing command: {command}")
+    logger.debug(f"Executing command: {command}")
 
     try:
         output = subprocess.run(

--- a/lib/charms/opensearch/v0/helper_charm.py
+++ b/lib/charms/opensearch/v0/helper_charm.py
@@ -173,6 +173,8 @@ def run_cmd(command: str, args: str = None) -> SimpleNamespace:
 
     command_with_args = " ".join(command_with_args.split())
 
+    # only log the command and no arguments to avoid logging sensitive information
+    command = command.split()[0]
     logger.debug(f"Executing command: {command}")
 
     try:

--- a/lib/charms/opensearch/v0/helper_charm.py
+++ b/lib/charms/opensearch/v0/helper_charm.py
@@ -167,16 +167,17 @@ def run_cmd(command: str, args: str = None) -> SimpleNamespace:
         command: can contain arguments
         args: command line arguments
     """
+    command_with_args = command
     if args is not None:
-        command = f"{command} {args}"
+        command_with_args = f"{command} {args}"
 
-    command = " ".join(command.split())
+    command_with_args = " ".join(command_with_args.split())
 
     logger.debug(f"Executing command: {command}")
 
     try:
         output = subprocess.run(
-            command,
+            command_with_args,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             shell=True,

--- a/lib/charms/opensearch/v0/helper_charm.py
+++ b/lib/charms/opensearch/v0/helper_charm.py
@@ -174,8 +174,8 @@ def run_cmd(command: str, args: str = None) -> SimpleNamespace:
     command_with_args = " ".join(command_with_args.split())
 
     # only log the command and no arguments to avoid logging sensitive information
-    command = command.split()[0]
-    logger.debug(f"Executing command: {command}")
+    command = mask_sensitive_information(command_with_args)
+    logger.info(f"Executing command: {command}")
 
     try:
         output = subprocess.run(
@@ -196,3 +196,10 @@ def run_cmd(command: str, args: str = None) -> SimpleNamespace:
         return SimpleNamespace(cmd=command, out=output.stdout, err=output.stderr)
     except (TimeoutError, subprocess.TimeoutExpired):
         raise OpenSearchCmdError(cmd=command)
+
+
+def mask_sensitive_information(cmd: str) -> str:
+    """Replace passwords or secrets by 'xxx' and return the masked str."""
+    pattern = re.compile(r"(--tspass\s+|-storepass\s+|-new\s+|pass:)(\S+)")
+
+    return re.sub(pattern, r"\1" + "xxx", cmd)

--- a/lib/charms/opensearch/v0/helper_charm.py
+++ b/lib/charms/opensearch/v0/helper_charm.py
@@ -200,6 +200,6 @@ def run_cmd(command: str, args: str = None) -> SimpleNamespace:
 
 def mask_sensitive_information(cmd: str) -> str:
     """Replace passwords or secrets by 'xxx' and return the masked str."""
-    pattern = re.compile(r"(--tspass\s+|-storepass\s+|-new\s+|pass:)(\S+)")
+    pattern = re.compile(r"(-tspass\s+|-kspass\s+|-storepass\s+|-new\s+|pass:)(\S+)")
 
     return re.sub(pattern, r"\1" + "xxx", cmd)

--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -338,6 +338,8 @@ class OpenSearchDistribution(ABC):
         if args is not None:
             command_with_args = f"{command} {args}"
 
+        # only log the command and no arguments to avoid logging sensitive information
+        command = command.split()[0]
         logger.debug(f"Executing command: {command}")
 
         try:

--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -17,6 +17,7 @@ from typing import Dict, List, Optional, Set, Union
 
 import requests
 import urllib3.exceptions
+from charms.opensearch.v0.helper_charm import mask_sensitive_information
 from charms.opensearch.v0.helper_cluster import Node
 from charms.opensearch.v0.helper_conf_setter import YamlConfigSetter
 from charms.opensearch.v0.helper_http import error_http_retry_log
@@ -339,7 +340,7 @@ class OpenSearchDistribution(ABC):
             command_with_args = f"{command} {args}"
 
         # only log the command and no arguments to avoid logging sensitive information
-        command = command.split()[0]
+        command = mask_sensitive_information(command_with_args)
         logger.debug(f"Executing command: {command}")
 
         try:

--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -334,14 +334,15 @@ class OpenSearchDistribution(ABC):
 
         Returns the stdout
         """
+        command_with_args = command
         if args is not None:
-            command = f"{command} {args}"
+            command_with_args = f"{command} {args}"
 
         logger.debug(f"Executing command: {command}")
 
         try:
             output = subprocess.run(
-                command,
+                command_with_args,
                 input=stdin,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,

--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -462,7 +462,8 @@ class OpenSearchTLS(Object):
                 -keystore {store_path} \
                 -file {ca_tmp_file.name} \
                 -storetype PKCS12
-            """, f"-storepass {admin_secrets.get("keystore-password-ca")}"
+            """,
+                f"-storepass {admin_secrets.get("keystore-password-ca")}",
             )
             run_cmd(f"sudo chmod +r {store_path}")
 
@@ -476,7 +477,7 @@ class OpenSearchTLS(Object):
 
         stored_certs = run_cmd(
             f"openssl pkcs12 -in {ca_trust_store}",
-            f"-passin pass:{secrets.get("keystore-password-ca")}"
+            f"-passin pass:{secrets.get("keystore-password-ca")}",
         ).out
 
         # parse output to retrieve the current CA (in case there are many)

--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -534,7 +534,7 @@ class OpenSearchTLS(Object):
                 -out {store_path} \
                 -name {cert_name}
             """
-            args = f"-passout pass:{secrets.get(f"keystore-password-{cert_name}")}"
+            args = f"-passout pass:{secrets.get(f'keystore-password-{cert_name}')}"
             if secrets.get("key-password"):
                 args = f"{args} -passin pass:{secrets.get('key-password')}"
 

--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -461,9 +461,8 @@ class OpenSearchTLS(Object):
                 -alias {alias} \
                 -keystore {store_path} \
                 -file {ca_tmp_file.name} \
-                -storepass {admin_secrets.get("keystore-password-ca")} \
                 -storetype PKCS12
-            """
+            """, f"-storepass {admin_secrets.get("keystore-password-ca")}"
             )
             run_cmd(f"sudo chmod +r {store_path}")
 
@@ -476,10 +475,8 @@ class OpenSearchTLS(Object):
             return None
 
         stored_certs = run_cmd(
-            f"""openssl pkcs12 \
-            -in {ca_trust_store} \
-            -passin pass:{secrets.get("keystore-password-ca")}
-            """
+            f"openssl pkcs12 -in {ca_trust_store}",
+            f"-passin pass:{secrets.get("keystore-password-ca")}"
         ).out
 
         # parse output to retrieve the current CA (in case there are many)
@@ -534,13 +531,13 @@ class OpenSearchTLS(Object):
                 -in {tmp_cert.name} \
                 -inkey {tmp_key.name} \
                 -out {store_path} \
-                -name {cert_name} \
-                -passout pass:{secrets.get(f"keystore-password-{cert_name}")}
+                -name {cert_name}
             """
+            args = f"-passout pass:{secrets.get(f"keystore-password-{cert_name}")}"
             if secrets.get("key-password"):
-                cmd = f"{cmd} -passin pass:{secrets.get('key-password')}"
+                args = f"{args} -passin pass:{secrets.get('key-password')}"
 
-            run_cmd(cmd)
+            run_cmd(cmd, args)
             run_cmd(f"sudo chmod +r {store_path}")
         finally:
             tmp_key.close()

--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -463,7 +463,7 @@ class OpenSearchTLS(Object):
                 -file {ca_tmp_file.name} \
                 -storetype PKCS12
             """,
-                f"-storepass {admin_secrets.get("keystore-password-ca")}",
+                f"-storepass {admin_secrets.get('keystore-password-ca')}",
             )
             run_cmd(f"sudo chmod +r {store_path}")
 
@@ -477,7 +477,7 @@ class OpenSearchTLS(Object):
 
         stored_certs = run_cmd(
             f"openssl pkcs12 -in {ca_trust_store}",
-            f"-passin pass:{secrets.get("keystore-password-ca")}",
+            f"-passin pass:{secrets.get('keystore-password-ca')}",
         ).out
 
         # parse output to retrieve the current CA (in case there are many)

--- a/tests/unit/lib/test_helper_charm.py
+++ b/tests/unit/lib/test_helper_charm.py
@@ -6,7 +6,7 @@
 import unittest
 
 from charms.opensearch.v0.constants_charm import PeerRelationName
-from charms.opensearch.v0.helper_charm import Status
+from charms.opensearch.v0.helper_charm import mask_sensitive_information, Status
 from ops.model import BlockedStatus, MaintenanceStatus, WaitingStatus
 from ops.testing import Harness
 
@@ -45,3 +45,22 @@ class TestHelperDatabag(unittest.TestCase):
         self.charm.unit.status = BlockedStatus(message_template.format(5, "unit tests"))
         self.status.clear(message_template, pattern=Status.CheckPattern.Interpolated)
         self.assertEqual(self.charm.unit.status.name, "active")
+
+    def test_mask_sensitive_information(self):
+        """Verify the pattern to remove sensitive information from the logs."""
+        command_to_test = """-tspass mypasswd \
+        -kspass myother!passwd \
+        -storepass another#passwd \
+        -new newpasswd% \
+        pass:pass&wd,
+        """
+
+        expected_result = """-tspass xxx \
+        -kspass xxx \
+        -storepass xxx \
+        -new xxx \
+        pass:xxx
+        """
+
+        actual_result = mask_sensitive_information(command_to_test)
+        assert actual_result == expected_result

--- a/tests/unit/lib/test_helper_charm.py
+++ b/tests/unit/lib/test_helper_charm.py
@@ -6,7 +6,7 @@
 import unittest
 
 from charms.opensearch.v0.constants_charm import PeerRelationName
-from charms.opensearch.v0.helper_charm import mask_sensitive_information, Status
+from charms.opensearch.v0.helper_charm import Status, mask_sensitive_information
 from ops.model import BlockedStatus, MaintenanceStatus, WaitingStatus
 from ops.testing import Harness
 


### PR DESCRIPTION
To avoid writing sensitive information to the logs I propose to adjust the run_cmd function and mask known patterns for passwords and secrets.