### PR TITLE
[DPE-3426] migrate from _cat to _cluster APIs 

### DIFF
--- a/lib/charms/opensearch/v0/helper_cluster.py
+++ b/lib/charms/opensearch/v0/helper_cluster.py
@@ -259,12 +259,12 @@ class ClusterState:
         endpoint = "/_cluster/health?level=indices"
         cluster_health = opensearch.request("GET", endpoint, host=host, alt_hosts=alt_hosts)
         indices_health = cluster_health["indices"]
-        
+
         idx = {}
         for index in indices_state:
             idx[index] = {
-                'health': indices_health[index]['status'],
-                'status': indices_state[index]['state'],
+                "health": indices_health[index]["status"],
+                "status": indices_state[index]["state"],
             }
         return idx
 


### PR DESCRIPTION
## Issue
We are using some `_cat` API calls to fetch data around shard information and node statuses. The `_cat` API is designed as a human-readable interface.

## Solution
Move the `_cat` API calls to other API endpoints such as `_cluster/state` and `_cluster/health` while keeping the same data model.