### PR TITLE
[DPE-5202] Test TLS through Manual TLS Certificates

### DIFF
--- a/tests/integration/tls/helpers_manual_tls.py
+++ b/tests/integration/tls/helpers_manual_tls.py
@@ -1,0 +1,186 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import base64
+import json
+import logging
+from collections import deque
+from typing import TYPE_CHECKING, NamedTuple
+
+from charms.tls_certificates_interface.v3.tls_certificates import (
+    generate_ca,
+    generate_certificate,
+    generate_private_key,
+)
+from juju.unit import Unit
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+if TYPE_CHECKING:
+    from juju.action import Action
+
+logger = logging.getLogger(__name__)
+
+MANUAL_TLS_CERTIFICATES_APP_NAME = "manual-tls-certificates"
+
+
+class GettingOutstandingCertificateRequestsFailedError(Exception):
+    """Exception raised when getting outstanding certificate requests fails."""
+
+    def __init__(self, message: str) -> None:
+        """Initialise the exception."""
+        super().__init__(message)
+
+
+class CSRsMissingError(Exception):
+    """Exception raised when the number of CSRs in the queue is less than the expected number."""
+
+    def __init__(self, message: str) -> None:
+        """Initialise the exception."""
+        super().__init__(message)
+
+
+class ProvidingCertificateFailedError(Exception):
+    """Exception raised when providing a certificate fails."""
+
+    def __init__(self, message: str) -> None:
+        """Initialise the exception."""
+        super().__init__(message)
+
+
+class CSR(NamedTuple):
+    """CSR represents the information about a certificate signing request."""
+
+    relation_id: str
+    application_name: str
+    unit_name: str
+    csr: bytes
+    is_ca: bool
+
+    @classmethod
+    def from_charm_csr(cls, charm_csr: dict) -> "CSR":
+        """Create a CSR object from a dictionary.
+
+        Arguments:
+        ---------
+            charm_csr : dict
+                The dictionary containing the information about
+                the certificate signing request gotten from the charm.
+
+        Returns:
+        -------
+            CSR: The CSR object.
+
+        """
+        return cls(
+            relation_id=charm_csr["relation_id"],
+            application_name=charm_csr["application_name"],
+            unit_name=charm_csr["unit_name"],
+            csr=charm_csr["csr"].encode(),
+            is_ca=charm_csr["is_ca"],
+        )
+
+
+class ManualTLSAgent:
+    """An agent that processes certificate signing requests from the TLS operator."""
+
+    def __init__(self, tls_unit: Unit) -> None:
+        """Initialise the agent."""
+        self.tls_unit = tls_unit
+        self.ca_key = generate_private_key()
+        self.ca = generate_ca(self.ca_key, "CN_CA")
+        self.csr_queue = deque()
+
+    async def get_outstanding_certificate_requests(self) -> None:
+        """Get the outstanding certificate requests from the TLS operator.
+
+        Raises
+        ------
+            GettingOutstandingCertificateRequestsFailedError:
+                If getting the outstanding certificate requests fails.
+
+        """
+        logging.info("Getting outstanding certificate requests")
+        action = await self.tls_unit.run_action("get-outstanding-certificate-requests")
+        action: Action = await action.wait()
+        if action.status != "completed":
+            message = action.safe_data.get(
+                "message",
+                "Failed to get outstanding certificate requests",
+            )
+            if "No outstanding certificate requests" in message:
+                logging.info(message)
+            if "No certificates relation has been created yet" in message:
+                logging.info(message)
+            logging.error(message)
+            raise GettingOutstandingCertificateRequestsFailedError(message)
+        csrs = json.loads(action.results["result"])
+        for csr in csrs:
+            self.csr_queue.append(CSR.from_charm_csr(csr))
+
+    @retry(
+        wait=wait_exponential(multiplier=1, min=5, max=20),
+        stop=stop_after_attempt(100),
+    )
+    async def wait_for_csrs_in_queue(self, nbr_csrs: int = 1) -> None:
+        """Wait for the number of csrs in the queue to be equal to the number of csrs specified.
+
+        Arguments:
+        ---------
+            nbr_csrs : int
+                The number of csrs to wait for in the queue.
+
+        Raises:
+        ------
+            CSRsMissingError: If the number of csrs in the queue is less than the expected number.
+
+        """
+        await self.get_outstanding_certificate_requests()
+        if len(self.csr_queue) < nbr_csrs:
+            message = f"{nbr_csrs - len(self.csr_queue)} CSRs missing in queue"
+            raise CSRsMissingError(message)
+
+    async def process_csr(self, csr: CSR) -> None:
+        """Process the certificate signing request.
+
+        Arguments:
+        ---------
+            csr : CSR
+                The certificate signing request to process.
+
+        Raises:
+        ------
+            ProvidingCertificateFailedError: If providing the certificate fails.
+
+        """
+        # Generate a certificate
+        certificate = generate_certificate(
+            csr=csr.csr,
+            ca=self.ca,
+            ca_key=self.ca_key,
+            is_ca=csr.is_ca,
+        )
+        logger.info("Generated certificate for %s", csr.unit_name)
+        # Send the certificate back to the charm
+        action = await self.tls_unit.run_action(
+            "provide-certificate",
+            relation_id=csr.relation_id,
+            **{
+                "certificate": base64.b64encode(certificate).decode(),
+                "ca-certificate": base64.b64encode(self.ca).decode(),
+                "certificate-signing-request": base64.b64encode(
+                    csr.csr,
+                ).decode(),
+            },
+        )
+        action = await action.wait()
+        if action.status != "completed":
+            message = "Failed to provide certificate for %s", csr.unit_name
+            logging.error(message)
+            raise ProvidingCertificateFailedError(message)
+        logger.info("Provided certificate to %s", csr.unit_name)
+
+    async def process_queue(self) -> None:
+        """Process the certificate signing requests in the queue."""
+        while self.csr_queue:
+            csr = self.csr_queue.popleft()
+            await self.process_csr(csr)

--- a/tests/integration/tls/helpers_manual_tls.py
+++ b/tests/integration/tls/helpers_manual_tls.py
@@ -114,8 +114,7 @@ class ManualTLSAgent:
             logging.error(message)
             raise GettingOutstandingCertificateRequestsFailedError(message)
         csrs = json.loads(action.results["result"])
-        for csr in csrs:
-            self.csr_queue.append(CSR.from_charm_csr(csr))
+        self.csr_queue = deque([CSR.from_charm_csr(csr) for csr in csrs])
 
     @retry(
         wait=wait_exponential(multiplier=1, min=5, max=20),

--- a/tests/integration/tls/helpers_manual_tls.py
+++ b/tests/integration/tls/helpers_manual_tls.py
@@ -101,7 +101,7 @@ class ManualTLSAgent:
             )
             raise GetOutstandingCertificateRequestsError(message)
         csrs = json.loads(action.results["result"])
-        self.csr_queue = deque([CSR.from_charm_csr(csr) for csr in csrs])
+        self.csr_queue = deque([CSR.from_dict(csr) for csr in csrs])
 
     @retry(
         wait=wait_exponential(multiplier=1, min=5, max=20),

--- a/tests/integration/tls/test_manual_tls.py
+++ b/tests/integration/tls/test_manual_tls.py
@@ -72,6 +72,15 @@ async def test_build_and_deploy_with_manual_tls(ops_test: OpsTest) -> None:
     logger.info("Scaling up the application by adding a new unit")
     await os_app.add_unit(1)
 
+    # Wait for the new unit to be in maintenance
+    logger.info("Waiting for the new unit to be in maintenance waiting for certificates")
+    await wait_until(
+        ops_test,
+        apps=[APP_NAME],
+        units_statuses=["active", "maintenance"],
+        wait_for_exact_units=len(UNIT_IDS) + 1,
+    )
+
     # Wait for the new unit request certificates
     logger.info("Waiting for the new unit to request certificates")
     await manual_tls_daemon.wait_for_csrs_in_queue(2)

--- a/tests/integration/tls/test_manual_tls.py
+++ b/tests/integration/tls/test_manual_tls.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+
+import pytest
+from juju.application import Application
+from pytest_operator.plugin import OpsTest
+
+from ..helpers import APP_NAME, MODEL_CONFIG, SERIES, UNIT_IDS
+from ..helpers_deployments import wait_until
+from .helpers_manual_tls import MANUAL_TLS_CERTIFICATES_APP_NAME, ManualTLSAgent
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+@pytest.mark.skip_if_deployed
+async def test_build_and_deploy_with_manual_tls(ops_test: OpsTest) -> None:
+    """Build and deploy prod cluster of OpenSearch with Manual TLS Operator integration."""
+    my_charm = await ops_test.build_charm(".")
+    await ops_test.model.set_config(MODEL_CONFIG)
+
+    os_app: Application = await ops_test.model.deploy(
+        my_charm,
+        num_units=len(UNIT_IDS),
+        series=SERIES,
+        application_name=APP_NAME,
+    )
+
+    # Deploy TLS Certificates operator.
+    tls_app: Application = await ops_test.model.deploy(
+        MANUAL_TLS_CERTIFICATES_APP_NAME,
+        channel="beta",
+    )
+    await wait_until(
+        ops_test,
+        apps=[MANUAL_TLS_CERTIFICATES_APP_NAME],
+        apps_statuses=["active"],
+    )
+    logger.info("Deployed %s application", MANUAL_TLS_CERTIFICATES_APP_NAME)
+
+    # Integrate it to OpenSearch to set up TLS.
+    await ops_test.model.integrate(APP_NAME, MANUAL_TLS_CERTIFICATES_APP_NAME)
+    logger.info("Integrated %s with %s", APP_NAME, MANUAL_TLS_CERTIFICATES_APP_NAME)
+
+    # Initialize the ManualTLSAgent to process the CSRs
+    manual_tls_daemon = ManualTLSAgent(tls_app.units[0])
+    # Wait for len(UNIT_IDS)*2+1 CSRs to be created.
+    # 1 for each unit for http and transport and 1 for the admin cert.
+    logger.info("Waiting for CSRs to be created")
+    await manual_tls_daemon.wait_for_csrs_in_queue(len(UNIT_IDS) * 2 + 1)
+
+    # Sign all CSRs
+    logger.info("Signing CSRs")
+    await manual_tls_daemon.process_queue()
+
+    await wait_until(
+        ops_test,
+        apps=[APP_NAME],
+        apps_statuses=["active"],
+        units_statuses=["active"],
+        wait_for_exact_units=len(UNIT_IDS),
+        timeout=2000,
+    )
+    assert len(ops_test.model.applications[APP_NAME].units) == len(UNIT_IDS)
+
+    # Scale up the application by adding a new unit
+    logger.info("Scaling up the application by adding a new unit")
+    await os_app.add_unit(1)
+
+    # Wait for the new unit request certificates
+    logger.info("Waiting for the new unit to request certificates")
+    await manual_tls_daemon.wait_for_csrs_in_queue(2)
+
+    # Sign all CSRs
+    logger.info("Signing CSRs")
+    await manual_tls_daemon.process_queue()
+
+    # Wait for the new unit to be active
+    logger.info("Waiting for the new unit to be active")
+    await wait_until(
+        ops_test,
+        apps=[APP_NAME],
+        units_statuses=["active"],
+        wait_for_exact_units=len(UNIT_IDS) + 1,
+    )
+    assert len(ops_test.model.applications[APP_NAME].units) == len(UNIT_IDS) + 1

--- a/tests/integration/tls/test_manual_tls.py
+++ b/tests/integration/tls/test_manual_tls.py
@@ -34,7 +34,7 @@ async def test_build_and_deploy_with_manual_tls(ops_test: OpsTest) -> None:
     # Deploy TLS Certificates operator.
     tls_app: Application = await ops_test.model.deploy(
         MANUAL_TLS_CERTIFICATES_APP_NAME,
-        channel="beta",
+        channel="stable",
     )
     await wait_until(
         ops_test,

--- a/tests/integration/tls/test_tls.py
+++ b/tests/integration/tls/test_tls.py
@@ -5,7 +5,6 @@
 import logging
 
 import pytest
-from juju.application import Application
 from pytest_operator.plugin import OpsTest
 
 from ..helpers import (
@@ -28,7 +27,6 @@ from ..tls.helpers import (
     check_unit_tls_configured,
     get_loaded_tls_certificates,
 )
-from .helpers_manual_tls import MANUAL_TLS_CERTIFICATES_APP_NAME, ManualTLSAgent
 
 logger = logging.getLogger(__name__)
 
@@ -156,75 +154,3 @@ async def test_tls_renewal(ops_test: OpsTest) -> None:
         updated_certs["http_certificates_list"][0]["not_before"]
         > current_certs["http_certificates_list"][0]["not_before"]
     )
-
-
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
-@pytest.mark.group(1)
-@pytest.mark.abort_on_fail
-@pytest.mark.skip_if_deployed
-async def test_build_and_deploy_with_manual_tls(ops_test: OpsTest) -> None:
-    """Build and deploy prod cluster of OpenSearch with Manual TLS Operator integration."""
-    my_charm = await ops_test.build_charm(".")
-    await ops_test.model.set_config(MODEL_CONFIG)
-
-    os_app_name = APP_NAME + "-manual-tls"
-    os_app: Application = await ops_test.model.deploy(
-        my_charm,
-        num_units=len(UNIT_IDS),
-        series=SERIES,
-        application_name=os_app_name,
-    )
-
-    # Deploy TLS Certificates operator.
-    tls_app: Application = await ops_test.model.deploy(
-        MANUAL_TLS_CERTIFICATES_APP_NAME, channel="beta"
-    )
-    await wait_until(ops_test, apps=[MANUAL_TLS_CERTIFICATES_APP_NAME], apps_statuses=["active"])
-    logger.info(f"Deployed {MANUAL_TLS_CERTIFICATES_APP_NAME} application")
-
-    # Integrate it to OpenSearch to set up TLS.
-    await ops_test.model.integrate(os_app_name, MANUAL_TLS_CERTIFICATES_APP_NAME)
-    logger.info(f"Integrated {MANUAL_TLS_CERTIFICATES_APP_NAME} with {os_app_name}")
-
-    # Initialize the ManualTLSAgent to process the CSRs
-    manual_tls_daemon = ManualTLSAgent(tls_app.units[0])
-    # Wait for len(UNIT_IDS)*2+1 CSRs to be created.
-    # 1 for each unit for http and transport and 1 for the admin cert.
-    logger.info("Waiting for CSRs to be created")
-    await manual_tls_daemon.wait_for_csrs_in_queue(len(UNIT_IDS) * 2 + 1)
-
-    # Sign all CSRs
-    logger.info("Signing CSRs")
-    await manual_tls_daemon.process_queue()
-
-    await wait_until(
-        ops_test,
-        apps=[os_app_name],
-        apps_statuses=["active"],
-        units_statuses=["active"],
-        wait_for_exact_units=len(UNIT_IDS),
-        timeout=2000,
-    )
-    assert len(ops_test.model.applications[os_app_name].units) == len(UNIT_IDS)
-
-    # Scale up the application by adding a new unit
-    logger.info("Scaling up the application by adding a new unit")
-    await os_app.add_unit(1)
-
-    # Wait for the new unit request certificates
-    logger.info("Waiting for the new unit to request certificates")
-    await manual_tls_daemon.wait_for_csrs_in_queue(2)
-
-    # Sign all CSRs
-    logger.info("Signing CSRs")
-    await manual_tls_daemon.process_queue()
-
-    # Wait for the new unit to be active
-    logger.info("Waiting for the new unit to be active")
-    await wait_until(
-        ops_test,
-        apps=[os_app_name],
-        units_statuses=["active"],
-        wait_for_exact_units=len(UNIT_IDS) + 1,
-    )
-    assert len(ops_test.model.applications[os_app_name].units) == len(UNIT_IDS) + 1

--- a/tests/integration/tls/test_tls.py
+++ b/tests/integration/tls/test_tls.py
@@ -6,6 +6,9 @@ import logging
 
 import pytest
 from pytest_operator.plugin import OpsTest
+from juju.application import Application
+
+from .helpers_manual_tls import MANUAL_TLS_CERTIFICATES_APP_NAME, ManualTLSAgent
 
 from ..helpers import (
     APP_NAME,
@@ -154,3 +157,72 @@ async def test_tls_renewal(ops_test: OpsTest) -> None:
         updated_certs["http_certificates_list"][0]["not_before"]
         > current_certs["http_certificates_list"][0]["not_before"]
     )
+
+
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy_with_manual_tls(ops_test: OpsTest) -> None:
+    """Build and deploy prod cluster of OpenSearch with Manual TLS Operator integration."""
+    my_charm = await ops_test.build_charm(".")
+    await ops_test.model.set_config(MODEL_CONFIG)
+
+    os_app: Application = await ops_test.model.deploy(
+        my_charm,
+        num_units=len(UNIT_IDS),
+        series=SERIES,
+    )
+
+    # Deploy TLS Certificates operator.
+    tls_app: Application = await ops_test.model.deploy(
+        MANUAL_TLS_CERTIFICATES_APP_NAME, channel="beta"
+    )
+    await wait_until(ops_test, apps=[MANUAL_TLS_CERTIFICATES_APP_NAME], apps_statuses=["active"])
+    logger.info(f"Deployed {MANUAL_TLS_CERTIFICATES_APP_NAME} application")
+
+    # Integrate it to OpenSearch to set up TLS.
+    await ops_test.model.integrate(APP_NAME, MANUAL_TLS_CERTIFICATES_APP_NAME)
+    logger.info(f"Integrated {MANUAL_TLS_CERTIFICATES_APP_NAME} with {APP_NAME}")
+
+    # Initialize the ManualTLSAgent to process the CSRs
+    manual_tls_daemon = ManualTLSAgent(tls_app.units[0])
+    # Wait for len(UNIT_IDS)*2+1 CSRs to be created.
+    # 1 for each unit for http and transport and 1 for the admin cert.
+    logger.info("Waiting for CSRs to be created")
+    await manual_tls_daemon.wait_for_csrs_in_queue(len(UNIT_IDS) * 2 + 1)
+
+    # Sign all CSRs
+    logger.info("Signing CSRs")
+    await manual_tls_daemon.process_queue()
+
+    await wait_until(
+        ops_test,
+        apps=[APP_NAME],
+        apps_statuses=["active"],
+        units_statuses=["active"],
+        wait_for_exact_units=len(UNIT_IDS),
+        timeout=2000,
+    )
+    assert len(ops_test.model.applications[APP_NAME].units) == len(UNIT_IDS)
+
+    # Scale up the application by adding a new unit
+    logger.info("Scaling up the application by adding a new unit")
+    await os_app.add_unit(1)
+
+    # Wait for the new unit request certificates
+    logger.info("Waiting for the new unit to request certificates")
+    await manual_tls_daemon.wait_for_csrs_in_queue(2)
+
+    # Sign all CSRs
+    logger.info("Signing CSRs")
+    await manual_tls_daemon.process_queue()
+
+    # Wait for the new unit to be active
+    logger.info("Waiting for the new unit to be active")
+    await wait_until(
+        ops_test,
+        apps=[APP_NAME],
+        units_statuses=["active"],
+        wait_for_exact_units=len(UNIT_IDS) + 1,
+    )
+    assert len(ops_test.model.applications[APP_NAME].units) == len(UNIT_IDS) + 1

--- a/tests/integration/tls/test_tls.py
+++ b/tests/integration/tls/test_tls.py
@@ -5,10 +5,8 @@
 import logging
 
 import pytest
-from pytest_operator.plugin import OpsTest
 from juju.application import Application
-
-from .helpers_manual_tls import MANUAL_TLS_CERTIFICATES_APP_NAME, ManualTLSAgent
+from pytest_operator.plugin import OpsTest
 
 from ..helpers import (
     APP_NAME,
@@ -30,6 +28,7 @@ from ..tls.helpers import (
     check_unit_tls_configured,
     get_loaded_tls_certificates,
 )
+from .helpers_manual_tls import MANUAL_TLS_CERTIFICATES_APP_NAME, ManualTLSAgent
 
 logger = logging.getLogger(__name__)
 

--- a/tests/integration/tls/test_tls.py
+++ b/tests/integration/tls/test_tls.py
@@ -161,6 +161,7 @@ async def test_tls_renewal(ops_test: OpsTest) -> None:
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
+@pytest.mark.skip_if_deployed
 async def test_build_and_deploy_with_manual_tls(ops_test: OpsTest) -> None:
     """Build and deploy prod cluster of OpenSearch with Manual TLS Operator integration."""
     my_charm = await ops_test.build_charm(".")


### PR DESCRIPTION
Add a test for an OpenSearch deployment with TLS certificates issued by the `manual-tls-certificates` operator.