### PR TITLE
[DPE-4900] bugfix truststore secret

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -443,7 +443,8 @@ class OpenSearchTLS(Object):
         keytool = f"sudo {self.jdk_path}/bin/keytool"
 
         admin_secrets = self.charm.secrets.get_object(Scope.APP, CertType.APP_ADMIN.val)
-        self._create_keystore_pwd_if_not_exists(Scope.APP, CertType.APP_ADMIN, "ca")
+        if self.charm.unit.is_leader():
+            self._create_keystore_pwd_if_not_exists(Scope.APP, CertType.APP_ADMIN, "ca")
 
         if not (secrets.get("ca-cert", {}) and admin_secrets.get("truststore-password", {})):
             logging.error("CA cert not found, quitting.")


### PR DESCRIPTION
## Issue
This is a follow-up to https://github.com/canonical/opensearch-operator/pull/357. If the `on_certificate_available` hook is run before the `on_relation_created` (for the TLS relation), it may happen that the truststore password is not yet available and is therefore created. But this must only happen on leader-units, because the truststore-secret is of scope `app` and otherwise the secret creation would fail with `ops.model.ModelError: ERROR this unit is not the leader` (as seen in [this CI run](https://github.com/canonical/opensearch-dashboards-operator/actions/runs/10007015106/job/27661171763#step:22:211)).

## Solution
Only create the truststore password secret if the current unit is the juju-leader.