### PR TITLE
`publish_host` is a single IP, not a list

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_config.py
+++ b/lib/charms/opensearch/v0/opensearch_config.py
@@ -244,8 +244,8 @@ class OpenSearchConfig:
             ),
             NetworkHost(
                 "network.publish_host",
-                set(node.get("network.publish_host", [])),
-                set(self._opensearch.host),
+                node.get("network.publish_host"),
+                self._opensearch.host,
             ),
         ]:
             if not host.old:


### PR DESCRIPTION
The way `publish_host` is being dealt, it is expected a list of hostnames / IPs. However, publish_host has a single value. Hence, we should not filter it with `set()`.

This fix has been originally applied in this PR: https://github.com/canonical/opensearch-operator/pull/367. It has been also verified with successful passed runs of `test_ha_networking.py` checks, which triggers this logic.