### PR TITLE
Exclude subsequent CM clusters from bootstrap

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -1343,7 +1343,10 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             cm_names.append(self.unit_name)
             cm_ips.append(self.unit_ip)
 
-            if self.opensearch_peer_cm.deployment_desc().typ == DeploymentType.MAIN_ORCHESTRATOR:
+            if (
+                self.opensearch_peer_cm.deployment_desc().typ == DeploymentType.MAIN_ORCHESTRATOR
+                and not self.peers_data.get(Scope.APP, "bootstrapped", False)
+            ):
                 cms_in_bootstrap = self.peers_data.get(
                     Scope.APP, "bootstrap_contributors_count", 0
                 )
@@ -1372,6 +1375,8 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
 
     def _cleanup_bootstrap_conf_if_applies(self) -> None:
         """Remove some conf props in the CM nodes that contributed to the cluster bootstrapping."""
+        if self.unit.is_leader():
+            self.peers_data.put(Scope.APP, "bootstrapped", True)
         self.peers_data.delete(Scope.UNIT, "bootstrap_contributor")
         self.opensearch_config.cleanup_bootstrap_conf()
 

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -1343,17 +1343,20 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             cm_names.append(self.unit_name)
             cm_ips.append(self.unit_ip)
 
-            cms_in_bootstrap = self.peers_data.get(Scope.APP, "bootstrap_contributors_count", 0)
-            if cms_in_bootstrap < self.app.planned_units():
-                contribute_to_bootstrap = True
+            if self.opensearch_peer_cm.deployment_desc().typ == DeploymentType.MAIN_ORCHESTRATOR:
+                cms_in_bootstrap = self.peers_data.get(
+                    Scope.APP, "bootstrap_contributors_count", 0
+                )
+                if cms_in_bootstrap < self.app.planned_units():
+                    contribute_to_bootstrap = True
 
-                if self.unit.is_leader():
-                    self.peers_data.put(
-                        Scope.APP, "bootstrap_contributors_count", cms_in_bootstrap + 1
-                    )
+                    if self.unit.is_leader():
+                        self.peers_data.put(
+                            Scope.APP, "bootstrap_contributors_count", cms_in_bootstrap + 1
+                        )
 
-                # indicates that this unit is part of the "initial cm nodes"
-                self.peers_data.put(Scope.UNIT, "bootstrap_contributor", True)
+                    # indicates that this unit is part of the "initial cm nodes"
+                    self.peers_data.put(Scope.UNIT, "bootstrap_contributor", True)
 
         deployment_desc = self.opensearch_peer_cm.deployment_desc()
         self.opensearch_config.set_node(

--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -562,6 +562,9 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
         # register main and failover cm app names if any
         self.charm.peers_data.put_object(Scope.APP, "orchestrators", orchestrators.to_dict())
 
+        # let the charm know this is an already bootstrapped cluster
+        self.charm.peers_data.put(Scope.APP, "bootstrapped", True)
+
         # store the security related settings in secrets, peer_data, disk
         self._set_security_conf(data)
 


### PR DESCRIPTION
## Issue
We used to include nodes in the bootstrapping process only based on the `cluster_manager` role. 
We should instead only do it on the `MAIN_ORCHESTRATOR` and flag for every subsequent non-MAIN-ORCHESTRATOR that the cluster is already bootstrapped and that there is no need to attempt that again. 