### PR TITLE
[DPE-5169] Add unicast_hosts.txt review on update_status

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -537,6 +537,9 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         if not self.opensearch.is_node_up():
             return
 
+        # review available CMs
+        self._add_cm_addresses_to_conf()
+
         # if there are exclusions to be removed
         if self.unit.is_leader():
             self.opensearch_exclusions.cleanup()


### PR DESCRIPTION
The unicast_hosts.txt needs to be also reviewed at `update-status`, so we can consider situations such as nodes that have been broken and not responsive anymore.