### PR TITLE
[DPE-4859] Make cloud-init optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ juju remove-relation opensearch self-signed-certificates
 **Note:** The TLS settings shown here are for self-signed-certificates, which are not recommended for production clusters. The Self Signed Certificates Operator offers a variety of configuration options. Read more on the TLS Certificates Operator [here](https://charmhub.io/self-signed-certificates).
 
 ## Security
+
 Security issues in the Charmed OpenSearch Operator can be reported through [LaunchPad](https://wiki.ubuntu.com/DebuggingSecurity#How%20to%20File). Please do not file GitHub issues about security issues.
 
 ## Customizing

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Bootstrap a [lxd controller](https://juju.is/docs/olm/lxd#heading--create-a-cont
 juju add-model opensearch
 ```
 
-Configure the system settings required by [OpenSearch](https://opensearch.org/docs/latest/install-and-configure/install-opensearch/index/),
+Configure the system settings required by [OpenSearch](https://opensearch.org/docs/latest/install-and-configure/install-opensearch/index/).
 
 ### Basic usage
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Configure the system settings required by [OpenSearch](https://opensearch.org/do
 
 ### Basic usage
 
-To deploy a single unit of OpenSearch using its default configuration.
+To deploy a single unit of OpenSearch with default configuration, use:
 
 ```shell
 juju deploy opensearch --channel=2/edge

--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ Security issues in the Charmed OpenSearch Operator can be reported through [Laun
 
 Certain values can be configured with different cloud-init values.
 We'll do that by creating and setting a [`cloudinit-userdata.yaml` file](https://juju.is/docs/olm/juju-model-config) on the model. 
-```
+
+```shell
 cat <<EOF > cloudinit-userdata.yaml
 cloudinit-userdata: |
   postruncmd:

--- a/README.md
+++ b/README.md
@@ -27,19 +27,8 @@ juju add-model opensearch
 ```
 
 Configure the system settings required by [OpenSearch](https://opensearch.org/docs/latest/install-and-configure/install-opensearch/index/),
-we'll do that by creating and setting a [`cloudinit-userdata.yaml` file](https://juju.is/docs/olm/juju-model-config) on the model. 
 As well as setting some kernel settings on the host machine.
 ```
-cat <<EOF > cloudinit-userdata.yaml
-cloudinit-userdata: |
-  postruncmd:
-    - [ 'echo', 'vm.max_map_count=262144', '>>', '/etc/sysctl.conf' ]
-    - [ 'echo', 'vm.swappiness=0', '>>', '/etc/sysctl.conf' ]
-    - [ 'echo', 'net.ipv4.tcp_retries2=5', '>>', '/etc/sysctl.conf' ]
-    - [ 'echo', 'fs.file-max=1048576', '>>', '/etc/sysctl.conf' ]
-    - [ 'sysctl', '-p' ]
-EOF
-
 sudo tee -a /etc/sysctl.conf > /dev/null <<EOT
 vm.max_map_count=262144
 vm.swappiness=0
@@ -48,8 +37,6 @@ fs.file-max=1048576
 EOT
 
 sudo sysctl -p
-
-juju model-config --file=./cloudinit-userdata.yaml
 ```
 
 ### Basic Usage
@@ -110,6 +97,23 @@ juju remove-relation opensearch self-signed-certificates
 
 ## Security
 Security issues in the Charmed OpenSearch Operator can be reported through [LaunchPad](https://wiki.ubuntu.com/DebuggingSecurity#How%20to%20File). Please do not file GitHub issues about security issues.
+
+## Customizing
+
+### Update Sysctl via ' clout-init`
+
+Certain values can be configured with different cloud-init values.
+We'll do that by creating and setting a [`cloudinit-userdata.yaml` file](https://juju.is/docs/olm/juju-model-config) on the model. 
+```
+cat <<EOF > cloudinit-userdata.yaml
+cloudinit-userdata: |
+  postruncmd:
+    - [ 'echo', 'net.ipv4.tcp_retries2=2', '>>', '/etc/sysctl.conf' ]
+    - [ 'sysctl', '-p' ]
+EOF
+
+juju model-config --file=./cloudinit-userdata.yaml
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To deploy a single unit of OpenSearch with default configuration, use:
 juju deploy opensearch --channel=2/edge
 ```
 
-### LXD Setup
+### LXD setup
 
 If you are using LXD as the backend for Juju, then most of the sysctl parameters need to be set manually on the host:
 

--- a/README.md
+++ b/README.md
@@ -27,23 +27,25 @@ juju add-model opensearch
 ```
 
 Configure the system settings required by [OpenSearch](https://opensearch.org/docs/latest/install-and-configure/install-opensearch/index/),
-As well as setting some kernel settings on the host machine.
-```
-sudo tee -a /etc/sysctl.conf > /dev/null <<EOT
-vm.max_map_count=262144
-vm.swappiness=0
-net.ipv4.tcp_retries2=5
-fs.file-max=1048576
-EOT
-
-sudo sysctl -p
-```
 
 ### Basic Usage
 To deploy a single unit of OpenSearch using its default configuration.
 
 ```shell
 juju deploy opensearch --channel=2/edge
+```
+
+### LXD Setup
+
+If you are using LXD as the backend for Juju, then most of the sysctl parameters need to be set manually on the host:
+```
+sudo tee -a /etc/sysctl.conf > /dev/null <<EOT
+vm.max_map_count=262144
+vm.swappiness=0
+fs.file-max=1048576
+EOT
+
+sudo sysctl -p
 ```
 
 ## Relations / Integrations

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ juju deploy opensearch --channel=2/edge
 
 ### LXD setup
 
-If you are using LXD as the backend for Juju, then most of the sysctl parameters need to be set manually on the host:
+If you are using LXD as the backend for Juju, then most of the sysctl parameters need to be set manually on the hypervisor:
 
 ```shell
 sudo tee -a /etc/sysctl.conf > /dev/null <<EOT
@@ -48,6 +48,22 @@ fs.file-max=1048576
 EOT
 
 sudo sysctl -p
+```
+
+### (Optional) customising: update sysctl via clout-init
+
+Certain values can be configured with different cloud-init values.
+We'll do that by creating and setting a [`cloudinit-userdata.yaml` file](https://juju.is/docs/olm/juju-model-config) on the model. 
+
+```shell
+cat <<EOF > cloudinit-userdata.yaml
+cloudinit-userdata: |
+  postruncmd:
+    - [ 'echo', 'net.ipv4.tcp_retries2=2', '>>', '/etc/sysctl.conf' ]
+    - [ 'sysctl', '-p' ]
+EOF
+
+juju model-config --file=./cloudinit-userdata.yaml
 ```
 
 ## Relations / Integrations
@@ -64,6 +80,7 @@ juju integrate opensearch data-integrator
 ```
 
 ### Large deployments:
+
 Charmed OpenSearch also allows to form large clusters or join an existing deployment, through the relations:
 - `peer-cluster`
 - `peer-cluster-orchestrator`
@@ -103,27 +120,10 @@ juju remove-relation opensearch self-signed-certificates
 
 Security issues in the Charmed OpenSearch Operator can be reported through [LaunchPad](https://wiki.ubuntu.com/DebuggingSecurity#How%20to%20File). Please do not file GitHub issues about security issues.
 
-## Customizing
-
-### Update Sysctl via clout-init
-
-Certain values can be configured with different cloud-init values.
-We'll do that by creating and setting a [`cloudinit-userdata.yaml` file](https://juju.is/docs/olm/juju-model-config) on the model. 
-
-```shell
-cat <<EOF > cloudinit-userdata.yaml
-cloudinit-userdata: |
-  postruncmd:
-    - [ 'echo', 'net.ipv4.tcp_retries2=2', '>>', '/etc/sysctl.conf' ]
-    - [ 'sysctl', '-p' ]
-EOF
-
-juju model-config --file=./cloudinit-userdata.yaml
-```
-
 ## Contributing
 
 Please see the [Juju SDK docs](https://juju.is/docs/sdk) for guidelines on enhancements to this charm following best practice guidelines, and [CONTRIBUTING.md](https://github.com/canonical/opensearch-operator/blob/main/CONTRIBUTING.md) for developer guidance.
 
 ## License
+
 The Charmed OpenSearch Operator is free software, distributed under the Apache Software License, version 2.0. See [LICENSE](https://github.com/canonical/opensearch-operator/blob/main/LICENSE) for more information.

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ EOT
 sudo sysctl -p
 ```
 
-### (Optional) customising: update sysctl via clout-init
+### Customise system settings with cloud-init
 
-Certain values can be configured with different cloud-init values.
+Optionally, system can be configured with different cloud-init values than set by default.
 We'll do that by creating and setting a [`cloudinit-userdata.yaml` file](https://juju.is/docs/olm/juju-model-config) on the model. 
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Security issues in the Charmed OpenSearch Operator can be reported through [Laun
 
 ## Customizing
 
-### Update Sysctl via ' clout-init`
+### Update Sysctl via clout-init
 
 Certain values can be configured with different cloud-init values.
 We'll do that by creating and setting a [`cloudinit-userdata.yaml` file](https://juju.is/docs/olm/juju-model-config) on the model. 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ juju add-model opensearch
 
 Configure the system settings required by [OpenSearch](https://opensearch.org/docs/latest/install-and-configure/install-opensearch/index/),
 
-### Basic Usage
+### Basic usage
+
 To deploy a single unit of OpenSearch using its default configuration.
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ juju deploy opensearch --channel=2/edge
 ### LXD Setup
 
 If you are using LXD as the backend for Juju, then most of the sysctl parameters need to be set manually on the host:
-```
+
+```shell
 sudo tee -a /etc/sysctl.conf > /dev/null <<EOT
 vm.max_map_count=262144
 vm.swappiness=0

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -39,12 +39,6 @@ TARBALL_INSTALL_CERTS_DIR = "/etc/opensearch/config/certificates"
 MODEL_CONFIG = {
     "logging-config": "<root>=INFO;unit=DEBUG",
     "update-status-hook-interval": "5m",
-    "cloudinit-userdata": """postruncmd:
-        - [ 'sysctl', '-w', 'vm.max_map_count=262144' ]
-        - [ 'sysctl', '-w', 'fs.file-max=1048576' ]
-        - [ 'sysctl', '-w', 'vm.swappiness=0' ]
-        - [ 'sysctl', '-w', 'net.ipv4.tcp_retries2=5' ]
-    """,
 }
 
 


### PR DESCRIPTION
Originally, cloud-init was mandatory to be set in order for OpenSearch to work. This PR updates the README and integration tests to remove this dependency, following recent charm changes.

Closes #359