### PR TITLE
[DPE-5536][test_upgrades.py] CI - Gracefully fail refresh cmd error

### DIFF
--- a/tests/integration/upgrades/helpers.py
+++ b/tests/integration/upgrades/helpers.py
@@ -5,9 +5,9 @@
 import logging
 import subprocess
 from typing import Optional
-from tenacity import Retrying, stop_after_attempt, wait_fixed
 
 from pytest_operator.plugin import OpsTest
+from tenacity import Retrying, stop_after_attempt, wait_fixed
 
 from ..ha.continuous_writes import ContinuousWrites
 from ..ha.helpers import (

--- a/tests/integration/upgrades/helpers.py
+++ b/tests/integration/upgrades/helpers.py
@@ -3,6 +3,8 @@
 # See LICENSE file for licensing details.
 
 import logging
+import subprocess
+from typing import Optional
 
 from pytest_operator.plugin import OpsTest
 
@@ -21,6 +23,41 @@ RESTART_DELAY = 360
 
 
 logger = logging.getLogger(__name__)
+
+
+async def refresh(
+    ops_test: OpsTest,
+    app_name: str,
+    *,
+    revision: Optional[int] = None,
+    switch: Optional[str] = None,
+    channel: Optional[str] = None,
+    path: Optional[str] = None,
+) -> None:
+    # due to: https://github.com/juju/python-libjuju/issues/1057
+    # the following call does not work:
+    # application = ops_test.model.applications[APP_NAME]
+    # await application.refresh(
+    #     revision=rev,
+    # )
+
+    # Point to the right model, as we are calling the juju cli directly
+    args = [f"--model={ops_test.model.info.name}"]
+    if revision:
+        args.append(f"--revision={revision}")
+    if switch:
+        args.append(f"--switch={switch}")
+    if channel:
+        args.append(f"--channel={channel}")
+    if path:
+        args.append(f"--path={path}")
+
+    for attempt in Retrying(stop=stop_after_attempt(6), wait=wait_fixed(wait=30)):
+        with attempt:
+            cmd = ["juju", "refresh"]
+            cmd.extend(args)
+            cmd.append(app_name)
+            subprocess.check_output(cmd)
 
 
 async def assert_upgrade_to_local(

--- a/tests/integration/upgrades/helpers.py
+++ b/tests/integration/upgrades/helpers.py
@@ -5,6 +5,7 @@
 import logging
 import subprocess
 from typing import Optional
+from tenacity import Retrying, stop_after_attempt, wait_fixed
 
 from pytest_operator.plugin import OpsTest
 

--- a/tests/integration/upgrades/test_small_deployment_upgrades.py
+++ b/tests/integration/upgrades/test_small_deployment_upgrades.py
@@ -172,7 +172,7 @@ async def test_upgrade_between_versions(
 
         async with ops_test.fast_forward():
             logger.info("Refresh the charm")
-            await _refresh(ops_test, revision=rev)
+            await _refresh(ops_test, app, revision=rev)
 
             await wait_until(
                 ops_test,
@@ -268,7 +268,7 @@ async def test_upgrade_rollback_from_local(
 
     async with ops_test.fast_forward():
         logger.info("Refresh the charm")
-        await _refresh(ops_test, path=charm)
+        await _refresh(ops_test, app, path=charm)
 
         await wait_until(
             ops_test,
@@ -285,6 +285,7 @@ async def test_upgrade_rollback_from_local(
         logger.info(f"Rolling back to {version}")
         await _refresh(
             ops_test,
+            app,
             switch=OPENSEARCH_ORIGINAL_CHARM_NAME,
             channel=OPENSEARCH_CHANNEL,
         )
@@ -304,6 +305,7 @@ async def test_upgrade_rollback_from_local(
         )
         await _refresh(
             ops_test,
+            app,
             revision=VERSION_TO_REVISION[version],
         )
 

--- a/tests/integration/upgrades/test_small_deployment_upgrades.py
+++ b/tests/integration/upgrades/test_small_deployment_upgrades.py
@@ -6,7 +6,6 @@ import logging
 
 import pytest
 from pytest_operator.plugin import OpsTest
-from tenacity import Retrying, stop_after_attempt, wait_fixed
 
 from ..ha.continuous_writes import ContinuousWrites
 from ..ha.helpers import app_name

--- a/tests/integration/upgrades/test_small_deployment_upgrades.py
+++ b/tests/integration/upgrades/test_small_deployment_upgrades.py
@@ -64,7 +64,8 @@ charm = None
 #
 #######################################################################
 async def _refresh(
-    ops_test: OpsTest, *,
+    ops_test: OpsTest,
+    *,
     revision: Optional[int] = None,
     switch: Optional[str] = None,
     channel: Optional[str] = None,

--- a/tests/integration/upgrades/test_small_deployment_upgrades.py
+++ b/tests/integration/upgrades/test_small_deployment_upgrades.py
@@ -65,6 +65,7 @@ charm = None
 #######################################################################
 async def _refresh(
     ops_test: OpsTest,
+    app_name: str,
     *,
     revision: Optional[int] = None,
     switch: Optional[str] = None,
@@ -93,6 +94,7 @@ async def _refresh(
         with attempt:
             cmd = ["juju", "refresh"]
             cmd.extend(args)
+            cmd.append(app_name)
             subprocess.check_output(cmd)
 
 


### PR DESCRIPTION
Currently, our CI is failing intermittently whenever we call `juju refresh`, [as the controller is still busy downloading the charm](https://github.com/juju/juju/blob/4584c53183a1b128ce0ffbe5f4e3c4b6235290bc/cmd/juju/application/refresh.go#L371)

To avoid failing due to this intermittent error, we add a retry loop at refresh call.

Closes #454
