### PR TITLE
fix_ha_storage_test

### DIFF
--- a/tests/integration/ha/test_storage.py
+++ b/tests/integration/ha/test_storage.py
@@ -175,14 +175,12 @@ async def test_storage_reuse_after_scale_to_zero(
         # give some time for removing each unit
         time.sleep(60)
 
-    await wait_until(
-        ops_test,
+    # using wait_until doesn't really work well here with 0 units
+    await ops_test.model.wait_for_idle(
+        # app status will not be active because after scaling down not all shards are assigned
         apps=[app],
-        apps_statuses=["active", "blocked"],
         timeout=1000,
-        wait_for_exact_units={
-            app: 0,
-        },
+        wait_for_exact_units=0,
     )
 
     # scale up again

--- a/tests/integration/ha/test_storage.py
+++ b/tests/integration/ha/test_storage.py
@@ -180,7 +180,6 @@ async def test_storage_reuse_after_scale_to_zero(
         apps=[app],
         apps_statuses=["active", "blocked"],
         timeout=1000,
-        idle_period=IDLE_PERIOD,
         wait_for_exact_units={
             app: 0,
         },

--- a/tests/integration/ha/test_storage.py
+++ b/tests/integration/ha/test_storage.py
@@ -294,7 +294,6 @@ async def test_storage_reuse_in_new_cluster_after_app_removal(
         apps_statuses=["active", "blocked"],
         units_statuses=["active"],
         wait_for_exact_units=1,
-        idle_period=IDLE_PERIOD,
         timeout=2400,
     )
 

--- a/tests/integration/ha/test_storage.py
+++ b/tests/integration/ha/test_storage.py
@@ -108,7 +108,7 @@ async def test_storage_reuse_after_scale_down(
     await wait_until(
         ops_test,
         apps=[app],
-        apps_statuses=["active"],
+        apps_statuses=["active", "blocked"],
         units_statuses=["active"],
         timeout=1000,
         idle_period=IDLE_PERIOD,

--- a/tests/integration/ha/test_storage.py
+++ b/tests/integration/ha/test_storage.py
@@ -266,10 +266,9 @@ async def test_storage_reuse_in_new_cluster_after_app_removal(
     await wait_until(
         ops_test,
         apps=[app],
-        apps_statuses=["active"],
+        apps_statuses=["active", "blocked"],
         units_statuses=["active"],
         timeout=1000,
-        idle_period=IDLE_PERIOD,
         wait_for_exact_units={
             app: 1,
         },

--- a/tests/integration/ha/test_storage.py
+++ b/tests/integration/ha/test_storage.py
@@ -104,6 +104,7 @@ async def test_storage_reuse_after_scale_down(
     subprocess.run(create_testfile_cmd, shell=True)
 
     # scale-down to 1
+    # app status might be blocked because after scaling down not all shards are assigned
     await ops_test.model.applications[app].destroy_unit(f"{app}/{unit_id}")
     await wait_until(
         ops_test,
@@ -263,6 +264,7 @@ async def test_storage_reuse_in_new_cluster_after_app_removal(
     for unit_id in unit_ids[1:]:
         await ops_test.model.applications[app].destroy_unit(f"{app}/{unit_id}")
 
+    # app status might be blocked because after scaling down not all shards are assigned
     await wait_until(
         ops_test,
         apps=[app],
@@ -287,6 +289,7 @@ async def test_storage_reuse_in_new_cluster_after_app_removal(
     await ops_test.model.integrate(app, TLS_CERTIFICATES_APP_NAME)
 
     # wait for cluster to be deployed
+    # app status might be blocked because not all shards are assigned
     await wait_until(
         ops_test,
         apps=[app],


### PR DESCRIPTION
## Issue
Currently the integration test for re-using storage fails occasionally. This is because in one of the tests we remove the application, keeping the storage disks and re-attaching them to a new application. This can lead to stale metadata, as described in [our docs](https://charmhub.io/opensearch/docs/h-attached-storage), which will cause the Opensearch service to fail on startup.

## Solution
Adjust the integration test workflow to first scale down to one remaining unit before removing the application. This will cause the remaining unit to become the leader, if it wasn't already. Removing the application now and later re-attaching this units' storage disk to the new leader means that we can start up Opensearch correctly.