### PR TITLE
Add critical alert if cluster is throttling for two hours

### DIFF
--- a/src/alert_rules/prometheus/prometheus_alerts.yaml
+++ b/src/alert_rules/prometheus/prometheus_alerts.yaml
@@ -131,7 +131,7 @@
 
   - "alert": "OpenSearchThrottling"
     "annotations":
-      "message": "Cluster {{ $labels.cluster }} is throttling. Please optimize queries and indexing patterns or consider scale the application."
+      "message": "Cluster {{ $labels.cluster }} is throttling. Please review your indexing request rate, index lifecycle or consider scale the application."
       "summary": "OpenSearch Indexing Throttle"
     "expr": |
       sum by (cluster) (opensearch_indices_indexing_is_throttled_bool) > 0
@@ -141,7 +141,7 @@
 
   - "alert": "OpenSearchThrottlingTooLong"
     "annotations":
-      "message": "Cluster {{ $labels.cluster }} is throttling for two hours. Please optimize queries and indexing patterns or consider scale the application."
+      "message": "Cluster {{ $labels.cluster }} is throttling for at least two hours. Please review your indexing request rate, index lifecycle or consider scale the application."
       "summary": "OpenSearch Indexing Throttle too long"
     "expr": |
       sum by (cluster) (opensearch_indices_indexing_is_throttled_bool) > 0

--- a/src/alert_rules/prometheus/prometheus_alerts.yaml
+++ b/src/alert_rules/prometheus/prometheus_alerts.yaml
@@ -138,3 +138,13 @@
     "for": "5m"
     "labels":
       "severity": "warning"
+
+  - "alert": "OpenSearchThrottlingTooLong"
+    "annotations":
+      "message": "Cluster {{ $labels.cluster }} is throttling for two hours. Please optimize queries and indexing patterns or consider scale the application."
+      "summary": "OpenSearch Indexing Throttle too long"
+    "expr": |
+      sum by (cluster) (opensearch_indices_indexing_is_throttled_bool) > 0
+    "for": "2h"
+    "labels":
+      "severity": "critical"

--- a/tests/unit/test_alert_rules/test_opensearch_rules.yaml
+++ b/tests/unit/test_alert_rules/test_opensearch_rules.yaml
@@ -191,5 +191,20 @@ tests:
               severity: warning
               cluster: opensearch-x7zb
             exp_annotations:
-              message: "Cluster opensearch-x7zb is throttling. Please optimize queries and indexing patterns or consider scale the application."
+              message: "Cluster opensearch-x7zb is throttling. Please review your indexing request rate, index lifecycle or consider scale the application."
               summary: "OpenSearch Indexing Throttle"
+
+  - interval: 1m
+    input_series:
+      - series: 'opensearch_indices_indexing_is_throttled_bool{cluster="opensearch-x7zb"}'
+        values: '1x360'
+    alert_rule_test:
+      - eval_time: 2h
+        alertname: OpenSearchThrottlingTooLong
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              cluster: opensearch-x7zb
+            exp_annotations:
+              message: "Cluster opensearch-x7zb is throttling for at least two hours. Please review your indexing request rate, index lifecycle or consider scale the application."
+              summary: "OpenSearch Indexing Throttle too long"


### PR DESCRIPTION
After showing the current alert rules for Managed Solutions, they asked to have a critical alert if the cluster is throttling for two hours.
