### PR TITLE
Update workflows to v21.0.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   lint:
     name: Lint
-    uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v16.7.0
+    uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v21.0.1
 
   unit-test:
     name: Unit test charm
@@ -61,7 +61,7 @@ jobs:
         path:
         - .
         - ./tests/integration/relations/opensearch_provider/application-charm/
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v16.7.0
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v21.0.1
     with:
       path-to-charm-directory: ${{ matrix.path }}
       cache: true
@@ -72,7 +72,7 @@ jobs:
       - lint
       - unit-test
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/integration_test_charm.yaml@v16.7.0
+    uses: canonical/data-platform-workflows/.github/workflows/integration_test_charm.yaml@v21.0.1
     with:
       artifact-prefix: packed-charm-cache-true
       cloud: lxd

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,13 +34,13 @@ jobs:
 
   build:
     name: Build charm
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v16.7.0
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v21.0.1
 
   release:
     name: Release charm
     needs:
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v16.7.0
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v21.0.1
     with:
       channel: 2/edge
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}

--- a/.github/workflows/sync_docs.yaml
+++ b/.github/workflows/sync_docs.yaml
@@ -5,15 +5,14 @@ name: Sync docs from Discourse
 on:
   workflow_dispatch:
   schedule:
-    - cron: 20 02 * * *
+    - cron: '53 0 * * *'    # Daily at 00:53 UTC
 
 jobs:
   sync-docs:
     name: Sync docs from Discourse
-    uses: canonical/data-platform-workflows/.github/workflows/_sync_docs.yaml@v16.7.0
-    secrets:
-      discourse-api-user: ${{ secrets.DISCOURSE_API_USERNAME }}
-      discourse-api-key: ${{ secrets.DISCOURSE_API_KEY }}
+    uses: canonical/data-platform-workflows/.github/workflows/sync_docs.yaml@v21.0.1
+    with:
+      reviewers: a-velasco
     permissions:
       contents: write  # Needed to push branch & tag
       pull-requests: write  # Needed to create PR

--- a/poetry.lock
+++ b/poetry.lock
@@ -31,8 +31,8 @@ pytest = "*"
 [package.source]
 type = "git"
 url = "https://github.com/canonical/data-platform-workflows"
-reference = "v16.7.0"
-resolved_reference = "9e3a54bc14e015cc1a5e793370f613daa0a71ff0"
+reference = "v21.0.1"
+resolved_reference = "06f252ea079edfd055cee236ede28c237467f9b0"
 subdirectory = "python/pytest_plugins/allure_pytest_collection_report"
 
 [[package]]

--- a/poetry.lock
+++ b/poetry.lock
@@ -1656,8 +1656,8 @@ develop = false
 [package.source]
 type = "git"
 url = "https://github.com/canonical/data-platform-workflows"
-reference = "v16.7.0"
-resolved_reference = "9e3a54bc14e015cc1a5e793370f613daa0a71ff0"
+reference = "v21.0.1"
+resolved_reference = "06f252ea079edfd055cee236ede28c237467f9b0"
 subdirectory = "python/pytest_plugins/github_secrets"
 
 [[package]]
@@ -1676,8 +1676,8 @@ pytest = "*"
 [package.source]
 type = "git"
 url = "https://github.com/canonical/data-platform-workflows"
-reference = "v16.7.0"
-resolved_reference = "9e3a54bc14e015cc1a5e793370f613daa0a71ff0"
+reference = "v21.0.1"
+resolved_reference = "06f252ea079edfd055cee236ede28c237467f9b0"
 subdirectory = "python/pytest_plugins/microceph"
 
 [[package]]
@@ -1714,8 +1714,8 @@ pyyaml = "*"
 [package.source]
 type = "git"
 url = "https://github.com/canonical/data-platform-workflows"
-reference = "v16.7.0"
-resolved_reference = "9e3a54bc14e015cc1a5e793370f613daa0a71ff0"
+reference = "v21.0.1"
+resolved_reference = "06f252ea079edfd055cee236ede28c237467f9b0"
 subdirectory = "python/pytest_plugins/pytest_operator_cache"
 
 [[package]]
@@ -1733,8 +1733,8 @@ pytest = "*"
 [package.source]
 type = "git"
 url = "https://github.com/canonical/data-platform-workflows"
-reference = "v16.7.0"
-resolved_reference = "9e3a54bc14e015cc1a5e793370f613daa0a71ff0"
+reference = "v21.0.1"
+resolved_reference = "06f252ea079edfd055cee236ede28c237467f9b0"
 subdirectory = "python/pytest_plugins/pytest_operator_groups"
 
 [[package]]
@@ -2405,4 +2405,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "f17da678b4320ccb1ad13513ad2a0a720e9db76aec95e185fd0a3f2f8e3f9b01"
+content-hash = "a91acac948a369830737ca22f4a2cde03134202e422b0848afaae1b52107422f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,12 +70,12 @@ responses = "^0.25.3"
 [tool.poetry.group.integration.dependencies]
 boto3 = "^1.34.135"
 pytest = "^8.2.2"
-pytest-github-secrets = {git = "https://github.com/canonical/data-platform-workflows", tag = "v16.7.0", subdirectory = "python/pytest_plugins/github_secrets"}
+pytest-github-secrets = {git = "https://github.com/canonical/data-platform-workflows", tag = "v21.0.1", subdirectory = "python/pytest_plugins/github_secrets"}
 pytest-asyncio = "^0.21.2"
 pytest-operator = "^0.35.0"
-pytest-operator-cache = {git = "https://github.com/canonical/data-platform-workflows", tag = "v16.7.0", subdirectory = "python/pytest_plugins/pytest_operator_cache"}
-pytest-operator-groups = {git = "https://github.com/canonical/data-platform-workflows", tag = "v16.7.0", subdirectory = "python/pytest_plugins/pytest_operator_groups"}
-pytest-microceph = {git = "https://github.com/canonical/data-platform-workflows", tag = "v16.7.0", subdirectory = "python/pytest_plugins/microceph"}
+pytest-operator-cache = {git = "https://github.com/canonical/data-platform-workflows", tag = "v21.0.1", subdirectory = "python/pytest_plugins/pytest_operator_cache"}
+pytest-operator-groups = {git = "https://github.com/canonical/data-platform-workflows", tag = "v21.0.1", subdirectory = "python/pytest_plugins/pytest_operator_groups"}
+pytest-microceph = {git = "https://github.com/canonical/data-platform-workflows", tag = "v21.0.1", subdirectory = "python/pytest_plugins/microceph"}
 # should not be updated unless https://github.com/juju/python-libjuju/issues/1093 is fixed
 juju = "~3.5.0"
 ops = "^2.15"
@@ -85,7 +85,7 @@ urllib3 = "^2.2.2"
 protobuf = "^5.27.2"
 opensearch-py = "^2.6.0"
 allure-pytest = "^2.13.5"
-allure-pytest-collection-report = {git = "https://github.com/canonical/data-platform-workflows", tag = "v16.7.0", subdirectory = "python/pytest_plugins/allure_pytest_collection_report"}
+allure-pytest-collection-report = {git = "https://github.com/canonical/data-platform-workflows", tag = "v21.0.1", subdirectory = "python/pytest_plugins/allure_pytest_collection_report"}
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
## Issue
Shared workflows (from data-platform-workflows) were outdated at `v16.7.0`. This prevented the repo from using newer shared workflows, like [`sync_docs.yaml`](https://github.com/canonical/data-platform-workflows/blob/main/.github/workflows/sync_docs.md). 

## Solution
* Updated existing workflow versions to `v21.0.1` (latest)
* Updated `sync_docs.yaml` to new version and new workflow parameters
* Updated `poetry.lock` version and commit hash

## Breaking changes of note
* [breaking: Change default charmcraft version to 2.x](https://github.com/canonical/data-platform-workflows/commit/da8bb57d6a9650fef8683cb76f233cd672f63db5)
* [breaking(`integration_test_charm.yaml`): Remove `jhack tail` logs](https://github.com/canonical/data-platform-workflows/commit/37129f44b9dacb57c67ed2ebbbc9fbfa3d218de5)
* [breaking(`integration_test_charm.yaml`): Only run juju 3.6 tests on `schedule`](https://github.com/canonical/data-platform-workflows/commit/c0eccd0a2229ce88cd09765d8260e22e12db0b13)

Full changelog between [`v16.7.0...v21.0.1`](https://github.com/canonical/data-platform-workflows/compare/v16.7.0...v21.0.1)
