### PR TITLE
extended timeout for large deployment

### DIFF
--- a/tests/integration/ha/test_large_deployments_relations.py
+++ b/tests/integration/ha/test_large_deployments_relations.py
@@ -135,6 +135,7 @@ async def test_invalid_conditions(ops_test: OpsTest) -> None:
             FAILOVER_APP: APP_UNITS[FAILOVER_APP],
         },
         idle_period=IDLE_PERIOD,
+        timeout=1800,
     )
 
     # integrate TLS to all applications
@@ -153,6 +154,7 @@ async def test_invalid_conditions(ops_test: OpsTest) -> None:
         units_statuses=["active"],
         wait_for_exact_units={app: units for app, units in APP_UNITS.items()},
         idle_period=IDLE_PERIOD,
+        timeout=1800,
     )
 
     c_writes = ContinuousWrites(ops_test, app=MAIN_APP)
@@ -179,6 +181,7 @@ async def test_invalid_conditions(ops_test: OpsTest) -> None:
         units_statuses=["active"],
         wait_for_exact_units={MAIN_APP: APP_UNITS[MAIN_APP], INVALID_APP: APP_UNITS[INVALID_APP]},
         idle_period=IDLE_PERIOD,
+        timeout=1800,
     )
 
     # delete the invalid app name
@@ -206,6 +209,7 @@ async def test_large_deployment_fully_formed(
             app: units for app, units in APP_UNITS.items() if app != INVALID_APP
         },
         idle_period=IDLE_PERIOD,
+        timeout=1800,
     )
 
     # fetch nodes, we should have 6 nodes (main + failover)-orchestrators


### PR DESCRIPTION
## Issue
The test_large_deployments_relations test has started failing for a few days now, we should investigate, if:
- ~~It is a regression in the code of the charm~~
- ~~if the test has a bug~~

## Solution
The problem seems to be that OpenSearch is taking longer to start and causes timeouts on the tests.