### PR TITLE
[DPE-4049][BUGFIX] Exception when offline unit is missing `node.roles` from static config

### DIFF
--- a/lib/charms/opensearch/v0/constants_charm.py
+++ b/lib/charms/opensearch/v0/constants_charm.py
@@ -98,6 +98,7 @@ COSUser = "monitor"
 COSRelationName = "cos-agent"
 COSRole = "readall_and_monitor"
 COSPort = "9200"
+GeneratedRoles = ["data", "ingest", "ml", "cluster_manager"]
 
 
 # Opensearch Users

--- a/lib/charms/opensearch/v0/helper_cluster.py
+++ b/lib/charms/opensearch/v0/helper_cluster.py
@@ -5,6 +5,7 @@
 import logging
 from typing import Dict, List, Optional
 
+from charms.opensearch.v0.constants_charm import GeneratedRoles
 from charms.opensearch.v0.helper_enums import BaseStrEnum
 from charms.opensearch.v0.models import App, Node
 from charms.opensearch.v0.opensearch_distro import OpenSearchDistribution
@@ -37,7 +38,7 @@ class ClusterTopology:
     @staticmethod
     def generated_roles() -> List[str]:
         """Get generated roles for a Node."""
-        return ["data", "ingest", "ml", "cluster_manager"]
+        return GeneratedRoles
 
     @staticmethod
     def get_cluster_settings(

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -5,16 +5,46 @@ import responses
 from ops.model import Model, Unit
 
 NODE_ID = "yTLtw5wNQlCsHUcrKaU5Kw"
+CLUSTER_NAME = "opensearch-nfp7"
 
 
-def mock_response_root(unit_name: str, host: str):
+def mock_deployment_desc(
+    model_uuid: str,
+    roles: list[str],
+    state: str,
+    typ: str,
+    temperature: str | None = None,
+    cluster_name: str = CLUSTER_NAME,
+) -> dict[str, str]:
+    return {
+        "app": {
+            "id": f"{model_uuid}/opensearch",
+            "model_uuid": model_uuid,
+            "name": "opensearch",
+            "short_id": "5a5",
+        },
+        "config": {
+            "cluster_name": cluster_name,
+            "data_temperature": temperature,
+            "init_hold": False,
+            "roles": roles,
+        },
+        "pending_directives": [],
+        "promotion_time": 1721391694.387948,
+        "start": "start-with-generated-roles",
+        "state": {"message": "", "value": "active"},
+        "typ": typ,
+    }
+
+
+def mock_response_root(unit_name: str, host: str, cluster_name: str = CLUSTER_NAME):
     """Add API mock for the API root ('/') query.
 
     Keep in mind to add @responses.activate decorator to the test function using this call!
     """
     expected_response_root = {
         "name": unit_name.replace("/", "-"),
-        "cluster_name": "opensearch-nfp7",
+        "cluster_name": cluster_name,
         "cluster_uuid": "TYji6UEuSw2tnIL-z8xEOg",
         "version": {
             "distribution": "opensearch",
@@ -38,14 +68,17 @@ def mock_response_root(unit_name: str, host: str):
     )
 
 
-def mock_response_nodes(unit_name: str, host: str, node_id: str = NODE_ID):
-    """Add API mock for the API root ('/') query.
+def mock_response_nodes(
+    unit_name: str, host: str, node_id: str = NODE_ID, cluster_name: str = CLUSTER_NAME
+):
+    """Add API mock for the API ('/nodes') query.
 
     Keep in mind to add @responses.activate decorator to the test function using this call!
+    NOTE: unit_name should be charm.unit_name (NOT charm.unit.name)
     """
     expected_response_nodes = {
         "_nodes": {"total": 1, "successful": 1, "failed": 0},
-        "cluster_name": "opensearch-nfp7",
+        "cluster_name": cluster_name,
         "nodes": {
             node_id: {
                 "name": unit_name.replace("/", "-"),
@@ -67,6 +100,75 @@ def mock_response_nodes(unit_name: str, host: str, node_id: str = NODE_ID):
 
     responses.add(
         method="GET", url=f"https://{host}:9200/_nodes", json=expected_response_nodes, status=200
+    )
+
+
+def mock_response_mynode(
+    unit_name: str, host: str, node_id: str = NODE_ID, cluster_name: str = CLUSTER_NAME
+):
+    """Add API mock for the API root ('/') query.
+
+    Keep in mind to add @responses.activate decorator to the test function using this call!
+    """
+    expected_response_mynode = {
+        "_nodes": {"total": 1, "successful": 1, "failed": 0},
+        "cluster_name": cluster_name,
+        "nodes": {
+            node_id: {
+                "name": unit_name,
+                "transport_address": f"{host}:9300",
+                "host": host,
+                "ip": host,
+                "version": "2.14.0",
+                "build_type": "tar",
+                "build_hash": "30dd870855093c9dca23fc6f8cfd5c0d7c83127d",
+                "total_indexing_buffer": 107374182,
+                "roles": ["cluster_manager", "coordinating_only", "data", "ingest", "ml"],
+                "attributes": {
+                    "shard_indexing_pressure_enabled": "true",
+                    "app_id": "617e5f02-5be5-4e25-85f0-276b2347a5ad/opensearch",
+                },
+                "settings": {
+                    "cluster": {
+                        "name": "opensearch-nfp7",
+                        "initial_cluster_manager_nodes": ["opensearch-1.e74"],
+                    },
+                    "node": {
+                        "attr": {
+                            "app_id": "617e5f02-5be5-4e25-85f0-276b2347a5ad/opensearch",
+                            "shard_indexing_pressure_enabled": "true",
+                        },
+                        "name": unit_name,
+                        "roles": [
+                            "data",
+                            "ingest",
+                            "ml",
+                            "coordinating_only",
+                            "cluster_manager",
+                        ],
+                    },
+                    "path": {
+                        "data": ["/var/snap/opensearch/common/var/lib/opensearch"],
+                        "logs": "/var/snap/opensearch/common/var/log/opensearch",
+                        "home": "/var/snap/opensearch/current/usr/share/opensearch",
+                    },
+                    "discovery": {"seed_providers": "file"},
+                    "client": {"type": "node"},
+                    "http": {
+                        "compression": "false",
+                        "type": "org.opensearch.security.http.SecurityHttpServerTransport",
+                        "type.default": "netty4",
+                    },
+                    "index": {},
+                },
+            }
+        },
+    }
+    responses.add(
+        method="GET",
+        url=f"https://{host}:9200/_nodes/{node_id}",
+        json=expected_response_mynode,
+        status=200,
     )
 
 

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -123,7 +123,7 @@ def mock_response_mynode(
                 "build_type": "tar",
                 "build_hash": "30dd870855093c9dca23fc6f8cfd5c0d7c83127d",
                 "total_indexing_buffer": 107374182,
-                "roles": ["cluster_manager", "coordinating_only", "data", "ingest", "ml"],
+                "roles": ["cluster_manager", "data", "ingest", "ml"],
                 "attributes": {
                     "shard_indexing_pressure_enabled": "true",
                     "app_id": "617e5f02-5be5-4e25-85f0-276b2347a5ad/opensearch",
@@ -143,7 +143,6 @@ def mock_response_mynode(
                             "data",
                             "ingest",
                             "ml",
-                            "coordinating_only",
                             "cluster_manager",
                         ],
                     },

--- a/tests/unit/lib/test_backups.py
+++ b/tests/unit/lib/test_backups.py
@@ -81,38 +81,40 @@ def create_deployment_desc():
 @pytest.fixture(scope="function")
 def harness():
     harness_obj = Harness(OpenSearchOperatorCharm)
-    charms.opensearch.v0.opensearch_base_charm.OpenSearchPeerClustersManager.deployment_desc = (
-        MagicMock(return_value=create_deployment_desc())
-    )
-    harness_obj.begin()
-    charm = harness_obj.charm
-    # Override the config to simulate the TestPlugin
-    # As config.yaml does not exist, the setup below simulates it
-    charm.plugin_manager._charm_config = harness_obj.model._config
-    # Override the ConfigExposedPlugins
-    charms.opensearch.v0.opensearch_plugin_manager.ConfigExposedPlugins = {
-        "repository-s3": {
-            "class": OpenSearchBackupPlugin,
-            "config": None,
-            "relation": "s3-credentials",
-        },
-    }
-    charm.opensearch.is_started = MagicMock(return_value=True)
-    charm.health.apply = MagicMock(return_value=HealthColors.GREEN)
-    # Mock retrials to speed up tests
-    charms.opensearch.v0.opensearch_backups.wait_fixed = MagicMock(
-        return_value=tenacity.wait.wait_fixed(0.1)
-    )
+    with patch(
+        "charms.opensearch.v0.opensearch_base_charm.OpenSearchPeerClustersManager.deployment_desc",
+        return_value=create_deployment_desc(),
+    ):
+        harness_obj.begin()
+        charm = harness_obj.charm
+        # Override the config to simulate the TestPlugin
+        # As config.yaml does not exist, the setup below simulates it
+        charm.plugin_manager._charm_config = harness_obj.model._config
+        # Override the ConfigExposedPlugins
+        charms.opensearch.v0.opensearch_plugin_manager.ConfigExposedPlugins = {
+            "repository-s3": {
+                "class": OpenSearchBackupPlugin,
+                "config": None,
+                "relation": "s3-credentials",
+            },
+        }
+        charm.opensearch.is_started = MagicMock(return_value=True)
+        charm.health.apply = MagicMock(return_value=HealthColors.GREEN)
+        # Mock retrials to speed up tests
+        charms.opensearch.v0.opensearch_backups.wait_fixed = MagicMock(
+            return_value=tenacity.wait.wait_fixed(0.1)
+        )
 
-    # Replace some unused methods that will be called as part of set_leader with mock
-    charm._put_admin_user = MagicMock()
-    charm._put_kibanaserver_user = MagicMock()
-    charm._put_or_update_internal_user_leader = MagicMock()
+        # Replace some unused methods that will be called as part of set_leader with mock
+        charm._put_admin_user = MagicMock()
+        charm._put_kibanaserver_user = MagicMock()
+        charm._put_or_update_internal_user_leader = MagicMock()
 
-    harness_obj.add_relation(PeerRelationName, "opensearch")
-    harness_obj.set_leader(is_leader=True)
+        harness_obj.add_relation(PeerRelationName, "opensearch")
+        harness_obj.set_leader(is_leader=True)
 
-    return harness_obj
+        yield harness_obj
+        # return harness_obj
 
 
 @pytest.fixture(scope="function")
@@ -478,44 +480,49 @@ def test_on_s3_broken_steps(
 
 
 @patch_network_get("1.1.1.1")
+@patch(
+    "charms.opensearch.v0.opensearch_base_charm.OpenSearchPeerClustersManager.deployment_desc",
+    return_value=create_deployment_desc(),
+)
 class TestBackups(unittest.TestCase):
     maxDiff = None
 
     def setUp(self) -> None:
         self.harness = Harness(OpenSearchOperatorCharm)
         self.addCleanup(self.harness.cleanup)
-        charms.opensearch.v0.opensearch_base_charm.OpenSearchPeerClustersManager.deployment_desc = MagicMock(
-            return_value=create_deployment_desc()
-        )
-        self.harness.begin()
+        with patch(
+            "charms.opensearch.v0.opensearch_base_charm.OpenSearchPeerClustersManager.deployment_desc",
+            return_value=create_deployment_desc(),
+        ):
+            self.harness.begin()
 
-        self.charm = self.harness.charm
-        # Override the config to simulate the TestPlugin
-        # As config.yaml does not exist, the setup below simulates it
-        self.charm.plugin_manager._charm_config = self.harness.model._config
-        self.plugin_manager = self.charm.plugin_manager
-        # Override the ConfigExposedPlugins
-        charms.opensearch.v0.opensearch_plugin_manager.ConfigExposedPlugins = {
-            "repository-s3": {
-                "class": OpenSearchBackupPlugin,
-                "config": None,
-                "relation": "s3-credentials",
-            },
-        }
-        self.charm.opensearch.is_started = MagicMock(return_value=True)
-        self.charm.health.apply = MagicMock(return_value=HealthColors.GREEN)
-        # Mock retrials to speed up tests
-        charms.opensearch.v0.opensearch_backups.wait_fixed = MagicMock(
-            return_value=tenacity.wait.wait_fixed(0.1)
-        )
-        self.charm.status = MagicMock()
+            self.charm = self.harness.charm
+            # Override the config to simulate the TestPlugin
+            # As config.yaml does not exist, the setup below simulates it
+            self.charm.plugin_manager._charm_config = self.harness.model._config
+            self.plugin_manager = self.charm.plugin_manager
+            # Override the ConfigExposedPlugins
+            charms.opensearch.v0.opensearch_plugin_manager.ConfigExposedPlugins = {
+                "repository-s3": {
+                    "class": OpenSearchBackupPlugin,
+                    "config": None,
+                    "relation": "s3-credentials",
+                },
+            }
+            self.charm.opensearch.is_started = MagicMock(return_value=True)
+            self.charm.health.apply = MagicMock(return_value=HealthColors.GREEN)
+            # Mock retrials to speed up tests
+            charms.opensearch.v0.opensearch_backups.wait_fixed = MagicMock(
+                return_value=tenacity.wait.wait_fixed(0.1)
+            )
+            self.charm.status = MagicMock()
 
-        # Replace some unused methods that will be called as part of set_leader with mock
-        self.charm._put_admin_user = MagicMock()
-        self.charm._put_kibanaserver_user = MagicMock()
-        self.charm._put_or_update_internal_user_leader = MagicMock()
-        self.peer_id = self.harness.add_relation(PeerRelationName, "opensearch")
-        self.harness.set_leader(is_leader=True)
+            # Replace some unused methods that will be called as part of set_leader with mock
+            self.charm._put_admin_user = MagicMock()
+            self.charm._put_kibanaserver_user = MagicMock()
+            self.charm._put_or_update_internal_user_leader = MagicMock()
+            self.peer_id = self.harness.add_relation(PeerRelationName, "opensearch")
+            self.harness.set_leader(is_leader=True)
 
         # Relate and run first check
         with patch(
@@ -525,7 +532,7 @@ class TestBackups(unittest.TestCase):
             self.harness.add_relation_unit(self.s3_rel_id, "s3-integrator/0")
             mock_pm_run.assert_not_called()
 
-    def test_get_endpoint_protocol(self) -> None:
+    def test_get_endpoint_protocol(self, _) -> None:
         """Tests the get_endpoint_protocol method."""
         assert self.charm.backup._get_endpoint_protocol("http://10.0.0.1:8000") == "http"
         assert self.charm.backup._get_endpoint_protocol("https://10.0.0.2:8000") == "https"
@@ -539,7 +546,7 @@ class TestBackups(unittest.TestCase):
     @patch("charms.opensearch.v0.opensearch_plugin_manager.OpenSearchPluginManager.apply_config")
     @patch("charms.opensearch.v0.opensearch_distro.OpenSearchDistribution.version")
     def test_00_update_relation_data(
-        self, __, mock_apply_config, _, mock_status, mock_pm_ready
+        self, _, mock_apply_config, __, mock_status, mock_pm_ready, ___
     ) -> None:
         """Tests if new relation without data returns."""
         mock_pm_ready.return_value = True
@@ -570,7 +577,7 @@ class TestBackups(unittest.TestCase):
     @patch("charms.opensearch.v0.opensearch_backups.OpenSearchBackup._request")
     @patch("charms.opensearch.v0.opensearch_distro.OpenSearchDistribution.request")
     @patch("charms.opensearch.v0.opensearch_plugin_manager.OpenSearchPluginManager.status")
-    def test_apply_api_config_if_needed(self, mock_status, _, mock_request) -> None:
+    def test_apply_api_config_if_needed(self, mock_status, _, mock_request, __) -> None:
         """Tests the application of post-restart steps."""
         self.harness.update_relation_data(
             self.s3_rel_id,
@@ -603,7 +610,7 @@ class TestBackups(unittest.TestCase):
             },
         )
 
-    def test_on_list_backups_action(self):
+    def test_on_list_backups_action(self, _):
         event = MagicMock()
         event.params = {"output": "table"}
         self.charm.backup._list_backups = MagicMock(return_value={"backup1": {"state": "SUCCESS"}})
@@ -613,7 +620,7 @@ class TestBackups(unittest.TestCase):
         self.charm.backup._on_list_backups_action(event)
         event.set_results.assert_called_with({"backups": "backup1 | finished"})
 
-    def test_on_list_backups_action_in_json_format(self):
+    def test_on_list_backups_action_in_json_format(self, _):
         event = MagicMock()
         event.params = {"output": "json"}
         self.charm.backup._list_backups = MagicMock(return_value={"backup1": {"state": "SUCCESS"}})
@@ -623,7 +630,7 @@ class TestBackups(unittest.TestCase):
         self.charm.backup._on_list_backups_action(event)
         event.set_results.assert_called_with({"backups": '{"backup1": {"state": "SUCCESS"}}'})
 
-    def test_is_restore_complete(self):
+    def test_is_restore_complete(self, _):
         rel = MagicMock()
         rel.data = {self.charm.app: {"restore_in_progress": "index1,index2"}}
         self.charm.model.get_relation = MagicMock(return_value=rel)
@@ -649,6 +656,7 @@ class TestBackups(unittest.TestCase):
         mock_request,
         mock_apply_config,
         _,
+        __,
     ) -> None:
         """Tests broken relation unit."""
         mock_request.side_effects = [
@@ -671,7 +679,7 @@ class TestBackups(unittest.TestCase):
             ).__dict__
         )
 
-    def test_format_backup_list(self):
+    def test_format_backup_list(self, _):
         """Tests the format of the backup list."""
         self.charm.opensearch.request = MagicMock(
             return_value={
@@ -687,7 +695,7 @@ class TestBackups(unittest.TestCase):
             self.charm.backup._generate_backup_list_output(backups), LIST_BACKUPS_TRIAL
         )
 
-    def test_can_unit_perform_backup_success(self):
+    def test_can_unit_perform_backup_success(self, _):
         plugin_method = "charms.opensearch.v0.opensearch_backups.OpenSearchBackup._plugin_status"
         event = MagicMock()
         with patch(plugin_method, new_callable=PropertyMock) as mock_plugin_status:
@@ -702,7 +710,7 @@ class TestBackups(unittest.TestCase):
 
     @patch("charms.opensearch.v0.opensearch_backups.datetime")
     @patch("charms.opensearch.v0.opensearch_backups.OpenSearchBackup._request")
-    def test_on_create_backup_action_success(self, mock_request, mock_time):
+    def test_on_create_backup_action_success(self, mock_request, mock_time, _):
         event = MagicMock()
         mock_time.now().strftime.return_value = "2023-01-01T00:00:00Z"
         self.charm.backup._can_unit_perform_backup = MagicMock(return_value=True)
@@ -718,13 +726,13 @@ class TestBackups(unittest.TestCase):
             {"backup-id": "2023-01-01T00:00:00Z", "status": "Backup is running."}
         )
 
-    def test_on_create_backup_action_failure(self):
+    def test_on_create_backup_action_failure(self, _):
         event = MagicMock()
         self.charm.backup._can_unit_perform_backup = MagicMock(return_value=False)
         self.charm.backup._on_create_backup_action(event)
         event.fail.assert_called_with("Failed: backup service is not configured or busy")
 
-    def test_on_create_backup_action_backup_in_progress(self):
+    def test_on_create_backup_action_backup_in_progress(self, _):
         event = MagicMock()
         self.charm.backup._check_repo_status = MagicMock(return_value=BackupServiceState.SUCCESS)
         self.charm.backup.is_backup_in_progress = MagicMock(return_value=True)
@@ -735,7 +743,7 @@ class TestBackups(unittest.TestCase):
             mock_plugin_status.assert_called_once()
         event.fail.assert_called_with("Failed: backup service is not configured or busy")
 
-    def test_on_create_backup_action_exception(self):
+    def test_on_create_backup_action_exception(self, _):
         event = MagicMock()
         self.charm.backup._can_unit_perform_backup = MagicMock(return_value=True)
         self.charm.backup.is_backup_in_progress = MagicMock(return_value=False)
@@ -747,7 +755,7 @@ class TestBackups(unittest.TestCase):
             "Failed with exception: HTTP error self.response_code='Internal Server Error'\nself.response_text=500"
         )
 
-    def test_on_restore_backup_action(self):
+    def test_on_restore_backup_action(self, _):
         """Runs the entire restore backup action successfully."""
         event = MagicMock()
         event.params = {"backup-id": "2023-01-01T00:00:00Z"}
@@ -779,7 +787,7 @@ class TestBackups(unittest.TestCase):
         self.charm.backup._close_indices_if_needed.assert_called_once_with("2023-01-01T00:00:00Z")
         self.charm.backup._restore.assert_called_once_with("2023-01-01T00:00:00Z")
 
-    def test_on_restore_backup_action_backup_service_not_configured(self):
+    def test_on_restore_backup_action_backup_service_not_configured(self, _):
         # Mocking helper method
         event = MagicMock()
         event.params = {"backup-id": "2023-01-01T00:00:00Z"}
@@ -799,7 +807,7 @@ class TestBackups(unittest.TestCase):
         event.fail.assert_called_once_with("Failed: backup service is not configured yet")
         event.set_results.assert_not_called()
 
-    def test_on_restore_backup_action_previous_restore_in_progress(self):
+    def test_on_restore_backup_action_previous_restore_in_progress(self, _):
         event = MagicMock()
         event.params = {"backup-id": "2023-01-01T00:00:00Z"}
         self.charm.backup._can_unit_perform_backup = MagicMock(return_value=True)
@@ -816,7 +824,7 @@ class TestBackups(unittest.TestCase):
         event.fail.assert_called_once_with("Failed: previous restore is still in progress")
         event.set_results.assert_not_called()
 
-    def test_on_restore_backup_action_backup_id_not_available(self):
+    def test_on_restore_backup_action_backup_id_not_available(self, _):
         event = MagicMock()
         event.params = {"backup-id": "2023-01-01T00:00:00Z"}
         self.charm.backup._can_unit_perform_backup = MagicMock(return_value=True)
@@ -834,7 +842,7 @@ class TestBackups(unittest.TestCase):
         event.fail.assert_called_once_with("Failed: no backup-id 2023-01-01T00:00:00Z")
         event.set_results.assert_not_called()
 
-    def test_on_restore_backup_action_restore_failed(self):
+    def test_on_restore_backup_action_restore_failed(self, _):
         event = MagicMock()
         event.params = {"backup-id": "2023-01-01T00:00:00Z"}
         self.charm.backup._can_unit_perform_backup = MagicMock(return_value=True)

--- a/tests/unit/lib/test_helper_cluster.py
+++ b/tests/unit/lib/test_helper_cluster.py
@@ -280,7 +280,7 @@ class TestHelperCluster(unittest.TestCase):
         self.assertEqual(raw_node.roles, from_json_node.roles)
         self.assertEqual(raw_node.ip, from_json_node.ip)
 
-    @patch("charms.opensearch.v0.helper_cluster.OpenSearchDistribution.request")
+    @patch("charms.opensearch.v0.opensearch_distro.OpenSearchDistribution.request")
     def test_get_cluster_settings(self, request_mock):
         """Test the get_cluster_settings method."""
         request_mock.return_value = {
@@ -313,26 +313,4 @@ class TestHelperCluster(unittest.TestCase):
             "/_cluster/settings?flat_settings=true&include_defaults=true",
             host=None,
             alt_hosts=None,
-        )
-
-    @patch("charms.opensearch.v0.helper_cluster.ClusterState.shards")
-    def test_count_shards_by_state(self, shards):
-        """Test the busy shards filtering."""
-        shards.return_value = [
-            {"index": "index1", "state": "STARTED", "node": "opensearch-0"},
-            {"index": "index1", "state": "INITIALIZING", "node": "opensearch-1"},
-            {"index": "index2", "state": "STARTED", "node": "opensearch-0"},
-            {"index": "index2", "state": "RELOCATING", "node": "opensearch-1"},
-            {"index": "index3", "state": "STARTED", "node": "opensearch-0"},
-            {"index": "index3", "state": "STARTED", "node": "opensearch-1"},
-            {"index": "index4", "state": "STARTED", "node": "opensearch-2"},
-            {"index": "index4", "state": "INITIALIZING", "node": "opensearch-2"},
-        ]
-        self.assertDictEqual(
-            ClusterState.shards_by_state(self.opensearch),
-            {
-                "STARTED": 5,
-                "INITIALIZING": 2,
-                "RELOCATING": 1,
-            },
         )

--- a/tests/unit/lib/test_opensearch_config.py
+++ b/tests/unit/lib/test_opensearch_config.py
@@ -5,15 +5,23 @@
 import shutil
 import unittest
 from typing import Dict
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from charms.opensearch.v0.constants_charm import PeerRelationName
 from charms.opensearch.v0.constants_tls import CertType
 from charms.opensearch.v0.helper_conf_setter import YamlConfigSetter
-from charms.opensearch.v0.models import App
 from ops.testing import Harness
 
 from charm import OpenSearchOperatorCharm
+from lib.charms.opensearch.v0.models import (
+    App,
+    DeploymentDescription,
+    DeploymentState,
+    DeploymentType,
+    PeerClusterConfig,
+    StartMode,
+    State,
+)
 from tests.helpers import copy_file_content_to_tmp
 
 
@@ -164,9 +172,23 @@ class TestOpenSearchConfig(unittest.TestCase):
         opensearch_conf = self.yaml_conf_setter.load(self.opensearch_yml)
         self.assertCountEqual(opensearch_conf["plugins.security.nodes_dn"], ["10.10.10.10"])
 
-    def test_set_node_and_cleanup_if_bootstrapped(self):
+    @patch(
+        "charms.opensearch.v0.opensearch_peer_clusters.OpenSearchPeerClustersManager.deployment_desc"
+    )
+    def test_set_node_and_cleanup_if_bootstrapped(self, mock_deployment_desc):
         """Test setting the core config of a node."""
         app = App(model_uuid=self.charm.model.uuid, name=self.charm.app.name)
+        mock_deployment_desc.return_value = DeploymentDescription(
+            config=PeerClusterConfig(
+                cluster_name="logs", init_hold=False, roles=["cluster_manager", "data"]
+            ),
+            start=StartMode.WITH_PROVIDED_ROLES,
+            pending_directives=[],
+            app=App(model_uuid="model-uuid", name="opensearch"),
+            typ=DeploymentType.MAIN_ORCHESTRATOR,
+            state=DeploymentState(value=State.ACTIVE),
+        )
+
         self.opensearch_config.set_node(
             app=app,
             cluster_name="opensearch-dev",

--- a/tests/unit/lib/test_opensearch_distro.py
+++ b/tests/unit/lib/test_opensearch_distro.py
@@ -1,0 +1,87 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import json
+import unittest
+from unittest.mock import patch
+
+import responses
+from charms.opensearch.v0.constants_charm import PeerRelationName
+from charms.opensearch.v0.helper_cluster import Node
+from charms.opensearch.v0.helper_conf_setter import YamlConfigSetter
+from charms.opensearch.v0.models import DeploymentState, DeploymentType, State
+from ops.testing import Harness
+
+from charm import OpenSearchOperatorCharm
+from tests.unit.helpers import (
+    mock_deployment_desc,
+    mock_response_mynode,
+    mock_response_nodes,
+    mock_response_root,
+)
+
+
+class TestOpenSearchConfig(unittest.TestCase):
+    def setUp(self) -> None:
+        self.harness = Harness(OpenSearchOperatorCharm)
+        self.addCleanup(self.harness.cleanup)
+        self.harness.begin()
+
+        self.charm = self.harness.charm
+        self.rel_id = self.harness.add_relation(PeerRelationName, self.charm.app.name)
+
+        self.config_path = "tests/unit/resources/config"
+        self.charm.opensearch.config = YamlConfigSetter(base_path=self.config_path)
+
+        # Adding Deployment Description to the Peer Relation Data
+        deployment_desc = mock_deployment_desc(
+            model_uuid=self.harness.charm.model.uuid,
+            roles=["deployment_role1", "deployment_role2"],
+            state=DeploymentState(value=State.ACTIVE),
+            typ=DeploymentType.MAIN_ORCHESTRATOR,
+            temperature="warm",
+        )
+
+        with self.harness.hooks_disabled():
+            self.harness.update_relation_data(
+                self.rel_id,
+                f"{self.charm.app.name}",
+                {"deployment-description": json.dumps(deployment_desc)},
+            )
+
+    @responses.activate
+    @patch("socket.socket.connect")
+    def test_distro_current_online_ok(self, _):
+        """Current node information retrieved from cluster state."""
+        mock_response_root(self.charm.unit_name, self.charm.opensearch.host)
+        mock_response_nodes(self.charm.unit_name, self.charm.opensearch.host)
+        mock_response_mynode(self.charm.unit_name, self.charm.opensearch.host)
+
+        node = self.charm.opensearch.current()
+        assert isinstance(node, Node)
+        assert node.app.name == "opensearch"
+        assert node.roles == ["cluster_manager", "coordinating_only", "data", "ingest", "ml"]
+        assert not node.temperature
+
+    def test_distro_current_api_unavail_fallback_to_static_conf(self):
+        """Current node attributes are to be determined from static config."""
+        node = self.charm.opensearch.current()
+        assert isinstance(node, Node)
+        assert node.app.name == "opensearch"
+        assert node.temperature == "hot"
+        assert sorted(node.roles) == sorted(
+            ["cluster_manager", "coordinating_only", "data", "ingest", "ml"]
+        )
+
+    # We pretend that the config file is empty
+    @patch("charms.opensearch.v0.helper_conf_setter.YamlConfigSetter.load", return_value={})
+    def test_distro_current_api_unavail_static_conf_unavail_fallback_to_deployment(self, _):
+        """Current node attributes are to be determined from Deployment State information.
+
+        Deployment State information is available from service startup on the Peer Relation Data.
+        """
+        node = self.charm.opensearch.current()
+        assert isinstance(node, Node)
+        assert node.app.name == "opensearch"
+        assert node.roles == ["deployment_role1", "deployment_role2"]
+        assert node.temperature == "warm"

--- a/tests/unit/resources/config/opensearch.yml
+++ b/tests/unit/resources/config/opensearch.yml
@@ -86,3 +86,13 @@
 # Require explicit names when deleting indices:
 #
 #action.destructive_requires_name: true
+#
+node.attr.app_id: opensearch
+node.attr.temp: hot
+node.roles: 
+- data
+- ingest
+- ml
+- coordinating_only
+- cluster_manager
+

--- a/tests/unit/resources/config/opensearch.yml
+++ b/tests/unit/resources/config/opensearch.yml
@@ -87,12 +87,11 @@
 #
 #action.destructive_requires_name: true
 #
-node.attr.app_id: opensearch
+node.attr.app_id: 617e5f02-5be5-4e25-85f0-276b2347a5ad/opensearch
 node.attr.temp: hot
 node.roles: 
 - data
 - ingest
 - ml
-- coordinating_only
 - cluster_manager
 


### PR DESCRIPTION
## Issue

https://github.com/canonical/opensearch-operator/issues/222

Context (as highlighted in the [issue comment](https://github.com/canonical/opensearch-operator/issues/222#issuecomment-2306491781)):

"When a unit is online, unit-specific service information is taken from the Opensearch API (`/_nodes`).

However if the unit is offline, we fall back to static configuration.
This is the part where we had the issue, in case `node.roles` was missing from the configuration."

## Solution

We shouldn't directly refer to a field that may be missing from the config.

NOTE: Since the `opensearch_distro` had no unittests, this PR is also adding a new unttest module dedicated to `opensearch_distro`. For the time being only the concerned `current()` method is being tested (both for happy and broken path -- the latter was the target of the fix.) The test module should be extended in the future for additional test coverage for the `opensearch_distro` module.

NOTE2: The PR is including a global fix for Opensearch Unit Tests, as a global mock was applied (in a hidden corner) imacting ALL tests.