### PR TITLE
increase waiting time for certificate expiry

### DIFF
--- a/tests/integration/tls/test_tls.py
+++ b/tests/integration/tls/test_tls.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 
 TLS_CERTIFICATES_APP_NAME = "self-signed-certificates"
 # wait time for secret expiry = 65 * 60
-SECRET_EXPIRY_WAIT_TIME = 3900
+SECRET_EXPIRY_WAIT_TIME = 4200
 
 
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])


### PR DESCRIPTION
## Issue
With https://github.com/canonical/opensearch-operator/pull/408 a new integration test was introduced, asserting that the workflow for certificate expiration (and renewal) is functional. The test includes waiting for about 1 hour for receiving a secret expiry from `juju` and for `certificate availabe` events from the self-signed-certificates operator. Obviously the waiting time is not long enough, as the logs and history of events processed in [this CI run](https://github.com/canonical/opensearch-operator/actions/runs/10558606898/job/29252649331) shows, where the certificates operator did not yet send `CertificateAvailableEvents` after the secrets for the current ones have expired.

## Solution
Increase the fixed waiting time to cover at least on processing of `update_status` on the certificates operator side.