### PR TITLE
[DPE-5483] Shuffle URLs we try to connect to

### DIFF
--- a/lib/charms/opensearch/v0/helper_http.py
+++ b/lib/charms/opensearch/v0/helper_http.py
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 
 """File containing http related helpers."""
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from tenacity import RetryCallState
 
@@ -18,11 +18,12 @@ LIBPATCH = 1
 
 
 def error_http_retry_log(
-    logger, retry_max: int, method: str, url: str, payload: Optional[Dict[str, Any]]
+    logger, retry_max: int, method: str, urls: List[str], payload: Optional[Dict[str, Any]]
 ):
     """Return a custom log function to run before a new Tenacity retry."""
 
     def log_error(retry_state: RetryCallState):
+        url = urls[(retry_state.attempt_number - 1) % len(urls)]
         logger.error(
             f"Request {method} to {url} with payload: {payload} failed."
             f"(Attempts left: {retry_max - retry_state.attempt_number})\n"

--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import pathlib
+import random
 import socket
 import subprocess
 import time
@@ -310,6 +311,7 @@ class OpenSearchDistribution(ABC):
 
         resp = None
         try:
+            random.shuffle(urls)
             resp = call(urls[0])
             if resp_status_code:
                 return resp.status_code

--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -25,7 +25,6 @@ from charms.opensearch.v0.helper_charm import (
 )
 from charms.opensearch.v0.helper_cluster import Node
 from charms.opensearch.v0.helper_conf_setter import YamlConfigSetter
-from charms.opensearch.v0.helper_http import error_http_retry_log
 from charms.opensearch.v0.helper_networking import get_host_ip, is_reachable
 from charms.opensearch.v0.models import App, StartMode
 from charms.opensearch.v0.opensearch_exceptions import (
@@ -255,7 +254,6 @@ class OpenSearchDistribution(ABC):
                 | retry_if_exception_type(urllib3.exceptions.HTTPError),
                 stop=stop_after_attempt(retries),
                 wait=wait_fixed(1),
-                before_sleep=error_http_retry_log(logger, retries, method, url, payload),
                 reraise=True,
             ):
                 with attempt, requests.Session() as s:

--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -248,7 +248,7 @@ class OpenSearchDistribution(ABC):
             OpenSearchHttpError if hosts are unreachable
         """
 
-        def call(url: str) -> requests.Response:
+        def call(urls: List[str]) -> requests.Response:
             """Performs an HTTP request."""
             for attempt in Retrying(
                 retry=retry_if_exception_type(requests.RequestException)
@@ -259,6 +259,8 @@ class OpenSearchDistribution(ABC):
                 reraise=True,
             ):
                 with attempt, requests.Session() as s:
+                    random.shuffle(urls)
+                    url = urls[0]
                     admin_field = self._charm.secrets.password_key("admin")
                     if cert_files:
                         s.cert = cert_files
@@ -311,8 +313,7 @@ class OpenSearchDistribution(ABC):
 
         resp = None
         try:
-            random.shuffle(urls)
-            resp = call(urls[0])
+            resp = call(urls)
             if resp_status_code:
                 return resp.status_code
 


### PR DESCRIPTION
Currently, the "retrial" mechanism of the `request()` method always target the very same unit, even if we specified more than one option. 

This PR applies the retrial to the different targets of the list.