### PR TITLE
[DPE-4857] improve naming of truststore and keystore secrets

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -709,11 +709,9 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
 
         if scope == Scope.UNIT:
             truststore_pwd = self.secrets.get_object(Scope.APP, CertType.APP_ADMIN.val)[
-                "keystore-password-ca"
+                "truststore-password"
             ]
-            keystore_pwd = self.secrets.get_object(scope, cert_type.val)[
-                f"keystore-password-{cert_type}"
-            ]
+            keystore_pwd = self.secrets.get_object(scope, cert_type.val)["keystore-password"]
 
             # node http or transport cert
             self.opensearch_config.set_node_tls_conf(
@@ -1270,11 +1268,11 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             f"-cn {self.opensearch_peer_cm.deployment_desc().config.cluster_name}",
             f"-h {self.unit_ip}",
             f"-ts {self.opensearch.paths.certs}/ca.p12",
-            f"-tspass {self.secrets.get_object(Scope.APP, CertType.APP_ADMIN.val)['keystore-password-ca']}",
+            f"-tspass {self.secrets.get_object(Scope.APP, CertType.APP_ADMIN.val)['truststore-password']}",
             "-tsalias ca",
             "-tst PKCS12",
             f"-ks {self.opensearch.paths.certs}/{CertType.APP_ADMIN}.p12",
-            f"-kspass {self.secrets.get_object(Scope.APP, CertType.APP_ADMIN.val)['keystore-password-app-admin']}",
+            f"-kspass {self.secrets.get_object(Scope.APP, CertType.APP_ADMIN.val)['keystore-password']}",
             f"-ksalias {CertType.APP_ADMIN}",
             "-kst PKCS12",
         ]

--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -424,10 +424,7 @@ class OpenSearchTLS(Object):
     def _create_keystore_pwd_if_not_exists(self, scope: Scope, cert_type: CertType, alias: str):
         """Create passwords for the key stores if not already created."""
         store_pwd = None
-        if alias == "ca":
-            store_type = "truststore"
-        else:
-            store_type = "keystore"
+        store_type = "truststore" if alias == "ca" else "keystore"
 
         secrets = self.charm.secrets.get_object(scope, cert_type.val)
         if secrets:

--- a/tests/unit/lib/test_opensearch_tls.py
+++ b/tests/unit/lib/test_opensearch_tls.py
@@ -235,7 +235,7 @@ class TestOpenSearchTLS(unittest.TestCase):
         self.secret_store.put_object(
             Scope.UNIT,
             secret_key,
-            {"csr": csr, "keystore-password-unit-transport": keystore_password},
+            {"csr": csr, "keystore-password": keystore_password},
         )
 
         event_mock = MagicMock(
@@ -250,7 +250,7 @@ class TestOpenSearchTLS(unittest.TestCase):
                 "chain": chain[0],
                 "cert": cert,
                 "ca-cert": ca,
-                "keystore-password-unit-transport": keystore_password,
+                "keystore-password": keystore_password,
             },
         )
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -29,10 +29,10 @@ class TestCharm(TestOpenSearchBaseCharm):
             unit_resources = create_x509_resources()
 
             self.secret_store.put_object(
-                Scope.UNIT, CertType.UNIT_TRANSPORT, {"keystore-password-unit-transport": "123"}
+                Scope.UNIT, CertType.UNIT_TRANSPORT, {"keystore-password": "123"}
             )
             self.secret_store.put_object(
-                Scope.APP, CertType.APP_ADMIN, {"keystore-password-app-admin": "123"}
+                Scope.APP, CertType.APP_ADMIN, {"keystore-password": "123"}
             )
 
             self.charm.tls.store_new_tls_resources(


### PR DESCRIPTION
## Issue
Currently the secrets for storing the truststore and keystore passwords are named `keystore-password-{category}`, which is not ideal considering they are already stored as part of the tls secret for each category.

## Solution
Rename the secrets to:
- `truststore-password` for the ca truststore
- `keystore-password` as the generic name that can be referenced within the respective secrets app-admin, unit-transport and unit-http