### PR TITLE
[DPE-4892] Fix the opensearch-dashboard relation test

### DIFF
--- a/tests/integration/relations/test_opensearch_provider.py
+++ b/tests/integration/relations/test_opensearch_provider.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Copyright 2024 Canonical Ltd.
-# See LICENSE file for licensing details.
+# See LICENSE file for licensing details. 
 import asyncio
 import json
 import logging

--- a/tests/integration/relations/test_opensearch_provider.py
+++ b/tests/integration/relations/test_opensearch_provider.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Copyright 2024 Canonical Ltd.
-# See LICENSE file for licensing details. 
+# See LICENSE file for licensing details.
 import asyncio
 import json
 import logging

--- a/tests/integration/relations/test_opensearch_provider.py
+++ b/tests/integration/relations/test_opensearch_provider.py
@@ -230,6 +230,9 @@ async def test_dashboard_relation(ops_test: OpsTest):
         idle_period=70,
     )
 
+    # Work-around for issue: canonical/opensearch-operator/issue#370
+    await ops_test.model.wait_for_idle()
+
     # On this request, kibanaserver user with its own password should be exposed
     secret_uri = await get_application_relation_data(
         ops_test, f"{DASHBOARDS_APP_NAME}/0", DASHBOARDS_RELATION_NAME, "secret-user"

--- a/tests/integration/relations/test_opensearch_provider.py
+++ b/tests/integration/relations/test_opensearch_provider.py
@@ -222,6 +222,10 @@ async def test_dashboard_relation(ops_test: OpsTest):
     dashboards_relation = await ops_test.model.integrate(OPENSEARCH_APP_NAME, DASHBOARDS_APP_NAME)
     wait_for_relation_joined_between(ops_test, OPENSEARCH_APP_NAME, DASHBOARDS_APP_NAME)
 
+    # Work-around for issue: canonical/opensearch-operator/issue#370
+    # Wait it to settle down
+    await asyncio.sleep(100)
+
     await wait_until(
         ops_test,
         apps=ALL_APPS,
@@ -230,7 +234,6 @@ async def test_dashboard_relation(ops_test: OpsTest):
         idle_period=70,
     )
 
-    # Work-around for issue: canonical/opensearch-operator/issue#370
     await ops_test.model.wait_for_idle()
 
     # On this request, kibanaserver user with its own password should be exposed

--- a/tests/integration/relations/test_opensearch_provider.py
+++ b/tests/integration/relations/test_opensearch_provider.py
@@ -41,7 +41,7 @@ NUM_UNITS = 3
 
 FIRST_RELATION_NAME = "first-index"
 SECOND_RELATION_NAME = "second-index"
-DASHBOARDS_RELATION_NAME = "opensearch_client"
+DASHBOARDS_RELATION_NAME = "opensearch-client"
 ADMIN_RELATION_NAME = "admin"
 PROTECTED_INDICES = [
     ".opendistro_security",


### PR DESCRIPTION
Example of a failing run: https://github.com/canonical/opensearch-operator/actions/runs/9973343069/job/27558732859?pr=367

Essentially, we are having dashboard testing failing due to: https://pastebin.ubuntu.com/p/bbQWk4PRCZ/

That makes sense, given the opensearch / dashboard units did not settled yet before `wait_until` considers its check finished:
```
App                       Version  Status   Scale  Charm                     Channel        Rev  Exposed  Message
application                        active       1  application                                0  no       
opensearch                         active       3  opensearch                                 0  no       
opensearch-dashboards              blocked      1  opensearch-dashboards     2/edge          15  no       Opensearch connection is missing
self-signed-certificates           active       1  self-signed-certificates  latest/stable  155  no       

Unit                         Workload  Agent      Machine  Public address  Ports     Message
application/0*               active    idle       2        10.56.58.252              
opensearch-dashboards/0*     active    executing  1        10.56.58.227    5601/tcp  
opensearch/0                 active    executing  3        10.56.58.87     9200/tcp  
opensearch/1                 active    executing  4        10.56.58.192    9200/tcp  
opensearch/2*                active    idle       5        10.56.58.214    9200/tcp  
self-signed-certificates/0*  active    idle       0        10.56.58.254              

Machine  State    Address       Inst id        Base          AZ  Message
0        started  10.56.58.254  juju-7df6f8-0  ubuntu@22.04      Running
1        started  10.56.58.227  juju-7df6f8-1  ubuntu@22.04      Running
2        started  10.56.58.252  juju-7df6f8-2  ubuntu@22.04      Running
3        started  10.56.58.87   juju-7df6f8-3  ubuntu@22.04      Running
4        started  10.56.58.192  juju-7df6f8-4  ubuntu@22.04      Running
5        started  10.56.58.214  juju-7df6f8-5  ubuntu@22.04      Running
```

Adopted solutions:
1) Set a sleep time between relate and wait_until in the tests: assures idle period is reached correctly
2) Fixes the opensearch-dashboards's relation name