### PR TITLE
[DPE-5615] - Manage chain file for requests like that of a CA

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -118,7 +118,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 2
 
 
 SERVICE_MANAGER = "service"
@@ -645,7 +645,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         # If the unit reloads its certs but the other units are not ready yet
         # we need to wait for them all to be ready before deleting the old CA
         if (
-            self.tls._read_stored_ca("old-ca")
+            self.tls.read_stored_ca("old-ca")
             and self.tls.ca_and_certs_rotation_complete_in_cluster()
         ):
             logger.debug("update_status: Detected CA rotation complete in cluster")
@@ -831,7 +831,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
                     # if all certs are stored and CA rotation is complete in the cluster
                     # we delete the old ca and update the chain to only include the new one
                     if (
-                        self.tls._read_stored_ca("old-ca")
+                        self.tls.read_stored_ca("old-ca")
                         and self.tls.ca_and_certs_rotation_complete_in_cluster()
                     ):
                         logger.info("on_tls_conf_set: Detected CA rotation complete in cluster")
@@ -1181,7 +1181,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         # We remove the old CA and update the chain to only include the new one
         # if all certs are stored and CA rotation is complete in the cluster
         if (
-            self.tls._read_stored_ca("old-ca")
+            self.tls.read_stored_ca("old-ca")
             and self.tls.ca_and_certs_rotation_complete_in_cluster()
         ):
             logger.info("post_start_init: Detected CA rotation complete in cluster")

--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -888,7 +888,7 @@ class OpenSearchTLS(Object):
                 Scope.UNIT,
                 "tls_ca_renewed",
             )
-            or self.charm.peers_data.get(Scope.UNIT, "tls_configured") != "True"
+            or self.charm.peers_data.get(Scope.UNIT, "tls_configured") is not True
         ):
             logger.debug("TLS CA rotation ongoing on this unit.")
             return False

--- a/tests/unit/lib/test_opensearch_base_charm.py
+++ b/tests/unit/lib/test_opensearch_base_charm.py
@@ -360,7 +360,7 @@ class TestOpenSearchBaseCharm(unittest.TestCase):
     @patch(
         f"{BASE_LIB_PATH}.opensearch_tls.OpenSearchTLS.ca_and_certs_rotation_complete_in_cluster"
     )
-    @patch(f"{BASE_LIB_PATH}.opensearch_tls.OpenSearchTLS._read_stored_ca")
+    @patch(f"{BASE_LIB_PATH}.opensearch_tls.OpenSearchTLS.read_stored_ca")
     @patch(f"{BASE_LIB_PATH}.opensearch_tls.OpenSearchTLS.on_ca_certs_rotation_complete")
     def test_reload_tls_certs_without_restart(
         self,
@@ -369,7 +369,7 @@ class TestOpenSearchBaseCharm(unittest.TestCase):
         is_fully_configured,
         reload_tls_certificates,
         ca_and_certs_rotation_complete_in_cluster,
-        _read_stored_ca,
+        read_stored_ca,
         on_ca_certs_rotation_complete,
     ):
         """Test that tls configuration set does not trigger restart."""
@@ -381,7 +381,7 @@ class TestOpenSearchBaseCharm(unittest.TestCase):
         is_admin_user_configured.return_value = True
         is_fully_configured.return_value = True
         ca_and_certs_rotation_complete_in_cluster.return_value = True
-        _read_stored_ca.return_value = "ca_1234"
+        read_stored_ca.return_value = "ca_1234"
 
         store_admin_tls_secrets_if_applies.assert_called_once()
         reload_tls_certificates.assert_called_once()

--- a/tests/unit/lib/test_opensearch_tls.py
+++ b/tests/unit/lib/test_opensearch_tls.py
@@ -1500,7 +1500,7 @@ class TestOpenSearchTLS(unittest.TestCase):
 
         assert re.search(
             "openssl pkcs12 -export .* -out "
-            f"\/var\/snap\/opensearch\/current\/etc\/opensearch\/certificates\/{cert_type}.p12 .* -name {cert_type}",
+            rf"/var/snap/opensearch/current/etc/opensearch/certificates/{cert_type}.p12 .* -name {cert_type}",
             run_cmd.call_args_list[0].args[0],
         )
         assert (

--- a/tests/unit/lib/test_opensearch_tls.py
+++ b/tests/unit/lib/test_opensearch_tls.py
@@ -459,14 +459,14 @@ class TestOpenSearchTLS(unittest.TestCase):
     @patch("charms.opensearch.v0.opensearch_tls.run_cmd")
     @patch(f"{PEER_CLUSTERS_MANAGER}.deployment_desc")
     # Mocks to avoid I/O
-    @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS._read_stored_ca")
+    @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS.read_stored_ca")
     @patch("builtins.open", side_effect=unittest.mock.mock_open())
     def test_on_certificate_available_leader_app_cert_full_workflow(
         self,
         # NOTE: Syntax: parametrized parameter comes first
         deployment_type,
         _,
-        _read_stored_ca,
+        read_stored_ca,
         deployment_desc,
         run_cmd,
     ):
@@ -505,7 +505,7 @@ class TestOpenSearchTLS(unittest.TestCase):
         )
 
         # There was no change of the CA (certificate), the event matches the one on disk
-        _read_stored_ca.return_value = ca
+        read_stored_ca.return_value = ca
 
         # Applies to ANY deployment type
         deployment_desc.return_value = DeploymentDescription(
@@ -571,7 +571,7 @@ class TestOpenSearchTLS(unittest.TestCase):
     @patch("charms.opensearch.v0.opensearch_tls.run_cmd")
     @patch(f"{PEER_CLUSTERS_MANAGER}.deployment_desc")
     # Mocks to avoid I/O
-    @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS._read_stored_ca")
+    @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS.read_stored_ca")
     @patch("builtins.open", side_effect=unittest.mock.mock_open())
     def test_on_certificate_available_any_node_unit_cert_full_workflow(
         self,
@@ -580,7 +580,7 @@ class TestOpenSearchTLS(unittest.TestCase):
         leader,
         cert_type,
         _,
-        _read_stored_ca,
+        read_stored_ca,
         deployment_desc,
         run_cmd,
     ):
@@ -647,7 +647,7 @@ class TestOpenSearchTLS(unittest.TestCase):
         )
 
         # There was no change of the CA (certificate), the event matches the one on disk
-        _read_stored_ca.return_value = ca
+        read_stored_ca.return_value = ca
 
         # Applies to ANY deployment type
         deployment_desc.return_value = DeploymentDescription(
@@ -708,7 +708,7 @@ class TestOpenSearchTLS(unittest.TestCase):
         ]
     )
     @patch("charms.opensearch.v0.opensearch_tls.run_cmd")
-    @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS._read_stored_ca")
+    @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS.read_stored_ca")
     @patch(f"{PEER_CLUSTERS_MANAGER}.deployment_desc")
     # Mocks to avoid I/O
     @patch("builtins.open", side_effect=unittest.mock.mock_open())
@@ -718,7 +718,7 @@ class TestOpenSearchTLS(unittest.TestCase):
         deployment_type,
         _,
         deployment_desc,
-        _read_stored_ca,
+        read_stored_ca,
         run_cmd,
     ):
         """Test CA rotation 1st stage.
@@ -771,7 +771,7 @@ class TestOpenSearchTLS(unittest.TestCase):
         )
 
         # The CA stored in the keystore is still the old one
-        _read_stored_ca.return_value = "old_ca"
+        read_stored_ca.return_value = "old_ca"
 
         # Applies to ANY deployment type
         deployment_desc.return_value = DeploymentDescription(
@@ -832,14 +832,14 @@ class TestOpenSearchTLS(unittest.TestCase):
         ]
     )
     @patch("charms.opensearch.v0.opensearch_tls.run_cmd")
-    @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS._read_stored_ca")
+    @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS.read_stored_ca")
     @patch(f"{PEER_CLUSTERS_MANAGER}.deployment_desc")
     def test_on_certificate_available_ca_rotation_first_stage_any_cluster_non_leader(
         # NOTE: Syntax: parametrized parameter comes first
         self,
         deployment_type,
         deployment_desc,
-        _read_stored_ca,
+        read_stored_ca,
         run_cmd,
     ):
         """'certificate-available' with an app cert and/or a CA cert.
@@ -867,7 +867,7 @@ class TestOpenSearchTLS(unittest.TestCase):
             certificate_signing_request=csr, chain=chain, certificate=cert, ca=ca
         )
 
-        _read_stored_ca.return_value = "stored_ca"
+        read_stored_ca.return_value = "stored_ca"
 
         # Applies to ANY deployment type
         deployment_desc.return_value = DeploymentDescription(
@@ -916,7 +916,7 @@ class TestOpenSearchTLS(unittest.TestCase):
     @patch(
         "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.request_certificate_creation"
     )
-    @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS._read_stored_ca")
+    @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS.read_stored_ca")
     @patch(f"{PEER_CLUSTERS_MANAGER}.deployment_desc")
     # Necessary mocks to simulate a smotth startup
     @patch("machine_upgrade.Upgrade")
@@ -931,7 +931,7 @@ class TestOpenSearchTLS(unittest.TestCase):
         __,
         upgrade,
         deployment_desc,
-        _read_stored_ca,
+        read_stored_ca,
         create_cert,
         revoke_cert,
         renew_cert,
@@ -1083,7 +1083,7 @@ class TestOpenSearchTLS(unittest.TestCase):
     )
     @patch(f"{PEER_CLUSTERS_MANAGER}.deployment_desc")
     # Mocks to avoid I/O
-    @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS._read_stored_ca")
+    @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS.read_stored_ca")
     # Necessary mocks to simulate a smooth startup
     @patch("machine_upgrade.Upgrade")
     @patch("socket.socket.connect")
@@ -1094,7 +1094,7 @@ class TestOpenSearchTLS(unittest.TestCase):
         deployment_type,
         _,
         upgrade,
-        _read_stored_ca,
+        read_stored_ca,
         deployment_desc,
         revoke_cert,
         renew_cert,
@@ -1233,14 +1233,14 @@ class TestOpenSearchTLS(unittest.TestCase):
     @patch("charms.opensearch.v0.opensearch_tls.run_cmd")
     @patch(f"{PEER_CLUSTERS_MANAGER}.deployment_desc")
     # Mocks to avoid I/O
-    @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS._read_stored_ca")
+    @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS.read_stored_ca")
     @patch("builtins.open", side_effect=unittest.mock.mock_open())
     def test_on_certificate_available_ca_rotation_third_stage_leader_cert_app(
         self,
         # NOTE: Syntax: parametrized parameter comes first
         deployment_type,
         _,
-        _read_stored_ca,
+        read_stored_ca,
         deployment_desc,
         run_cmd,
     ):
@@ -1281,7 +1281,7 @@ class TestOpenSearchTLS(unittest.TestCase):
                 return "old_ca_cert"
             return ca
 
-        _read_stored_ca.side_effect = mock_stored_ca
+        read_stored_ca.side_effect = mock_stored_ca
 
         # Applies to ANY deployment type
         deployment_desc.return_value = DeploymentDescription(
@@ -1364,7 +1364,7 @@ class TestOpenSearchTLS(unittest.TestCase):
     @patch("charms.opensearch.v0.opensearch_tls.run_cmd")
     @patch(f"{PEER_CLUSTERS_MANAGER}.deployment_desc")
     # Mocks to avoid I/O
-    @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS._read_stored_ca")
+    @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS.read_stored_ca")
     @patch("charms.opensearch.v0.opensearch_tls.exists", return_value=True)
     @patch("opensearch.OpenSearchSnap.write_file")
     @patch("builtins.open", side_effect=unittest.mock.mock_open())
@@ -1380,7 +1380,7 @@ class TestOpenSearchTLS(unittest.TestCase):
         __,
         ___,
         _____,
-        _read_stored_ca,
+        read_stored_ca,
         deployment_desc,
         run_cmd,
         reload_tls_certificates,
@@ -1455,7 +1455,7 @@ class TestOpenSearchTLS(unittest.TestCase):
         )
 
         # The new CA cert has been saved to the keystore earlier
-        _read_stored_ca.return_value = ca
+        read_stored_ca.return_value = ca
 
         # Applies to ANY deployment type
         deployment_desc.return_value = DeploymentDescription(
@@ -1490,24 +1490,23 @@ class TestOpenSearchTLS(unittest.TestCase):
 
         self.charm.tls._on_certificate_available(event_mock)
 
-        # Saving new cert, cleaning up CA renewal flag, removing old CA from keystore
+        # Saving new cert, cleaning up CA renewal flag
         # Note: the high number of operations come from the fact that on each certificate received
         # the 'issuer' is checked on each certificate that is saved on the disk.
         if self.charm.unit.is_leader():
-            assert run_cmd.call_count == 14
+            assert run_cmd.call_count == 12
         else:
-            assert run_cmd.call_count == 16
+            assert run_cmd.call_count == 14
 
         assert re.search(
             "openssl pkcs12 -export .* -out "
-            f"/var/snap/opensearch/current/etc/opensearch/certificates/{cert_type}.p12 .* -name {cert_type}",
+            f"\/var\/snap\/opensearch\/current\/etc\/opensearch\/certificates\/{cert_type}.p12 .* -name {cert_type}",
             run_cmd.call_args_list[0].args[0],
         )
         assert (
             f"chmod +r /var/snap/opensearch/current/etc/opensearch/certificates/{cert_type}.p12"
             in run_cmd.call_args_list[1].args[0]
         )
-        assert re.search("keytool .*-delete .*-alias old-ca", run_cmd.call_args_list[-1].args[0])
 
         assert "tls_ca_renewing" not in self.harness.get_relation_data(self.rel_id, "opensearch/0")
         assert "tls_ca_renewed" not in self.harness.get_relation_data(self.rel_id, "opensearch/0")
@@ -1533,7 +1532,7 @@ class TestOpenSearchTLS(unittest.TestCase):
     @patch("charms.opensearch.v0.opensearch_tls.run_cmd")
     @patch(f"{PEER_CLUSTERS_MANAGER}.deployment_desc")
     # Mock to avoid I/O
-    @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS._read_stored_ca")
+    @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS.read_stored_ca")
     @patch("builtins.open", side_effect=unittest.mock.mock_open())
     def test_on_certificate_available_rotation_ongoing_on_this_unit(
         # NOTE: Syntax: parametrized parameter comes first
@@ -1541,7 +1540,7 @@ class TestOpenSearchTLS(unittest.TestCase):
         deployment_type,
         leader,
         _,
-        _read_stored_ca,
+        read_stored_ca,
         deployment_desc,
         run_cmd,
     ):
@@ -1571,7 +1570,7 @@ class TestOpenSearchTLS(unittest.TestCase):
             },
         )
 
-        _read_stored_ca.return_value = "stored_ca"
+        read_stored_ca.return_value = "stored_ca"
 
         # Applies to ANY deployment type
         deployment_desc.return_value = DeploymentDescription(
@@ -1629,7 +1628,7 @@ class TestOpenSearchTLS(unittest.TestCase):
     @patch("charms.opensearch.v0.opensearch_tls.run_cmd")
     @patch(f"{PEER_CLUSTERS_MANAGER}.deployment_desc")
     # Mock to avoid I/O
-    @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS._read_stored_ca")
+    @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS.read_stored_ca")
     @patch("builtins.open", side_effect=unittest.mock.mock_open())
     def test_on_certificate_available_rotation_ongoing_on_another_unit(
         # NOTE: Syntax: parametrized parameter comes first
@@ -1637,7 +1636,7 @@ class TestOpenSearchTLS(unittest.TestCase):
         deployment_type,
         leader,
         _,
-        _read_stored_ca,
+        read_stored_ca,
         deployment_desc,
         run_cmd,
     ):
@@ -1667,7 +1666,7 @@ class TestOpenSearchTLS(unittest.TestCase):
             },
         )
 
-        _read_stored_ca.return_value = "stored_ca"
+        read_stored_ca.return_value = "stored_ca"
 
         # Applies to ANY deployment type
         deployment_desc.return_value = DeploymentDescription(


### PR DESCRIPTION
## Issue
We were not updating the `chain.pem` file used by the request module to send requests which caused communication cuts in a lot of cases.
Also fixes #448

## Solution
Add the new chain to the `chain.pem` on CA rotation initiated and only delete it if all the nodes are done updating their CA **and** certs.


## Summary of changes
This pull request introduces several changes to improve the handling of CA (Certificate Authority) rotation in the OpenSearch charm. The key changes include enhancements to the CA rotation process, ensuring proper cleanup of old CA certificates, and updating the request CA bundle. Additionally, a new method has been added to handle the completion of CA rotation.

### Improvements to CA Rotation Process:
* [`lib/charms/opensearch/v0/opensearch_base_charm.py`](diffhunk://#diff-5c0d89f838ffd5a9ecf2288b3698320fda2d2b2b737361b6e10adb55d1929f43R645-R652): Added checks to ensure CA rotation is complete in the cluster before removing old CAs and updating the request bundle (`on_tls_conf_set`, `post_start_init`, `_on_update_status`). [[1]](diffhunk://#diff-5c0d89f838ffd5a9ecf2288b3698320fda2d2b2b737361b6e10adb55d1929f43R645-R652) [[2]](diffhunk://#diff-5c0d89f838ffd5a9ecf2288b3698320fda2d2b2b737361b6e10adb55d1929f43L821-R839) [[3]](diffhunk://#diff-5c0d89f838ffd5a9ecf2288b3698320fda2d2b2b737361b6e10adb55d1929f43R1180-R1188)
* [`lib/charms/opensearch/v0/opensearch_tls.py`](diffhunk://#diff-fcbdb57c37f5d32b5ecf046327cfa9ee91a33f156714ea7fb6f000a48d2c4ca4R880-R911): Introduced new methods `ca_and_certs_rotation_complete_in_cluster` and `on_ca_certs_rotation_complete` to handle the completion of CA rotations and update the request bundle accordingly. [[1]](diffhunk://#diff-fcbdb57c37f5d32b5ecf046327cfa9ee91a33f156714ea7fb6f000a48d2c4ca4R880-R911) [[2]](diffhunk://#diff-fcbdb57c37f5d32b5ecf046327cfa9ee91a33f156714ea7fb6f000a48d2c4ca4L887-R957)

### Version Updates:
* [`lib/charms/opensearch/v0/opensearch_base_charm.py`](diffhunk://#diff-5c0d89f838ffd5a9ecf2288b3698320fda2d2b2b737361b6e10adb55d1929f43L121-R121): Incremented `LIBPATCH` version from 2 to 3.
* [`lib/charms/opensearch/v0/opensearch_tls.py`](diffhunk://#diff-fcbdb57c37f5d32b5ecf046327cfa9ee91a33f156714ea7fb6f000a48d2c4ca4L64-R65): Incremented `LIBPATCH` version from 1 to 2.

### Unit Test Enhancements:
* [`tests/unit/lib/test_opensearch_base_charm.py`](diffhunk://#diff-39b4fe0e40f461d4a9731e4cb8281d7a1f6eaccaee15e3b3a4ec796840136d34L360-R373): Updated unit tests to mock new methods and ensure they are called correctly during the CA rotation process. [[1]](diffhunk://#diff-39b4fe0e40f461d4a9731e4cb8281d7a1f6eaccaee15e3b3a4ec796840136d34L360-R373) [[2]](diffhunk://#diff-39b4fe0e40f461d4a9731e4cb8281d7a1f6eaccaee15e3b3a4ec796840136d34R383-R388)

### Code Cleanup:
* [`lib/charms/opensearch/v0/opensearch_base_charm.py`](diffhunk://#diff-5c0d89f838ffd5a9ecf2288b3698320fda2d2b2b737361b6e10adb55d1929f43L952-L957): Removed redundant calls to `update_request_ca_bundle` and `remove_old_ca` in `_start_opensearch` and `_post_start_init`. [[1]](diffhunk://#diff-5c0d89f838ffd5a9ecf2288b3698320fda2d2b2b737361b6e10adb55d1929f43L952-L957) [[2]](diffhunk://#diff-5c0d89f838ffd5a9ecf2288b3698320fda2d2b2b737361b6e10adb55d1929f43L1164-L1167)

### Dependency Updates:
* [`lib/charms/opensearch/v0/opensearch_tls.py`](diffhunk://#diff-fcbdb57c37f5d32b5ecf046327cfa9ee91a33f156714ea7fb6f000a48d2c4ca4R24): Added import for `Path` from `pathlib`.
