### PR TITLE
Do not apply performance profile if deployment_desc does not exist

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -743,9 +743,14 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
                 self.status.clear(PluginConfigCheck, app=True)
                 self.status.clear(PluginConfigChangeError, app=True)
 
-        perf_profile_needs_restart = self.performance_profile.apply(
-            self.config.get(PERFORMANCE_PROFILE)
-        )
+        if self.opensearch_peer_cm.deployment_desc():
+            perf_profile_needs_restart = self.performance_profile.apply(
+                self.config.get(PERFORMANCE_PROFILE)
+            )
+        else:
+            event.defer()
+            return
+
         if plugin_needs_restart or perf_profile_needs_restart:
             self._restart_opensearch_event.emit()
 


### PR DESCRIPTION
## Issue
If the Opensearch operator receives a config change before the deployment description has been initialized, applying the performance profile will fail and the charm will be in a failed state.

This happens repeatedly on the integration test runs for Opensearch in the data-integrator CI, e.g. [here](https://github.com/canonical/data-integrator/actions/runs/11585189263/job/32253824740).

## Solution
If the deployment description does not exist yet, the performance profile should not be applied and the received event should be deferred.