### PR TITLE
Standardize prime plugin in charmcraft.yaml

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -11,7 +11,8 @@ bases:
         channel: "22.04"
 parts:
   files:
-    plugin: nil
+    plugin: dump
+    source: .
     prime:
       - charm_version
       - workload_version


### PR DESCRIPTION
I'd like to standardize the approach across data platform repos so that future automated tooling that may need to use this can be shared across all our repos

PRs in other repos:
https://github.com/canonical/mysql-operator/pull/496
https://github.com/canonical/mysql-router-k8s-operator/pull/298#discussion_r1713906228
https://github.com/canonical/mongodb-operator/pull/455
