### PR TITLE
Add new alert rules for throttling

### DIFF
--- a/src/alert_rules/prometheus/prometheus_alerts.yaml
+++ b/src/alert_rules/prometheus/prometheus_alerts.yaml
@@ -129,16 +129,6 @@
     "labels":
       "severity": "alert"
 
-  - "alert": "OpenSearchFewNodes"
-    "annotations":
-      "message": "Cluster {{ $labels.cluster }} has less nodes than expected. It's recommend to have at least 3 nodes for high availability."
-      "summary": "Few OpenSearch nodes on cluster"
-    "expr": |
-      sum by (cluster) (opensearch_cluster_nodes_number) / count by (cluster) (opensearch_cluster_nodes_number) < 3
-    "for": "5m"
-    "labels":
-      "severity": "warning"
-
   - "alert": "OpenSearchThrottling"
     "annotations":
       "message": "Cluster {{ $labels.cluster }} is throttling. Please optimize queries and indexing patterns or consider scale the application."

--- a/src/alert_rules/prometheus/prometheus_alerts.yaml
+++ b/src/alert_rules/prometheus/prometheus_alerts.yaml
@@ -105,3 +105,23 @@
     "for": "1m"
     "labels":
       "severity": "alert"
+
+  - "alert": "OpenSearchFewNodes"
+    "annotations":
+      "message": "Cluster {{ $labels.cluster }} has less nodes than expected. It's recommend to have at least 3 nodes for high availability."
+      "summary": "Few OpenSearch nodes on cluster"
+    "expr": |
+      sum by (cluster) (opensearch_cluster_nodes_number) / count by (cluster) (opensearch_cluster_nodes_number) < 3
+    "for": "5m"
+    "labels":
+      "severity": "warning"
+
+  - "alert": "OpenSearchThrottling"
+    "annotations":
+      "message": "Cluster {{ $labels.cluster }} is throttling. Please optimize queries and indexing patterns or consider scale the application."
+      "summary": "OpenSearch Indexing Throttle"
+    "expr": |
+      sum by (cluster) (opensearch_indices_indexing_is_throttled_bool) > 0
+    "for": "5m"
+    "labels":
+      "severity": "warning"


### PR DESCRIPTION
- If OpenSearch is throttling, this is an alert that optimizations are necessary like scaling the number of nodes or changing queries and indexing patterns