### PR TITLE
[DPE-4931] fix locking with unassigned shards

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -1018,20 +1018,12 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
                     # TODO: we should probably NOT have any exclusion on restart
                     # https://chat.canonical.com/canonical/pl/bgndmrfxr7fbpgmwpdk3hin93c
                     # 1. Add current node to the voting + alloc exclusions
-                    shards_before_relocation = self.opensearch.request(
-                        "GET", endpoint="/_cat/shards"
-                    )
-                    logger.debug(f"Shards before relocation: {shards_before_relocation}")
                     self.opensearch_exclusions.add_current()
             except OpenSearchHttpError:
                 logger.debug("Failed to get online nodes, voting and alloc exclusions not added")
 
-        # TODO: should block until all shards move addressed in PR DPE-2234
-        allocations = self.opensearch.request("GET", endpoint="/_cat/allocation")
+        # block until all primary shards are moved away from the unit that is stopping
         self.health.wait_for_shards_relocation()
-        shards_after_relocation = self.opensearch.request("GET", endpoint="/_cat/shards")
-        logger.debug(f"Allocations after relocation: {allocations}")
-        logger.debug(f"Shards after relocation: {shards_after_relocation}")
 
         # 2. stop the service
         self.opensearch.stop()

--- a/lib/charms/opensearch/v0/opensearch_health.py
+++ b/lib/charms/opensearch/v0/opensearch_health.py
@@ -115,7 +115,7 @@ class OpenSearchHealth:
         # we differentiate between a temp yellow (moving shards) and a permanent
         # one (such as: missing replicas)
         if status in [HealthColors.GREEN, HealthColors.YELLOW] and (
-                response["initializing_shards"] > 0 or response["relocating_shards"] > 0
+            response["initializing_shards"] > 0 or response["relocating_shards"] > 0
         ):
             try:
                 logger.debug(

--- a/lib/charms/opensearch/v0/opensearch_health.py
+++ b/lib/charms/opensearch/v0/opensearch_health.py
@@ -149,12 +149,9 @@ class OpenSearchHealth:
 
         # we throw an error because various operations should NOT start while data
         # is being relocated. Examples are: simple stop, unit removal, upgrade
-        if not (response["unassigned_shards"] == 0 and response["relocating_shards"] == 0):
+        if not response["relocating_shards"] == 0:
             logger.info(
-                f"""Some shards are still moving before stopping Opensearch: \
-                relocating: {response['relocating_shards']},
-                unassigned: {response['unassigned_shards']}
-                """
+                f"Shards still moving before stopping Opensearch: relocating: {response['relocating_shards']}"
             )
             raise OpenSearchHAError("Shards haven't completed relocating.")
 


### PR DESCRIPTION
## Issue
This PR addresses the issues https://github.com/canonical/opensearch-operator/issues/327 and https://github.com/canonical/opensearch-operator/issues/324.

When Opensearch is in the process of shutting down, the operator currently does not wait for data to be moved away from the stopping unit. This may result in shards not being assigned and could cause loss of data. In cases where the index `.charm_node_lock` is impacted, the operator can no longer acquire the lock to start or stop Opensearch. This will result in `503` errors in the logfile.

The behavior can be seen in this CI run, with some additional logging information added for debugging: https://github.com/canonical/opensearch-operator/actions/runs/10269420444/job/28415611890?pr=387
```
Shards before relocation: [...{'index': '.charm_node_lock', 'shard': '0', 'prirep': 'p', 'state': 'STARTED', 'docs': '1', 'store': '31.6kb', 'ip': '10.19.29.219', 'node': 'opensearch-0.e42'}, {'index': '.charm_node_lock', 'shard': '0', 'prirep': 'r', 'state': 'STARTED', 'docs': '1', 'store': '8.7kb', 'ip': '10.19.29.239', 'node': 'opensearch-1.e42'}]

Shards after relocation: [... {'index': '.opendistro_security', 'shard': '0', 'prirep': 'p', 'state': 'RELOCATING', 'docs': '10', 'store': '61.5kb', 'ip': '10.19.29.219', 'node': 'opensearch-0.e42 -> 10.19.29.239 yt3jiuSZRTCY8NnoeIni5w opensearch-1.e42'}, {'index': '.charm_node_lock', 'shard': '0', 'prirep': 'p', 'state': 'STARTED', 'docs': '1', 'store': '31.6kb', 'ip': '10.19.29.219', 'node': 'opensearch-0.e42'}]
```

Shortly after, the error is there:
```
unit-opensearch-0: 16:25:11 DEBUG unit.opensearch/0.juju-log opensearch-peers:1: https://10.19.29.239:9200 "GET /.charm_node_lock/_source/0 HTTP/11" 503 287
unit-opensearch-0: 16:25:11 ERROR unit.opensearch/0.juju-log opensearch-peers:1: Error checking which unit has OpenSearch lock
Traceback (most recent call last):
...
File "/var/lib/juju/agents/unit-opensearch-0/charm/lib/charms/opensearch/v0/opensearch_locking.py", line 263, in acquired
    unit = self._unit_with_lock(host)
  File "/var/lib/juju/agents/unit-opensearch-0/charm/lib/charms/opensearch/v0/opensearch_locking.py", line 225, in _unit_with_lock
    document_data = self._opensearch.request(
  File "/var/lib/juju/agents/unit-opensearch-0/charm/lib/charms/opensearch/v0/opensearch_distro.py", line 306, in request
    raise OpenSearchHttpError(
charms.opensearch.v0.opensearch_exceptions.OpenSearchHttpError: HTTP error self.response_code=503
self.response_body={'error': {'root_cause': [{'type': 'no_shard_available_action_exception', 'reason': 'No shard available for [get [.charm_node_lock][0]: routing [null]]'}], 'type': 'no_shard_available_action_exception', 'reason': 'No shard available for [get [.charm_node_lock][0]: routing [null]]'}, 'status': 503}
unit-opensearch-0: 16:25:11 DEBUG unit.opensearch/0.juju-log opensearch-peers:1: Lock to start opensearch not acquired. Will retry next event
```

## Solution
When stopping Opensearch, the operator should wait for the shards relocation to be completed. This should be happening right after adding the currently stopping unit to the allocation exclusions. The check should be blocking, meaning that Opensearch must not stop until the relocation is finished.

This will look something like this:
```
unit-opensearch-0: 10:07:28 DEBUG unit.opensearch/0.juju-log Shards before relocation: [... {'index': '.plugins-ml-config', 'shard': '0', 'prirep': 'p', 'state': 'STARTED', 'docs': '1', 'store': '3.9kb', 'ip': '10.18.168.228', 'node': 'opensearch-0.ccc'}, ...]

[...]

unit-opensearch-0: 10:07:32 DEBUG unit.opensearch/0.juju-log Shards after relocation: [... {'index': '.plugins-ml-config', 'shard': '0', 'prirep': 'p', 'state': 'STARTED', 'docs': '1', 'store': '3.9kb', 'ip': '10.18.168.28', 'node': 'opensearch-1.ccc'} ...]
```
To check if there are still some moving shards, the API `_cluster/health` can be queried for `"relocating_shards"`. If these are not `0`, the process of stopping should be halted. Depending on the amount of data, this can take quite some time. A reasonable maximum waiting time of 15 minutes has been added, after that an error will be raised.