### PR TITLE
Add subordinate support to `wait_until`

### DIFF
--- a/tests/integration/plugins/test_plugins.py
+++ b/tests/integration/plugins/test_plugins.py
@@ -82,7 +82,7 @@ async def _set_config(ops_test: OpsTest, deploy_type: str, conf: dict[str, str])
     await ops_test.model.applications[APP_NAME].set_config(conf)
 
 
-async def _wait_for_units(ops_test: OpsTest, deployment_type: str, extra_apps=[]) -> None:
+async def _wait_for_units(ops_test: OpsTest, deployment_type: str, wait_for_cos=False) -> None:
     """Wait for all units to be active.
 
     This wait will behavior accordingly to small/large.
@@ -90,13 +90,22 @@ async def _wait_for_units(ops_test: OpsTest, deployment_type: str, extra_apps=[]
     if deployment_type == "small_deployment":
         await wait_until(
             ops_test,
-            apps=[APP_NAME] + extra_apps,
+            apps=[APP_NAME],
             apps_statuses=["active"],
             units_statuses=["active"],
             timeout=1800,
             idle_period=IDLE_PERIOD,
         )
-        return
+        if wait_for_cos:
+            await wait_until(
+                ops_test,
+                apps=[COS_APP_NAME],
+                apps_statuses=["active", "blocked"],
+                units_statuses=["active", "blocked"],
+                timeout=1800,
+                idle_period=IDLE_PERIOD,
+            )
+            return
     await wait_until(
         ops_test,
         apps=[
@@ -104,13 +113,21 @@ async def _wait_for_units(ops_test: OpsTest, deployment_type: str, extra_apps=[]
             MAIN_ORCHESTRATOR_NAME,
             FAILOVER_ORCHESTRATOR_NAME,
             APP_NAME,
-        ]
-        + extra_apps,
+        ],
         apps_statuses=["active"],
         units_statuses=["active"],
         timeout=1800,
         idle_period=IDLE_PERIOD,
     )
+    if wait_for_cos:
+        await wait_until(
+            ops_test,
+            apps=[COS_APP_NAME],
+            apps_statuses=["active", "blocked"],
+            units_statuses=["active", "blocked"],
+            timeout=1800,
+            idle_period=IDLE_PERIOD,
+        )
 
 
 @pytest.mark.parametrize("deploy_type", SMALL_DEPLOYMENTS)
@@ -167,7 +184,7 @@ async def test_prometheus_exporter_enabled_by_default(ops_test, deploy_type: str
 async def test_small_deployments_prometheus_exporter_cos_relation(ops_test, deploy_type: str):
     await ops_test.model.deploy(COS_APP_NAME, channel="edge"),
     await ops_test.model.integrate(APP_NAME, COS_APP_NAME)
-    await _wait_for_units(ops_test, deploy_type, extra_apps=[COS_APP_NAME])
+    await _wait_for_units(ops_test, deploy_type, wait_for_cos=True)
 
     # Check that the correct settings were successfully communicated to grafana-agent
     cos_leader_id = await get_leader_unit_id(ops_test, COS_APP_NAME)
@@ -257,7 +274,7 @@ async def test_large_deployment_prometheus_exporter_cos_relation(ops_test, deplo
     await ops_test.model.integrate(MAIN_ORCHESTRATOR_NAME, COS_APP_NAME)
     await ops_test.model.integrate(APP_NAME, COS_APP_NAME)
 
-    await _wait_for_units(ops_test, deploy_type, extra_apps=[COS_APP_NAME])
+    await _wait_for_units(ops_test, deploy_type, wait_for_cos=True)
 
     leader_id = await get_leader_unit_id(ops_test, APP_NAME)
     leader_name = f"{APP_NAME}/{leader_id}"
@@ -309,7 +326,7 @@ async def test_prometheus_monitor_user_password_change(ops_test, deploy_type: st
     result1 = await run_action(
         ops_test, leader_id, "set-password", {"username": "monitor"}, app=app
     )
-    await _wait_for_units(ops_test, deploy_type, extra_apps=[COS_APP_NAME])
+    await _wait_for_units(ops_test, deploy_type, wait_for_cos=True)
 
     new_password = result1.response.get("monitor-password")
     # Now, we compare the change in the action above with the opensearch's nodes.

--- a/tests/integration/plugins/test_plugins.py
+++ b/tests/integration/plugins/test_plugins.py
@@ -100,8 +100,7 @@ async def _wait_for_units(ops_test: OpsTest, deployment_type: str, wait_for_cos=
             await wait_until(
                 ops_test,
                 apps=[COS_APP_NAME],
-                apps_statuses=["active", "blocked"],
-                units_statuses=["active", "blocked"],
+                units_statuses=["blocked"],
                 timeout=1800,
                 idle_period=IDLE_PERIOD,
             )
@@ -123,8 +122,7 @@ async def _wait_for_units(ops_test: OpsTest, deployment_type: str, wait_for_cos=
         await wait_until(
             ops_test,
             apps=[COS_APP_NAME],
-            apps_statuses=["active", "blocked"],
-            units_statuses=["active", "blocked"],
+            units_statuses=["blocked"],
             timeout=1800,
             idle_period=IDLE_PERIOD,
         )


### PR DESCRIPTION
This PR extends the wait_until to search for the units' status of a given subordinate charm, based on its principal charm.