### PR TITLE
[DPE-4653] certificate expiration integration test

### DIFF
--- a/.github/workflows/sync_docs.yaml
+++ b/.github/workflows/sync_docs.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   sync-docs:
     name: Sync docs from Discourse
-    uses: canonical/data-platform-workflows/.github/workflows/_sync_docs.yaml@main
+    uses: canonical/data-platform-workflows/.github/workflows/_sync_docs.yaml@16.7.0
     secrets:
       discourse-api-user: ${{ secrets.DISCOURSE_API_USERNAME }}
       discourse-api-key: ${{ secrets.DISCOURSE_API_KEY }}

--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -73,7 +73,7 @@ class OpenSearchTLS(Object):
         self.jdk_path = jdk_path
         self.certs_path = certs_path
         self.keytool = self.jdk_path + "/bin/keytool"
-        self.certs = TLSCertificatesRequiresV3(charm, TLS_RELATION, expiry_notification_time=168)
+        self.certs = TLSCertificatesRequiresV3(charm, TLS_RELATION, expiry_notification_time=23)
 
         self.framework.observe(
             self.charm.on.set_tls_private_key_action, self._on_set_tls_private_key

--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -302,6 +302,7 @@ class OpenSearchTLS(Object):
         subject = self._get_subject(cert_type)
         organization = self.charm.opensearch_peer_cm.deployment_desc().config.cluster_name
         new_csr = generate_csr(
+            add_unique_id_to_subject_name=False,
             private_key=key,
             private_key_password=(None if key_password is None else key_password.encode("utf-8")),
             subject=subject,

--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -73,7 +73,7 @@ class OpenSearchTLS(Object):
         self.jdk_path = jdk_path
         self.certs_path = certs_path
         self.keytool = self.jdk_path + "/bin/keytool"
-        self.certs = TLSCertificatesRequiresV3(charm, TLS_RELATION)
+        self.certs = TLSCertificatesRequiresV3(charm, TLS_RELATION, expiry_notification_time=168)
 
         self.framework.observe(
             self.charm.on.set_tls_private_key_action, self._on_set_tls_private_key

--- a/tests/integration/tls/test_tls.py
+++ b/tests/integration/tls/test_tls.py
@@ -191,8 +191,10 @@ async def test_tls_expiration(ops_test: OpsTest) -> None:
     )
 
     # Now apply a hack to make the certificate secrets expire in short time
-    # set the secret expiry to a fixed timedelta of 180 seconds to give time to start initially
-    # this happens on the tls_certificates lib and we apply the patch via sed-command
+    # set the secret expiry to a fixed timedelta of 180 seconds to give time to start initially.
+    # This happens on the tls_certificates lib and we apply the patch via sed-command.
+    # The patch accesses the method `_get_next_secret_expiry_time` in the tls_certificate libs.
+    # If the test should fail on updates to this lib, check if the method was renamed or removed.
     search_expression = "expire=self._get_next_secret_expiry_time\\(certificate\\)"
     replace_expression = "expire=timedelta\\(seconds=180\\)"
 

--- a/tests/integration/tls/test_tls.py
+++ b/tests/integration/tls/test_tls.py
@@ -219,12 +219,8 @@ async def test_tls_expiration(ops_test: OpsTest) -> None:
 
     # now compare the current certificates against the earlier ones and see if they were updated
     updated_certs = await get_loaded_tls_certificates(ops_test, unit_ip)
-    logger.info(
-        f"Certificates before expiry: {current_certs}"
-    )
-    logger.info(
-        f"Certificates after expiry: {updated_certs}"
-    )
+    logger.info(f"Certificates before expiry: {current_certs}")
+    logger.info(f"Certificates after expiry: {updated_certs}")
 
     assert (
         updated_certs["transport_certificates_list"][0]["not_before"]

--- a/tests/integration/tls/test_tls.py
+++ b/tests/integration/tls/test_tls.py
@@ -204,6 +204,10 @@ async def test_tls_expiration(ops_test: OpsTest) -> None:
     # Relate OpenSearch to TLS and wait until all is settled
     await ops_test.model.integrate(APP_NAME, TLS_CERTIFICATES_APP_NAME)
     assert await is_up(ops_test, unit_ip), "OpenSearch service hasn't started."
+    logger.info("Waiting for certificates to expire.")
+
+    # wait for the certs API to be ready
+    time.sleep(30)
 
     # now start with the actual test
     # first get the currently used certs
@@ -211,10 +215,16 @@ async def test_tls_expiration(ops_test: OpsTest) -> None:
 
     # now wait for the expiration period to pass by (and a bit longer for things to settle)
     # we can't use `wait_until` here because the unit might not be idle in the meantime
-    time.sleep(300)
+    time.sleep(240)
 
     # now compare the current certificates against the earlier ones and see if they were updated
     updated_certs = await get_loaded_tls_certificates(ops_test, unit_ip)
+    logger.info(
+        f"Certificates before expiry: {current_certs}"
+    )
+    logger.info(
+        f"Certificates after expiry: {updated_certs}"
+    )
 
     assert (
         updated_certs["transport_certificates_list"][0]["not_before"]

--- a/tests/integration/tls/test_tls.py
+++ b/tests/integration/tls/test_tls.py
@@ -4,6 +4,7 @@
 
 import logging
 import subprocess
+import time
 
 import pytest
 from pytest_operator.plugin import OpsTest
@@ -20,6 +21,7 @@ from ..helpers import (
     get_application_unit_names,
     get_leader_unit_id,
     get_leader_unit_ip,
+    is_up,
     run_action,
 )
 from ..helpers_deployments import wait_until
@@ -176,7 +178,7 @@ async def test_tls_expiration(ops_test: OpsTest) -> None:
     my_charm = await ops_test.build_charm(".")
     await ops_test.model.deploy(
         my_charm,
-        num_units=3,
+        num_units=1,
         series=SERIES,
     )
 
@@ -184,64 +186,37 @@ async def test_tls_expiration(ops_test: OpsTest) -> None:
         ops_test,
         apps=[APP_NAME],
         units_statuses=["blocked"],
-        wait_for_exact_units=3,
+        wait_for_exact_units=1,
     )
 
     # Now apply a hack to make the certificate secrets expire in short time
     # set the secret expiry to a fixed timedelta of 300 seconds to give time to start initially
     # this happens on the tls_certificates lib and we apply the patch via sed-command
     search_expression = "expire=self._get_next_secret_expiry_time\\(certificate\\)"
-    replace_expression = "expire=timedelta\\(seconds=300\\)"
+    replace_expression = "expire=timedelta\\(seconds=180\\)"
 
-    for unit_id in get_application_unit_ids(ops_test, APP_NAME):
-        lib_file = f"/var/lib/juju/agents/unit-opensearch-{unit_id}/charm/lib/charms/tls_certificates_interface/v3/tls_certificates.py"
-        cmd = f"juju ssh {APP_NAME}/{unit_id} sudo sed -i 's/{search_expression}/{replace_expression}/g' {lib_file}"
-        subprocess.run(cmd, shell=True)
+    unit_id = get_application_unit_ids(ops_test, APP_NAME)[0]
+    unit_ip = await get_leader_unit_ip(ops_test)
+    lib_file = f"/var/lib/juju/agents/unit-opensearch-{unit_id}/charm/lib/charms/tls_certificates_interface/v3/tls_certificates.py"
+    cmd = f"juju ssh {APP_NAME}/{unit_id} sudo sed -i 's/{search_expression}/{replace_expression}/g' {lib_file}"
+    subprocess.run(cmd, shell=True)
 
     # Relate OpenSearch to TLS and wait until all is settled
     await ops_test.model.integrate(APP_NAME, TLS_CERTIFICATES_APP_NAME)
-    await wait_until(
-        ops_test,
-        apps=[APP_NAME],
-        apps_statuses=["active"],
-        units_statuses=["active"],
-        wait_for_exact_units=3,
-        idle_period=15,
-    )
+    assert await is_up(ops_test, unit_ip), "OpenSearch service hasn't started."
 
     # now start with the actual test
     # first get the currently used certs
-    leader_unit_ip = await get_leader_unit_ip(ops_test)
-    leader_id = await get_leader_unit_id(ops_test)
-    non_leader_id = [
-        unit_id for unit_id in get_application_unit_ids(ops_test) if unit_id != leader_id
-    ][0]
-    units = await get_application_unit_ids_ips(ops_test, APP_NAME)
+    current_certs = await get_loaded_tls_certificates(ops_test, unit_ip)
 
-    current_certs_leader = await get_loaded_tls_certificates(ops_test, leader_unit_ip)
-    current_certs_non_leader = await get_loaded_tls_certificates(ops_test, units[non_leader_id])
-
-    # Now wait until the secrets have expired and the certificates have been renewed
-    await wait_until(
-        ops_test,
-        apps=[APP_NAME],
-        apps_statuses=["active"],
-        units_statuses=["active"],
-        wait_for_exact_units=len(UNIT_IDS),
-        idle_period=240,
-        timeout=1200,
-    )
+    # now wait for the expiration period to pass by (and a bit longer for things to settle)
+    # we can't use `wait_until` here because the unit might not be idle in the meantime
+    time.sleep(300)
 
     # now compare the current certificates against the earlier ones and see if they were updated
-    updated_certs_leader = await get_loaded_tls_certificates(ops_test, leader_unit_ip)
-    updated_certs_non_leader = await get_loaded_tls_certificates(ops_test, units[non_leader_id])
+    updated_certs = await get_loaded_tls_certificates(ops_test, unit_ip)
 
     assert (
-        updated_certs_leader["transport_certificates_list"][0]["not_before"]
-        > current_certs_leader["transport_certificates_list"][0]["not_before"]
-    )
-
-    assert (
-        updated_certs_non_leader["transport_certificates_list"][0]["not_before"]
-        > current_certs_non_leader["transport_certificates_list"][0]["not_before"]
+        updated_certs["transport_certificates_list"][0]["not_before"]
+        > current_certs["transport_certificates_list"][0]["not_before"]
     )

--- a/tests/integration/tls/test_tls.py
+++ b/tests/integration/tls/test_tls.py
@@ -190,8 +190,8 @@ async def test_tls_expiration(ops_test: OpsTest) -> None:
     # Now apply a hack to make the certificate secrets expire in short time
     # set the secret expiry to a fixed timedelta of 300 seconds to give time to start initially
     # this happens on the tls_certificates lib and we apply the patch via sed-command
-    search_expression = "expire=self._get_next_secret_expiry_time\(certificate\)"
-    replace_expression = "expire=timedelta\(seconds=300\)"
+    search_expression = "expire=self._get_next_secret_expiry_time\\(certificate\\)"
+    replace_expression = "expire=timedelta\\(seconds=300\\)"
 
     for unit_id in get_application_unit_ids(ops_test, APP_NAME):
         lib_file = f"/var/lib/juju/agents/unit-opensearch-{unit_id}/charm/lib/charms/tls_certificates_interface/v3/tls_certificates.py"
@@ -228,7 +228,7 @@ async def test_tls_expiration(ops_test: OpsTest) -> None:
         apps_statuses=["active"],
         units_statuses=["active"],
         wait_for_exact_units=len(UNIT_IDS),
-        idle_period=180,
+        idle_period=240,
         timeout=1200,
     )
 


### PR DESCRIPTION
This PR provides integration test coverage for the workflow of expiring TLS certificates and their renewal. 

It also includes a bugfix for renewing the expiring certificates, or better creating the certificate signing requests: When initially creating them, they do not include `unique-id` in the subject. But on renewal this is included, which causes the `subject` of the renewed certificate to be different from the initial one.

In addition to that, there's a config change to `TLSCertificatesRequiresV3` in order to get notification for expiring certificates with a reasonable lead time.

Please also note the documentation added for the TLS certificates workflow here: https://github.com/canonical/opensearch-operator/wiki/TLS-certificates-workflow
