### PR TITLE
[DPE-4792] reload certificates via API

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_config.py
+++ b/lib/charms/opensearch/v0/opensearch_config.py
@@ -186,6 +186,13 @@ class OpenSearchConfig:
             True,
         )
 
+        # enable hot reload of TLS certs (without restarting the node)
+        self._opensearch.config.put(
+            self.CONFIG_YML,
+            "plugins.security.ssl_cert_reload_enabled",
+            True,
+        )
+
     def remove_temporary_data_role(self):
         """Remove the data role that was added temporarily to the first dedicated CM node."""
         conf = self._opensearch.config.load(self.CONFIG_YML)


### PR DESCRIPTION
## Issue
Currently the OpenSearch application is restarted when TLS certificates are renewed. This could be simplified by using the "hot reload" API OpenSearch provides for renewing the TLS certs.

## Solution
- activate the plugins.security.ssl_cert_reload_enabled setting
- when TLS conf is set, query the API instead of restarting OpenSearch