### PR TITLE
[DPE-5468][test_charm.py] ensure deployment_desc available at post start

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -895,6 +895,17 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
                 event.defer()
                 return
 
+        if not self.opensearch_peer_cm.deployment_desc():
+            # canonical/opensearch-operator#444
+            # https://bugs.launchpad.net/juju/+bug/2076599
+            # This condition is a corner case where we have:
+            #   1) a single-node cluster
+            #   2) an unfinished (re)start: yet to run _post_start_init() method
+            #   3) LP#2076599: remove-application was called in-between and peer databag is empty
+            # TODO: remove this IF condition once LP#2076599 is fixed in Juju.
+            event.defer()
+            return
+
         if not self._can_service_start():
             self.node_lock.release()
             event.defer()

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -867,10 +867,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
 
     def _start_opensearch(self, event: _StartOpenSearch) -> None:  # noqa: C901
         """Start OpenSearch, with a generated or passed conf, if all resources configured."""
-        if (
-            not self.opensearch_peer_cm.deployment_desc()
-            and self._charm.app.planned_units() == 0
-        ):
+        if not self.opensearch_peer_cm.deployment_desc() and self._charm.app.planned_units() == 0:
             # canonical/opensearch-operator#444
             # https://bugs.launchpad.net/juju/+bug/2076599
             # This condition is a corner case where we have:

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -867,6 +867,17 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
 
     def _start_opensearch(self, event: _StartOpenSearch) -> None:  # noqa: C901
         """Start OpenSearch, with a generated or passed conf, if all resources configured."""
+        if not self.opensearch_peer_cm.deployment_desc():
+            # canonical/opensearch-operator#444
+            # https://bugs.launchpad.net/juju/+bug/2076599
+            # This condition is a corner case where we have:
+            #   1) a single-node cluster
+            #   2) an unfinished (re)start: yet to run _post_start_init() method
+            #   3) LP#2076599: remove-application was called in-between and peer databag is empty
+            # TODO: remove this IF condition once LP#2076599 is fixed in Juju.
+            event.defer()
+            return
+
         if self.opensearch.is_started():
             try:
                 self._post_start_init(event)
@@ -894,17 +905,6 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
                 logger.debug("Lock to start opensearch not acquired. Will retry next event")
                 event.defer()
                 return
-
-        if not self.opensearch_peer_cm.deployment_desc():
-            # canonical/opensearch-operator#444
-            # https://bugs.launchpad.net/juju/+bug/2076599
-            # This condition is a corner case where we have:
-            #   1) a single-node cluster
-            #   2) an unfinished (re)start: yet to run _post_start_init() method
-            #   3) LP#2076599: remove-application was called in-between and peer databag is empty
-            # TODO: remove this IF condition once LP#2076599 is fixed in Juju.
-            event.defer()
-            return
 
         if not self._can_service_start():
             self.node_lock.release()

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -1337,7 +1337,6 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
 
     def _get_nodes(self, use_localhost: bool) -> List[Node]:
         """Fetch the list of nodes of the cluster, depending on the requester."""
-
         if self.app.planned_units() == 0 and not self.opensearch_peer_cm.deployment_desc():
             # This app is going away and the -broken event already happened
             return []

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -867,7 +867,10 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
 
     def _start_opensearch(self, event: _StartOpenSearch) -> None:  # noqa: C901
         """Start OpenSearch, with a generated or passed conf, if all resources configured."""
-        if not self.opensearch_peer_cm.deployment_desc():
+        if (
+             not self.opensearch_peer_cm.deployment_desc()
+             and self._charm.app.planned_units() == 0
+        ):
             # canonical/opensearch-operator#444
             # https://bugs.launchpad.net/juju/+bug/2076599
             # This condition is a corner case where we have:
@@ -875,7 +878,6 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             #   2) an unfinished (re)start: yet to run _post_start_init() method
             #   3) LP#2076599: remove-application was called in-between and peer databag is empty
             # TODO: remove this IF condition once LP#2076599 is fixed in Juju.
-            event.defer()
             return
 
         if self.opensearch.is_started():

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -1337,6 +1337,11 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
 
     def _get_nodes(self, use_localhost: bool) -> List[Node]:
         """Fetch the list of nodes of the cluster, depending on the requester."""
+
+        if self.app.planned_units() == 0 and not self.opensearch_peer_cm.deployment_desc():
+            # This app is going away and the -broken event already happened
+            return []
+
         # This means it's the first unit on the cluster.
         if self.opensearch_peer_cm.deployment_desc().start == StartMode.WITH_PROVIDED_ROLES:
             computed_roles = self.opensearch_peer_cm.deployment_desc().config.roles

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -868,8 +868,8 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
     def _start_opensearch(self, event: _StartOpenSearch) -> None:  # noqa: C901
         """Start OpenSearch, with a generated or passed conf, if all resources configured."""
         if (
-             not self.opensearch_peer_cm.deployment_desc()
-             and self._charm.app.planned_units() == 0
+            not self.opensearch_peer_cm.deployment_desc()
+            and self._charm.app.planned_units() == 0
         ):
             # canonical/opensearch-operator#444
             # https://bugs.launchpad.net/juju/+bug/2076599

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -867,7 +867,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
 
     def _start_opensearch(self, event: _StartOpenSearch) -> None:  # noqa: C901
         """Start OpenSearch, with a generated or passed conf, if all resources configured."""
-        if not self.opensearch_peer_cm.deployment_desc() and self._charm.app.planned_units() == 0:
+        if not self.opensearch_peer_cm.deployment_desc() and self.app.planned_units() == 0:
             # canonical/opensearch-operator#444
             # https://bugs.launchpad.net/juju/+bug/2076599
             # This condition is a corner case where we have:


### PR DESCRIPTION
Due to [LP#2076599](https://bugs.launchpad.net/juju/+bug/2076599)

The  relation databags may be empty if we are running a single unit cluster and we hit "remove-application".

In this case, if we had a post start running, then this method will fail as it tries to check for the deployment description.

Closes #444
