### PR TITLE
[DPE-4875] Apply sysctl requirements if possible

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -452,24 +452,30 @@ class OpenSearchDistribution(ABC):
 
         return exclusions
 
-    @staticmethod
-    def missing_sys_requirements() -> List[str]:
+    def missing_sys_requirements(self) -> List[str]:
         """Checks the system requirements."""
+
+        def apply(prop: str, value: str) -> bool:
+            """Apply a sysctl value and check if it was set."""
+            try:
+                self._run_cmd(f"sysctl -w {prop}={value}")
+                return self._run_cmd(f"sysctl -n {prop}") == value
+            except OpenSearchCmdError:
+                return False
+
         missing_requirements = []
 
-        max_map_count = int(subprocess.getoutput("sysctl vm.max_map_count").split("=")[-1].strip())
-        if max_map_count < 262144:
-            missing_requirements.append("vm.max_map_count should be at least 262144")
+        prop, val = "vm.max_map_count", "262144"
+        if self._run_cmd(f"sysctl -n {prop}") < val and not apply(prop, val):
+            missing_requirements.append(f"{prop} should be at least {val}")
 
-        swappiness = int(subprocess.getoutput("sysctl vm.swappiness").split("=")[-1].strip())
-        if swappiness > 0:
-            missing_requirements.append("vm.swappiness should be 0")
+        prop, val = "vm.swappiness", "0"
+        if self._run_cmd(f"sysctl -n {prop}") > val and not apply(prop, val):
+            missing_requirements.append(f"{prop} should be {val}")
 
-        tcp_retries = int(
-            subprocess.getoutput("sysctl net.ipv4.tcp_retries2").split("=")[-1].strip()
-        )
-        if tcp_retries > 5:
-            missing_requirements.append("net.ipv4.tcp_retries2 should be 5")
+        prop, val = "net.ipv4.tcp_retries2", "5"
+        if self._run_cmd(f"sysctl -n {prop}") > val and not apply(prop, val):
+            missing_requirements.append(f"{prop} should be at most {val}")
 
         return missing_requirements
 

--- a/lib/charms/opensearch/v0/opensearch_relation_provider.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_provider.py
@@ -59,7 +59,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 1
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Issue
This PR implements [DPE-4875](https://warthogs.atlassian.net/browse/DPE-4875), namely:
- check sysctl requirements 
- apply them if needed and possible
- check them again for verification

[DPE-4875]: https://warthogs.atlassian.net/browse/DPE-4875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ