### PR TITLE
[DPE-5668] Move grafana to use the same SERIES constant as the opensearch charm

### DIFF
--- a/tests/integration/plugins/test_plugins.py
+++ b/tests/integration/plugins/test_plugins.py
@@ -171,7 +171,7 @@ async def test_prometheus_exporter_enabled_by_default(ops_test, deploy_type: str
 @pytest.mark.parametrize("deploy_type", SMALL_DEPLOYMENTS)
 @pytest.mark.abort_on_fail
 async def test_small_deployments_prometheus_exporter_cos_relation(ops_test, deploy_type: str):
-    await ops_test.model.deploy(COS_APP_NAME, channel="edge"),
+    await ops_test.model.deploy(COS_APP_NAME, channel="edge", series=SERIES),
     await ops_test.model.integrate(APP_NAME, COS_APP_NAME)
     await _wait_for_units(ops_test, deploy_type)
 
@@ -258,7 +258,7 @@ async def test_large_deployment_build_and_deploy(ops_test: OpsTest, deploy_type:
 @pytest.mark.abort_on_fail
 async def test_large_deployment_prometheus_exporter_cos_relation(ops_test, deploy_type: str):
     # Check that the correct settings were successfully communicated to grafana-agent
-    await ops_test.model.deploy(COS_APP_NAME, channel="edge"),
+    await ops_test.model.deploy(COS_APP_NAME, channel="edge", series=SERIES),
     await ops_test.model.integrate(FAILOVER_ORCHESTRATOR_NAME, COS_APP_NAME)
     await ops_test.model.integrate(MAIN_ORCHESTRATOR_NAME, COS_APP_NAME)
     await ops_test.model.integrate(APP_NAME, COS_APP_NAME)


### PR DESCRIPTION
Moves the grafana-agent charm to use the same series as the opensearch.

Closes #477 