### PR TITLE
[DPE-5671] - Logic change in how check if ca rotation in complete in cluster

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -867,7 +867,7 @@ class OpenSearchTLS(Object):
             rotation_happening = True
         if not self.charm.peers_data.get(Scope.UNIT, "tls_ca_renewed", False):
             logger.debug(
-                f"TLS CA rotation ongoing in unit: {self.charm.unit_name}, will not update tls certificates."
+                f"TLS CA rotation ongoing in unit: {self.charm.unit.name}, will not update tls certificates."
             )
             rotation_complete = False
 


### PR DESCRIPTION
## Issue
Fixes #482 
If a unit finishes updating its CA before any of the other unit start the rotation then this unit will update its certificates and that will cause communication issues with the rest of the nodes

## Solution
Check if there's a `tls_ca_renewing` set on any of the units then consider the rotation started.

This pull request focuses on enhancing the logic for checking the status of CA (Certificate Authority) rotation in the `opensearch_tls.py` module. The changes aim to improve the accuracy and clarity of determining whether the CA rotation process is complete across all units in the cluster.

### Enhancements to CA Rotation Logic:

* **Updated Condition Checks:**
  - Replaced `is_ca_rotation_ongoing` with `ca_rotation_complete_in_cluster` to ensure the correct status is checked before deferring events and updating TLS resources. (`lib/charms/opensearch/v0/opensearch_tls.py`) [[1]](diffhunk://#diff-fcbdb57c37f5d32b5ecf046327cfa9ee91a33f156714ea7fb6f000a48d2c4ca4L213-R213) [[2]](diffhunk://#diff-fcbdb57c37f5d32b5ecf046327cfa9ee91a33f156714ea7fb6f000a48d2c4ca4L640-R640)

* **New Method Implementation:**
  - Implemented `ca_rotation_complete_in_cluster` to accurately determine if CA rotation is complete by checking flags across all units. This method now tracks both ongoing and completed states more effectively. (`lib/charms/opensearch/v0/opensearch_tls.py`)

* **Removed Redundant Method:**
  - Removed the `is_ca_rotation_ongoing` method as its functionality is now covered by the enhanced `ca_rotation_complete_in_cluster` method. (`lib/charms/opensearch/v0/opensearch_tls.py`)