### PR TITLE
[DPE-5047] Backport MLCommons changes

### DIFF
--- a/lib/charms/opensearch/v0/constants_charm.py
+++ b/lib/charms/opensearch/v0/constants_charm.py
@@ -108,7 +108,7 @@ KibanaserverUser = "kibanaserver"
 KibanaserverRole = "kibana_server"
 
 # Opensearch Snap revision
-OPENSEARCH_SNAP_REVISION = 53  # Keep in sync with `workload_version` file
+OPENSEARCH_SNAP_REVISION = 54  # Keep in sync with `workload_version` file
 
 # User-face Backup ID format
 OPENSEARCH_BACKUP_ID_FORMAT = "%Y-%m-%dT%H:%M:%SZ"


### PR DESCRIPTION
Updates the snap pinning to consider the newer revision with 2.14.0-ubuntu1. This release contains the backported fixes for plugin MLCommons.