### PR TITLE
[DPE-5483] Update logging on `requests()`code path

### DIFF
--- a/lib/charms/opensearch/v0/helper_http.py
+++ b/lib/charms/opensearch/v0/helper_http.py
@@ -23,7 +23,7 @@ def error_http_retry_log(
     """Return a custom log function to run before a new Tenacity retry."""
 
     def log_error(retry_state: RetryCallState):
-        logger.error(
+        logger.debug(
             f"Request {method} to {url} with payload: {payload} failed."
             f"(Attempts left: {retry_max - retry_state.attempt_number})\n"
             f"\tError: {retry_state.outcome.exception()}"

--- a/lib/charms/opensearch/v0/helper_networking.py
+++ b/lib/charms/opensearch/v0/helper_networking.py
@@ -92,7 +92,7 @@ def is_reachable(host: str, port: int) -> bool:
         s.connect((host, port))
         return True
     except Exception as e:
-        logger.error(e)
+        logger.debug(f"Connection to {host}:{port} fails with: {e}")
         return False
     finally:
         s.close()


### PR DESCRIPTION
Currently, each call to `OpenSearchDistribution.requests()` or `OpenSearchCharm.alt_hosts` may generate a number of `ERROR` entries in the charm log. However, these are checks or attempts executed within the each of the routines and not necessarily represent an error of the whole process.

This PR reduces their log to `DEBUG` level instead.