### PR TITLE
Fix to support charmcraft 3.1.1

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -10,6 +10,11 @@ bases:
       - name: "ubuntu"
         channel: "22.04"
 parts:
+  files:
+    plugin: nil
+    prime:
+      - charm_version
+      - workload_version
   charm:
     override-pull: |
       craftctl default
@@ -20,9 +25,6 @@ parts:
       fi
     charm-strict-dependencies: true
     charm-entrypoint: src/charm.py
-    prime:
-      - charm_version
-      - workload_version
     build-packages:
       - cargo
       - libffi-dev


### PR DESCRIPTION
## Issue
With the latest version 3.1.1 of charmcraft, build and deploying charms fails if there is a prime part in the `charmcraft.yaml` file: `Warning: use of 'prime' in a charm part is deprecated and no longer works, see https://juju.is/docs/sdk/include-extra-files-in-a-charm`.

## Solution
Fix the charmcraft.yaml config file.