### PR TITLE
[DPE-5932] Remove cert-available check for CA rotation

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -859,10 +859,6 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             if self.tls.is_fully_configured():
                 try:
                     self.tls.reload_tls_certificates()
-                except OpenSearchHttpError:
-                    logger.error("Could not reload TLS certificates via API, will restart.")
-                    self._restart_opensearch_event.emit()
-                else:
                     self.status.clear(TLSNotFullyConfigured)
                     self.tls.reset_ca_rotation_state()
                     # if all certs are stored and CA rotation is complete in the cluster
@@ -873,6 +869,10 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
                     ):
                         logger.info("on_tls_conf_set: Detected CA rotation complete in cluster")
                         self.tls.on_ca_certs_rotation_complete()
+
+                except OpenSearchHttpError:
+                    logger.error("Could not reload TLS certificates via API, will restart.")
+                    self._restart_opensearch_event.emit()
 
             else:
                 event.defer()

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -859,6 +859,10 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             if self.tls.is_fully_configured():
                 try:
                     self.tls.reload_tls_certificates()
+                except OpenSearchHttpError:
+                    logger.error("Could not reload TLS certificates via API, will restart.")
+                    self._restart_opensearch_event.emit()
+                else:
                     self.status.clear(TLSNotFullyConfigured)
                     self.tls.reset_ca_rotation_state()
                     # if all certs are stored and CA rotation is complete in the cluster
@@ -869,10 +873,6 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
                     ):
                         logger.info("on_tls_conf_set: Detected CA rotation complete in cluster")
                         self.tls.on_ca_certs_rotation_complete()
-
-                except OpenSearchHttpError:
-                    logger.error("Could not reload TLS certificates via API, will restart.")
-                    self._restart_opensearch_event.emit()
 
             else:
                 event.defer()

--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -67,10 +67,6 @@ LIBPATCH = 1
 logger = logging.getLogger(__name__)
 
 
-class OpenSearchTlsRotationWaitNextHookError(OpenSearchError):
-    """We wait for the next hook to finish the TLS rotation."""
-
-
 class OpenSearchTLS(Object):
     """Class that Manages OpenSearch relation with TLS Certificates Operator."""
 
@@ -102,18 +98,6 @@ class OpenSearchTLS(Object):
         self.framework.observe(
             self.certs.on.certificate_invalidated, self._on_certificate_invalidated
         )
-        # We want to avoid a corner case where the leader is the first unit to receive a certificate-available
-        # at CA rotation. It takes the lock (as the leader, it can execute the lock itself rightaway)
-        # which then moves from tls_ca_renewing=True, to `delete tls_ca_renewing` and set tls_ca_renewed=True
-        # That would happen on the call within _on_certificate_available's self.charm.on_tls_ca_rotation()
-        # Once that happens, the leader can still continue to run within the same hook and proceed with
-        # its _on_certificate_available call, reaching: self.charm.on_tls_conf_set(event, scope, cert_type, renewal)
-        # there it could execute the reload successfully and re-execute: reset_ca_rotation_state
-        # Finally, that removes the `tls_ca_renewed` from the databag.
-
-        # Therefore, this boolean exists: we will force the reset_ca_rotation_state to wait a whole hook
-        # between the two calls of reset_ca_rotation_state.
-        self.moved_to_tls_ca_renewed = False
 
     def _on_set_tls_private_key(self, event: ActionEvent) -> None:
         """Set the TLS private key, which will be used for requesting the certificate."""
@@ -268,11 +252,6 @@ class OpenSearchTLS(Object):
                 )
                 self.charm.on_tls_ca_rotation()
                 return
-
-#        elif not self.ca_rotation_complete_in_cluster():
-#            # We have same current_stored_ca and event.ca, but we are executing the rotation
-#            event.defer()
-#            return
 
         # store the certificates and keys in a key store
         self.store_new_tls_resources(
@@ -887,14 +866,11 @@ class OpenSearchTLS(Object):
             )
             self.moved_to_tls_ca_renewed = True
         else:
-#        elif not self.moved_to_tls_ca_renewed:
             # this means only the CA rotation completed, still need to create certificates
             self.charm.peers_data.put(Scope.UNIT, "tls_ca_renewed", True)
             self.update_ca_rotation_flag_to_peer_cluster_relation(
                 flag="tls_ca_renewed", operation="add"
             )
-#        else:
-#            raise OpenSearchTlsRotationWaitNextHookError()
 
     def ca_rotation_complete_in_cluster(self) -> bool:
         """Check whether the CA rotation completed in all units."""

--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -222,7 +222,8 @@ class OpenSearchTLS(Object):
 
         if secret != {"chain": ca_chain, "cert": event.certificate, "ca-cert": event.ca}:
             # Juju is not able to check if secrets' content changed between revisions
-            # this IF is intended to reduce a storm of secret-removed/-changed events for the same content
+            # this IF is intended to reduce a storm of secret-removed/-changed events
+            # for the same content
             self.charm.secrets.put_object(
                 scope,
                 cert_type.val,
@@ -864,7 +865,6 @@ class OpenSearchTLS(Object):
             self.update_ca_rotation_flag_to_peer_cluster_relation(
                 flag="tls_ca_renewed", operation="remove"
             )
-            self.moved_to_tls_ca_renewed = True
         else:
             # this means only the CA rotation completed, still need to create certificates
             self.charm.peers_data.put(Scope.UNIT, "tls_ca_renewed", True)

--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -67,6 +67,10 @@ LIBPATCH = 1
 logger = logging.getLogger(__name__)
 
 
+class OpenSearchTlsRotationWaitNextHookError(OpenSearchError):
+    """We wait for the next hook to finish the TLS rotation."""
+
+
 class OpenSearchTLS(Object):
     """Class that Manages OpenSearch relation with TLS Certificates Operator."""
 
@@ -98,6 +102,18 @@ class OpenSearchTLS(Object):
         self.framework.observe(
             self.certs.on.certificate_invalidated, self._on_certificate_invalidated
         )
+        # We want to avoid a corner case where the leader is the first unit to receive a certificate-available
+        # at CA rotation. It takes the lock (as the leader, it can execute the lock itself rightaway)
+        # which then moves from tls_ca_renewing=True, to `delete tls_ca_renewing` and set tls_ca_renewed=True
+        # That would happen on the call within _on_certificate_available's self.charm.on_tls_ca_rotation()
+        # Once that happens, the leader can still continue to run within the same hook and proceed with
+        # its _on_certificate_available call, reaching: self.charm.on_tls_conf_set(event, scope, cert_type, renewal)
+        # there it could execute the reload successfully and re-execute: reset_ca_rotation_state
+        # Finally, that removes the `tls_ca_renewed` from the databag.
+
+        # Therefore, this boolean exists: we will force the reset_ca_rotation_state to wait a whole hook
+        # between the two calls of reset_ca_rotation_state.
+        self.moved_to_tls_ca_renewed = False
 
     def _on_set_tls_private_key(self, event: ActionEvent) -> None:
         """Set the TLS private key, which will be used for requesting the certificate."""
@@ -210,23 +226,29 @@ class OpenSearchTLS(Object):
         if not self.charm.unit.is_leader() and scope == Scope.APP:
             return
 
-        if not self.ca_rotation_complete_in_cluster():
-            event.defer()
-            return
-
         old_cert = secrets.get("cert", None)
         ca_chain = "\n".join(event.chain[::-1])
 
-        self.charm.secrets.put_object(
-            scope,
-            cert_type.val,
-            {
-                "chain": ca_chain,
-                "cert": event.certificate,
-                "ca-cert": event.ca,
-            },
-            merge=True,
-        )
+        current_secret_obj = self.charm.secrets.get_object(scope, cert_type.val) or {}
+        secret = {
+            "chain": current_secret_obj.get("chain"),
+            "cert": current_secret_obj.get("cert"),
+            "ca-cert": current_secret_obj.get("ca-cert"),
+        }
+
+        if secret != {"chain": ca_chain, "cert": event.certificate, "ca-cert": event.ca}:
+            # Juju is not able to check if secrets' content changed between revisions
+            # this IF is intended to reduce a storm of secret-removed/-changed events for the same content
+            self.charm.secrets.put_object(
+                scope,
+                cert_type.val,
+                {
+                    "chain": ca_chain,
+                    "cert": event.certificate,
+                    "ca-cert": event.ca,
+                },
+                merge=True,
+            )
 
         current_stored_ca = self.read_stored_ca()
         if current_stored_ca != event.ca:
@@ -246,6 +268,11 @@ class OpenSearchTLS(Object):
                 )
                 self.charm.on_tls_ca_rotation()
                 return
+
+#        elif not self.ca_rotation_complete_in_cluster():
+#            # We have same current_stored_ca and event.ca, but we are executing the rotation
+#            event.defer()
+#            return
 
         # store the certificates and keys in a key store
         self.store_new_tls_resources(
@@ -858,12 +885,16 @@ class OpenSearchTLS(Object):
             self.update_ca_rotation_flag_to_peer_cluster_relation(
                 flag="tls_ca_renewed", operation="remove"
             )
+            self.moved_to_tls_ca_renewed = True
         else:
+#        elif not self.moved_to_tls_ca_renewed:
             # this means only the CA rotation completed, still need to create certificates
             self.charm.peers_data.put(Scope.UNIT, "tls_ca_renewed", True)
             self.update_ca_rotation_flag_to_peer_cluster_relation(
                 flag="tls_ca_renewed", operation="add"
             )
+#        else:
+#            raise OpenSearchTlsRotationWaitNextHookError()
 
     def ca_rotation_complete_in_cluster(self) -> bool:
         """Check whether the CA rotation completed in all units."""

--- a/tests/unit/lib/test_opensearch_tls.py
+++ b/tests/unit/lib/test_opensearch_tls.py
@@ -83,7 +83,7 @@ class TestOpenSearchTLS(unittest.TestCase):
 
     @patch("charm.OpenSearchOperatorCharm._put_or_update_internal_user_leader")
     def setUp(self, _) -> None:
-        self.skipTest('module not tested')
+        self.skipTest("TODO: remove this skip")
 
         self.harness = Harness(OpenSearchOperatorCharm)
         self.addCleanup(self.harness.cleanup)

--- a/tests/unit/lib/test_opensearch_tls.py
+++ b/tests/unit/lib/test_opensearch_tls.py
@@ -83,8 +83,6 @@ class TestOpenSearchTLS(unittest.TestCase):
 
     @patch("charm.OpenSearchOperatorCharm._put_or_update_internal_user_leader")
     def setUp(self, _) -> None:
-        self.skipTest("TODO: remove this skip")
-
         self.harness = Harness(OpenSearchOperatorCharm)
         self.addCleanup(self.harness.cleanup)
         self.rel_id = self.harness.add_network("1.1.1.1", endpoint=PeerRelationName)
@@ -1625,7 +1623,6 @@ class TestOpenSearchTLS(unittest.TestCase):
         )
 
         self.harness.set_leader(is_leader=leader)
-        original_status = self.harness.model.unit.status
 
         # This unit is within the process of certificate renewal
         with self.harness.hooks_disabled():
@@ -1635,20 +1632,32 @@ class TestOpenSearchTLS(unittest.TestCase):
 
         self.charm.tls._on_certificate_available(self.charm.on.certificate_available)
 
-        # No action taken, no change on status or certificates
-        assert run_cmd.call_count == 0
-        assert self.harness.model.unit.status == original_status
+        # exactly three run_cmd commands to be executed: checking the current CA for the
+        # admin cert, the unit_http cert and the unit_transport cert
         if leader:
-            self.charm.on.certificate_available.defer.assert_called_once()
+            assert run_cmd.call_count == 3
+            assert self.harness.model.unit.status == MaintenanceStatus(
+                "Applying new CA certificate..."
+            )
+            assert self.secret_store.get_object(Scope.APP, CertType.APP_ADMIN.val) == {
+                "csr": csr,
+                "chain": "new_chain",
+                "keystore-password": "keystore_12345",
+                "truststore-password": "truststore_12345",
+                "ca-cert": "new_ca",
+                "cert": "new_cert",
+            }
         else:
-            self.charm.on.certificate_available.defer.assert_not_called()
-        assert self.secret_store.get_object(Scope.APP, CertType.APP_ADMIN.val) == {
-            "csr": csr,
-            "keystore-password": "keystore_12345",
-            "truststore-password": "truststore_12345",
-            "ca-cert": "old_ca_cert",
-            "cert": "old_cert",
-        }
+            # We have scope == Scope.APP, so we will skip the entire logic
+            assert run_cmd.call_count == 0
+            assert self.harness.model.unit.status == MaintenanceStatus("")
+            assert self.secret_store.get_object(Scope.APP, CertType.APP_ADMIN.val) == {
+                "csr": csr,
+                "keystore-password": "keystore_12345",
+                "truststore-password": "truststore_12345",
+                "ca-cert": "old_ca_cert",
+                "cert": "old_cert",
+            }
 
     # Mock to investigate/compare/alter
     @parameterized.expand(
@@ -1723,7 +1732,6 @@ class TestOpenSearchTLS(unittest.TestCase):
         )
 
         self.harness.set_leader(is_leader=leader)
-        original_status = self.harness.model.unit.status
 
         # This unit has updated CA certificate
         # but another unit of the cluster is still within the process
@@ -1738,17 +1746,29 @@ class TestOpenSearchTLS(unittest.TestCase):
 
         self.charm.tls._on_certificate_available(self.charm.on.certificate_available)
 
-        # No action taken, no change on status or certificates
-        assert run_cmd.call_count == 0
-        assert self.harness.model.unit.status == original_status
+        # exactly three run_cmd commands to be executed: checking the current CA for the
+        # admin cert, the unit_http cert and the unit_transport cert
         if leader:
-            self.charm.on.certificate_available.defer.assert_called_once()
+            assert run_cmd.call_count == 3
+            assert self.harness.model.unit.status == MaintenanceStatus(
+                "Applying new CA certificate..."
+            )
+            assert self.secret_store.get_object(Scope.APP, CertType.APP_ADMIN.val) == {
+                "csr": csr,
+                "chain": "new_chain",
+                "keystore-password": "keystore_12345",
+                "truststore-password": "truststore_12345",
+                "ca-cert": "new_ca",
+                "cert": "new_cert",
+            }
         else:
-            self.charm.on.certificate_available.defer.assert_not_called()
-        assert self.secret_store.get_object(Scope.APP, CertType.APP_ADMIN.val) == {
-            "csr": csr,
-            "keystore-password": "keystore_12345",
-            "truststore-password": "truststore_12345",
-            "ca-cert": "old_ca_cert",
-            "cert": "old_cert",
-        }
+            # We have scope == Scope.APP, so we will skip the entire logic
+            assert run_cmd.call_count == 0
+            assert self.harness.model.unit.status == MaintenanceStatus("")
+            assert self.secret_store.get_object(Scope.APP, CertType.APP_ADMIN.val) == {
+                "csr": csr,
+                "keystore-password": "keystore_12345",
+                "truststore-password": "truststore_12345",
+                "ca-cert": "old_ca_cert",
+                "cert": "old_cert",
+            }

--- a/tests/unit/lib/test_opensearch_tls.py
+++ b/tests/unit/lib/test_opensearch_tls.py
@@ -1580,9 +1580,6 @@ class TestOpenSearchTLS(unittest.TestCase):
     ):
         """Additional 'certificate-available' event while processing CA rotation.
 
-        In case any stage of a CA cert rotation is being processed,
-        further 'certificate-available' events are deferred.
-
         Applies to:
          - any deployment
          - any unit
@@ -1688,9 +1685,6 @@ class TestOpenSearchTLS(unittest.TestCase):
         run_cmd,
     ):
         """Additional 'certificate-available' event while processing CA rotation.
-
-        In case any stage of a CA cert rotation is being processed,
-        further 'certificate-available' events are deferred.
 
         Applies to:
          - any deployment

--- a/tests/unit/lib/test_opensearch_tls.py
+++ b/tests/unit/lib/test_opensearch_tls.py
@@ -1580,6 +1580,14 @@ class TestOpenSearchTLS(unittest.TestCase):
     ):
         """Additional 'certificate-available' event while processing CA rotation.
 
+        This run represents a 'certificate-available' right before the leader
+        sets the TLS renewal flags in the peer relation.
+
+        In this case, the leader must execute the update logic for itself.
+
+        Remaining units will just wait until the first flags are set, hence
+        will not have `run_cmd` calls.
+
         Applies to:
          - any deployment
          - any unit
@@ -1685,6 +1693,11 @@ class TestOpenSearchTLS(unittest.TestCase):
         run_cmd,
     ):
         """Additional 'certificate-available' event while processing CA rotation.
+
+        In this case, the leader must execute the update logic for itself.
+
+        Remaining units will just wait until the first flags are set, hence
+        will not have `run_cmd` calls.
 
         Applies to:
          - any deployment

--- a/tests/unit/lib/test_opensearch_tls.py
+++ b/tests/unit/lib/test_opensearch_tls.py
@@ -83,6 +83,8 @@ class TestOpenSearchTLS(unittest.TestCase):
 
     @patch("charm.OpenSearchOperatorCharm._put_or_update_internal_user_leader")
     def setUp(self, _) -> None:
+        self.skipTest('module not tested')
+
         self.harness = Harness(OpenSearchOperatorCharm)
         self.addCleanup(self.harness.cleanup)
         self.rel_id = self.harness.add_network("1.1.1.1", endpoint=PeerRelationName)

--- a/tests/unit/resources/config/opensearch-security/internal_users.yml
+++ b/tests/unit/resources/config/opensearch-security/internal_users.yml
@@ -9,12 +9,8 @@ _meta:
 
 ## Demo users
 
-kibanaserver:
-  hash: $2b$12$UPS8q4bPIUaycBLIXPqcsOBcd/2BjDBY6opZYtPmJXjTmau6CmuLm
-  reserved: false
-  description: Kibanaserver user
 admin:
-  hash: $2b$12$l3s/BwbEQwuvZrGOMN.7EeIuNSiU5c2FYSO/LZDOOCX4qCSmrWTT.
+  hash: $2b$12$Cts2k6vk.emW.E1mQN.B5u/5DfwKybaXFRREHfIwUs7RUHNp8h.c.
   reserved: false
   backend_roles:
   - admin
@@ -22,3 +18,7 @@ admin:
   - security_rest_api_access
   - all_access
   description: Admin user
+kibanaserver:
+  hash: $2b$12$0ZYW/CiICy1.7YXpRYDjeOLD75qnPAu4I3w5KXZmJvFp1rRiCm8qa
+  reserved: false
+  description: Kibanaserver user


### PR DESCRIPTION
This PR removes one of the filters that was causing a race condition at CA rotation + large deployments. It fixes the CA rotation for large deployments in our CI.

Closes #500