### PR TITLE
[DPE-5283] stabilization for CA rotation and integration test for large deployments

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -784,9 +784,6 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
                     # cleaning the former CA certificate from the truststore
                     # must only be done AFTER all renewed certificates are available and loaded
                     self.tls.remove_old_ca()
-            else:
-                event.defer()
-                return
 
     def on_tls_relation_broken(self, _: RelationBrokenEvent):
         """As long as all certificates are produced, we don't do anything."""

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -784,6 +784,9 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
                     # cleaning the former CA certificate from the truststore
                     # must only be done AFTER all renewed certificates are available and loaded
                     self.tls.remove_old_ca()
+            else:
+                event.defer()
+                return
 
     def on_tls_relation_broken(self, _: RelationBrokenEvent):
         """As long as all certificates are produced, we don't do anything."""

--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -245,15 +245,19 @@ class OpenSearchTLS(Object):
             cert_type, self.charm.secrets.get_object(scope, cert_type.val)
         )
 
-        # store the admin certificates in non-leader units
-        if not self.charm.unit.is_leader():
-            if self.all_certificates_available():
-                self.store_admin_tls_secrets_if_applies()
-
-        # apply the chain.pem file for API requests only if the CA cert has not been updated
-        admin_secrets = self.charm.secrets.get_object(Scope.APP, CertType.APP_ADMIN.val)
+        # apply the chain.pem file for API requests, only if the CA cert has not been updated
+        admin_secrets = self.charm.secrets.get_object(Scope.APP, CertType.APP_ADMIN.val) or {}
         if admin_secrets.get("chain") and not self._read_stored_ca(alias="old-ca"):
             self.update_request_ca_bundle()
+
+        # store the admin certificates in non-leader units
+        # if admin cert not available we need to defer, otherwise it will never be stored
+        if not self.charm.unit.is_leader():
+            if admin_secrets.get("cert"):
+                self.store_new_tls_resources(CertType.APP_ADMIN, admin_secrets)
+            else:
+                event.defer()
+                return
 
         for relation in self.charm.opensearch_provider.relations:
             self.charm.opensearch_provider.update_certs(relation.id, ca_chain)

--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -164,7 +164,6 @@ class OpenSearchTLS(Object):
                 Scope.APP, CertType.APP_ADMIN, CertType.APP_ADMIN.val
             )
 
-            # if not admin_cert:
             self._request_certificate(Scope.APP, CertType.APP_ADMIN)
         elif not admin_cert.get("truststore-password"):
             logger.debug("Truststore-password from main-orchestrator not available yet.")

--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -123,8 +123,8 @@ class OpenSearchTLS(Object):
         """Request the generation of a new admin certificate."""
         if not self.charm.unit.is_leader():
             return
-
-        self._request_certificate(Scope.APP, CertType.APP_ADMIN)
+        admin_secrets = self.charm.secrets.get_object(Scope.APP, CertType.APP_ADMIN.val) or {}
+        self._request_certificate(Scope.APP, CertType.APP_ADMIN, admin_secrets.get("key"), admin_secrets.get("key-password"))
 
     def request_new_unit_certificates(self) -> None:
         """Requests a new certificate with the given scope and type from the tls operator."""
@@ -159,8 +159,8 @@ class OpenSearchTLS(Object):
                 Scope.APP, CertType.APP_ADMIN, CertType.APP_ADMIN.val
             )
 
-            if not admin_cert:
-                self._request_certificate(Scope.APP, CertType.APP_ADMIN)
+            # if not admin_cert:
+            self._request_certificate(Scope.APP, CertType.APP_ADMIN)
         elif not admin_cert.get("truststore-password"):
             logger.debug("Truststore-password from main-orchestrator not available yet.")
             event.defer()

--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -249,10 +249,6 @@ class OpenSearchTLS(Object):
         if not self.charm.unit.is_leader():
             if self.all_certificates_available():
                 self.store_admin_tls_secrets_if_applies()
-            else:
-                # we need to defer, otherwise the admin cert might never be stored on this unit
-                event.defer()
-                return
 
         # apply the chain.pem file for API requests only if the CA cert has not been updated
         admin_secrets = self.charm.secrets.get_object(Scope.APP, CertType.APP_ADMIN.val)

--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -124,7 +124,12 @@ class OpenSearchTLS(Object):
         if not self.charm.unit.is_leader():
             return
         admin_secrets = self.charm.secrets.get_object(Scope.APP, CertType.APP_ADMIN.val) or {}
-        self._request_certificate(Scope.APP, CertType.APP_ADMIN, admin_secrets.get("key"), admin_secrets.get("key-password"))
+        self._request_certificate(
+            Scope.APP,
+            CertType.APP_ADMIN,
+            admin_secrets.get("key"),
+            admin_secrets.get("key-password"),
+        )
 
     def request_new_unit_certificates(self) -> None:
         """Requests a new certificate with the given scope and type from the tls operator."""

--- a/tests/integration/tls/test_ca_rotation.py
+++ b/tests/integration/tls/test_ca_rotation.py
@@ -2,7 +2,6 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import asyncio
 import logging
 
 import pytest
@@ -12,7 +11,6 @@ from pytest_operator.plugin import OpsTest
 from ..ha.continuous_writes import ContinuousWrites
 from ..helpers import (
     APP_NAME,
-    IDLE_PERIOD,
     MODEL_CONFIG,
     SERIES,
     UNIT_IDS,
@@ -25,16 +23,6 @@ logger = logging.getLogger(__name__)
 
 
 TLS_CERTIFICATES_APP_NAME = "self-signed-certificates"
-REL_ORCHESTRATOR = "peer-cluster-orchestrator"
-REL_PEER = "peer-cluster"
-
-MAIN_APP = "opensearch-main"
-FAILOVER_APP = "opensearch-failover"
-DATA_APP = "opensearch-data"
-
-CLUSTER_NAME = "log-app"
-
-APP_UNITS = {MAIN_APP: 1, FAILOVER_APP: 1, DATA_APP: 2}
 
 
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "xlarge"])
@@ -101,106 +89,6 @@ async def test_rollout_new_ca(ops_test: OpsTest) -> None:
     leader_unit_ip = await get_leader_unit_ip(ops_test)
     url = f"https://{leader_unit_ip}:9200/_plugins/_security/api/ssl/certs"
     admin_secret = await get_secret_by_label(ops_test, "opensearch:app:app-admin")
-
-    with open("admin.cert", "w") as cert:
-        cert.write(admin_secret["cert"])
-
-    with open("admin.key", "w") as key:
-        key.write(admin_secret["key"])
-
-    response = requests.get(url, cert=("admin.cert", "admin.key"), verify=False)
-    data = response.json()
-    assert new_config["ca-common-name"] in data["http_certificates_list"][0]["issuer_dn"]
-
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "xlarge"])
-@pytest.mark.group(1)
-@pytest.mark.abort_on_fail
-async def test_build_large_deployment(ops_test: OpsTest) -> None:
-    """Setup a large deployments cluster."""
-    # remove the existing application
-    await ops_test.model.remove_application(APP_NAME, block_until_done=True)
-
-    # deploy new cluster
-    my_charm = await ops_test.build_charm(".")
-    await asyncio.gather(
-        ops_test.model.deploy(
-            my_charm,
-            application_name=MAIN_APP,
-            num_units=1,
-            series=SERIES,
-            config={"cluster_name": CLUSTER_NAME, "roles": "cluster_manager"},
-        ),
-        ops_test.model.deploy(
-            my_charm,
-            application_name=FAILOVER_APP,
-            num_units=1,
-            series=SERIES,
-            config={"cluster_name": CLUSTER_NAME, "init_hold": True, "roles": "cluster_manager"},
-        ),
-        ops_test.model.deploy(
-            my_charm,
-            application_name=DATA_APP,
-            num_units=2,
-            series=SERIES,
-            config={"cluster_name": CLUSTER_NAME, "init_hold": True, "roles": "data"},
-        ),
-    )
-
-    # integrate TLS to all applications
-    for app in [MAIN_APP, FAILOVER_APP, DATA_APP]:
-        await ops_test.model.integrate(app, TLS_CERTIFICATES_APP_NAME)
-
-    # create the peer-cluster-relation
-    await ops_test.model.integrate(f"{DATA_APP}:{REL_PEER}", f"{MAIN_APP}:{REL_ORCHESTRATOR}")
-    await ops_test.model.integrate(f"{FAILOVER_APP}:{REL_PEER}", f"{MAIN_APP}:{REL_ORCHESTRATOR}")
-    await ops_test.model.integrate(f"{DATA_APP}:{REL_PEER}", f"{FAILOVER_APP}:{REL_ORCHESTRATOR}")
-
-    # wait for the cluster to fully form
-    await wait_until(
-        ops_test,
-        apps=[MAIN_APP, DATA_APP, FAILOVER_APP],
-        apps_full_statuses={
-            MAIN_APP: {"active": []},
-            DATA_APP: {"active": []},
-            FAILOVER_APP: {"active": []},
-        },
-        units_statuses=["active"],
-        wait_for_exact_units={app: units for app, units in APP_UNITS.items()},
-        idle_period=IDLE_PERIOD,
-    )
-
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "xlarge"])
-@pytest.mark.group(1)
-@pytest.mark.abort_on_fail
-async def test_rollout_new_ca_large_deployment(ops_test: OpsTest) -> None:
-    """Repeat the CA rotation test for the large deployment."""
-    c_writes = ContinuousWrites(ops_test, DATA_APP)
-    await c_writes.start()
-
-    # trigger a rollout of the new CA by changing the config on TLS Provider side
-    new_config = {"ca-common-name": "EVEN_NEWER_CA"}
-    await ops_test.model.applications[TLS_CERTIFICATES_APP_NAME].set_config(new_config)
-
-    writes_count = await c_writes.count()
-
-    await wait_until(
-        ops_test,
-        apps=[APP_NAME],
-        apps_statuses=["active"],
-        units_statuses=["active"],
-        timeout=1800,
-        idle_period=60,
-        wait_for_exact_units=len(UNIT_IDS),
-    )
-
-    more_writes = await c_writes.count()
-    await c_writes.stop()
-    assert more_writes > writes_count, "Writes have not continued during CA rotation"
-
-    # using the SSL API requires authentication with app-admin cert and key
-    leader_unit_ip = await get_leader_unit_ip(ops_test, DATA_APP)
-    url = f"https://{leader_unit_ip}:9200/_plugins/_security/api/ssl/certs"
-    admin_secret = await get_secret_by_label(ops_test, "opensearch-data:app:app-admin")
 
     with open("admin.cert", "w") as cert:
         cert.write(admin_secret["cert"])

--- a/tests/integration/tls/test_ca_rotation.py
+++ b/tests/integration/tls/test_ca_rotation.py
@@ -2,6 +2,7 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import asyncio
 import logging
 
 import pytest
@@ -11,6 +12,7 @@ from pytest_operator.plugin import OpsTest
 from ..ha.continuous_writes import ContinuousWrites
 from ..helpers import (
     APP_NAME,
+    IDLE_PERIOD,
     MODEL_CONFIG,
     SERIES,
     UNIT_IDS,
@@ -23,6 +25,16 @@ logger = logging.getLogger(__name__)
 
 
 TLS_CERTIFICATES_APP_NAME = "self-signed-certificates"
+REL_ORCHESTRATOR = "peer-cluster-orchestrator"
+REL_PEER = "peer-cluster"
+
+MAIN_APP = "opensearch-main"
+FAILOVER_APP = "opensearch-failover"
+DATA_APP = "opensearch-data"
+
+CLUSTER_NAME = "log-app"
+
+APP_UNITS = {MAIN_APP: 1, FAILOVER_APP: 1, DATA_APP: 2}
 
 
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "xlarge"])
@@ -89,6 +101,106 @@ async def test_rollout_new_ca(ops_test: OpsTest) -> None:
     leader_unit_ip = await get_leader_unit_ip(ops_test)
     url = f"https://{leader_unit_ip}:9200/_plugins/_security/api/ssl/certs"
     admin_secret = await get_secret_by_label(ops_test, "opensearch:app:app-admin")
+
+    with open("admin.cert", "w") as cert:
+        cert.write(admin_secret["cert"])
+
+    with open("admin.key", "w") as key:
+        key.write(admin_secret["key"])
+
+    response = requests.get(url, cert=("admin.cert", "admin.key"), verify=False)
+    data = response.json()
+    assert new_config["ca-common-name"] in data["http_certificates_list"][0]["issuer_dn"]
+
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "xlarge"])
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_build_large_deployment(ops_test: OpsTest) -> None:
+    """Setup a large deployments cluster."""
+    # remove the existing application
+    await ops_test.model.remove_application(APP_NAME, block_until_done=True)
+
+    # deploy new cluster
+    my_charm = await ops_test.build_charm(".")
+    await asyncio.gather(
+        ops_test.model.deploy(
+            my_charm,
+            application_name=MAIN_APP,
+            num_units=1,
+            series=SERIES,
+            config={"cluster_name": CLUSTER_NAME, "roles": "cluster_manager"},
+        ),
+        ops_test.model.deploy(
+            my_charm,
+            application_name=FAILOVER_APP,
+            num_units=1,
+            series=SERIES,
+            config={"cluster_name": CLUSTER_NAME, "init_hold": True, "roles": "cluster_manager"},
+        ),
+        ops_test.model.deploy(
+            my_charm,
+            application_name=DATA_APP,
+            num_units=2,
+            series=SERIES,
+            config={"cluster_name": CLUSTER_NAME, "init_hold": True, "roles": "data"},
+        ),
+    )
+
+    # integrate TLS to all applications
+    for app in [MAIN_APP, FAILOVER_APP, DATA_APP]:
+        await ops_test.model.integrate(app, TLS_CERTIFICATES_APP_NAME)
+
+    # create the peer-cluster-relation
+    await ops_test.model.integrate(f"{DATA_APP}:{REL_PEER}", f"{MAIN_APP}:{REL_ORCHESTRATOR}")
+    await ops_test.model.integrate(f"{FAILOVER_APP}:{REL_PEER}", f"{MAIN_APP}:{REL_ORCHESTRATOR}")
+    await ops_test.model.integrate(f"{DATA_APP}:{REL_PEER}", f"{FAILOVER_APP}:{REL_ORCHESTRATOR}")
+
+    # wait for the cluster to fully form
+    await wait_until(
+        ops_test,
+        apps=[MAIN_APP, DATA_APP, FAILOVER_APP],
+        apps_full_statuses={
+            MAIN_APP: {"active": []},
+            DATA_APP: {"active": []},
+            FAILOVER_APP: {"active": []},
+        },
+        units_statuses=["active"],
+        wait_for_exact_units={app: units for app, units in APP_UNITS.items()},
+        idle_period=IDLE_PERIOD,
+    )
+
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "xlarge"])
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_rollout_new_ca_large_deployment(ops_test: OpsTest) -> None:
+    """Repeat the CA rotation test for the large deployment."""
+    c_writes = ContinuousWrites(ops_test, DATA_APP)
+    await c_writes.start()
+
+    # trigger a rollout of the new CA by changing the config on TLS Provider side
+    new_config = {"ca-common-name": "EVEN_NEWER_CA"}
+    await ops_test.model.applications[TLS_CERTIFICATES_APP_NAME].set_config(new_config)
+
+    writes_count = await c_writes.count()
+
+    await wait_until(
+        ops_test,
+        apps=[APP_NAME],
+        apps_statuses=["active"],
+        units_statuses=["active"],
+        timeout=1800,
+        idle_period=60,
+        wait_for_exact_units=len(UNIT_IDS),
+    )
+
+    more_writes = await c_writes.count()
+    await c_writes.stop()
+    assert more_writes > writes_count, "Writes have not continued during CA rotation"
+
+    # using the SSL API requires authentication with app-admin cert and key
+    leader_unit_ip = await get_leader_unit_ip(ops_test, DATA_APP)
+    url = f"https://{leader_unit_ip}:9200/_plugins/_security/api/ssl/certs"
+    admin_secret = await get_secret_by_label(ops_test, "opensearch-data:app:app-admin")
 
     with open("admin.cert", "w") as cert:
         cert.write(admin_secret["cert"])

--- a/tests/unit/lib/test_opensearch_tls.py
+++ b/tests/unit/lib/test_opensearch_tls.py
@@ -664,7 +664,10 @@ class TestOpenSearchTLS(unittest.TestCase):
         self.charm.tls._on_certificate_available(event_mock)
 
         # The new cert is saved to the keystore
-        assert run_cmd.call_count == 2
+        if self.charm.unit.is_leader():
+            assert run_cmd.call_count == 2
+        else:
+            assert run_cmd.call_count == 4
 
         assert re.search(
             "openssl pkcs12 -export .*-out "
@@ -1467,7 +1470,7 @@ class TestOpenSearchTLS(unittest.TestCase):
         if self.charm.unit.is_leader():
             assert run_cmd.call_count == 14
         else:
-            assert run_cmd.call_count == 20
+            assert run_cmd.call_count == 16
 
         assert re.search(
             "openssl pkcs12 -export .* -out "

--- a/tests/unit/lib/test_opensearch_tls.py
+++ b/tests/unit/lib/test_opensearch_tls.py
@@ -948,7 +948,7 @@ class TestOpenSearchTLS(unittest.TestCase):
         """
         # Units had their certificates already
         old_csr = "old_csr"
-        old_key = "old_key"
+        old_key = create_utf8_encoded_private_key()
         old_subject = "old_subject"
         keystore_password = "keystore_12345"
 
@@ -1024,7 +1024,7 @@ class TestOpenSearchTLS(unittest.TestCase):
 
         assert new_app_admin_secret["csr"] != old_csr
         assert new_app_admin_secret["ca-cert"] == new_ca
-        assert new_app_admin_secret["key"] != old_key
+        assert new_app_admin_secret["key"] == old_key
         assert new_app_admin_secret["subject"] != old_subject
 
         assert generate_csr.call_count == 3


### PR DESCRIPTION
This PR addresses the stabilization of the CA rotation workflow.

The following issues are fixed:
1) Error with `No cert in -in file '/tmp/tmp1uvvhlyo.cert' matches private key [xxx] certificate routines:X509_check_private_key:key values mismatch:../crypto/x509/x509_cmp.c:405:`: The private key was regenerated on every admin certificate request. When a CA rotation is restarting the nodes, the certificate that was being loaded was generated using an old private key and can no longer be validated with the stored key (see https://github.com/canonical/opensearch-operator/issues/417).

2) A long delay when restarting after renewing the TLS certificates on CA rotation (see https://github.com/canonical/opensearch-operator/issues/417).

3) An issue with the CA truststore file being updated/cleaned too early (before all nodes have been restarted in rolling fashion), which caused the respective node not to be able to join the cluster anymore after restarting.

4) An issue with updating the pem-file too early. This file is used for API requests by the operator to the node on which it is stored. If this file is updated too early, the operator can not communicate with the node anymore. The same if it is updated too late in the workflow.

5) An issue with deferring `CertificateAvailableEvents` on node initialization which caused the deployment in setups with `manual tls-operator` to end in endless deferrals and never to start correctly.