### PR TITLE
[DPE-5982][DPE-6088] Azure storage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -161,6 +161,8 @@ jobs:
       integration-test: |
         { "AWS_ACCESS_KEY": "${{ secrets.AWS_ACCESS_KEY }}",
           "AWS_SECRET_KEY": "${{ secrets.AWS_SECRET_KEY }}",
+          "AZURE_STORAGE_ACCOUNT": "${{ secrets.AZURE_STORAGE_ACCOUNT }}",
+          "AZURE_SECRET_KEY": "${{ secrets.AZURE_SECRET_KEY }}",
           "GCP_ACCESS_KEY": "${{ secrets.GCP_ACCESS_KEY }}",
           "GCP_SECRET_KEY": "${{ secrets.GCP_SECRET_KEY }}",
           "GCP_SERVICE_ACCOUNT": "${{ secrets.GCP_SERVICE_ACCOUNT }}", }

--- a/lib/charms/data_platform_libs/v0/object_storage.py
+++ b/lib/charms/data_platform_libs/v0/object_storage.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+from collections import namedtuple
+from typing import Dict, List, Optional
+
+from charms.data_platform_libs.v0.data_interfaces import (
+    EventHandlers,
+    ProviderData,
+    RequirerData,
+    RequirerEventHandlers,
+)
+from ops import Model
+from ops.charm import (
+    CharmBase,
+    CharmEvents,
+    RelationBrokenEvent,
+    RelationChangedEvent,
+    RelationEvent,
+    RelationJoinedEvent,
+    SecretChangedEvent,
+)
+from ops.framework import EventSource
+from ops.model import Relation
+
+# The unique Charmhub library identifier, never change it
+LIBID = "fca396f6254246c9bfa5650000000000"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+
+logger = logging.getLogger(__name__)
+
+
+AZURE_STORAGE_REQUIRED_INFO = ["container", "storage-account", "secret-key", "connection-protocol"]
+
+
+class ObjectStorageEvent(RelationEvent):
+    pass
+
+
+class ContainerEvent(ObjectStorageEvent):
+    """Base class for Azure storage events."""
+
+    @property
+    def container(self) -> Optional[str]:
+        """Returns the container name."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("container", "")
+
+
+class StorageConnectionInfoRequestedEvent(ContainerEvent):
+    pass
+
+
+class StorageConnectionInfoChangedEvent(ContainerEvent):
+    pass
+
+
+class StorageConnectionInfoGoneEvent(RelationEvent):
+    pass
+
+
+class AzureStorageProviderEvents(CharmEvents):
+    """Events for the AzureStorageProvider side implementation."""
+    storage_connection_info_requested = EventSource(StorageConnectionInfoRequestedEvent)
+
+
+class AzureStorageRequirerEvents(CharmEvents):
+    """Events for the AzureStorageRequirer side implementation."""
+
+    storage_connection_info_changed = EventSource(StorageConnectionInfoChangedEvent)
+    storage_connection_info_gone = EventSource(StorageConnectionInfoGoneEvent)
+
+
+class AzureStorageRequirerData(RequirerData):
+    SECRET_FIELDS = ["secret-key"]
+
+    def __init__(self, model, relation_name: str, container: Optional[str] = None):
+        super().__init__(
+            model,
+            relation_name,
+        )
+        self.container = container
+
+
+class AzureStorageRequirerEventHandlers(RequirerEventHandlers):
+    """Event handlers for for requirer side of Azure Storage relation."""
+
+    on = AzureStorageRequirerEvents()  # pyright: ignore[reportAssignmentType]
+
+    def __init__(
+        self, charm: CharmBase, relation_data: AzureStorageRequirerData
+    ):
+        super().__init__(charm, relation_data)
+
+        self.relation_name = relation_data.relation_name
+        self.charm = charm
+        self.local_app = self.charm.model.app
+        self.local_unit = self.charm.unit
+
+        self.framework.observe(
+            self.charm.on[self.relation_name].relation_joined, self._on_relation_joined_event
+        )
+        self.framework.observe(
+            self.charm.on[self.relation_name].relation_changed, self._on_relation_changed_event
+        )
+
+        self.framework.observe(
+            self.charm.on[self.relation_name].relation_broken,
+            self._on_relation_broken_event,
+        )
+
+    def _on_relation_joined_event(self, event: RelationJoinedEvent) -> None:
+        """Event emitted when the Azure Storage relation is joined."""
+        logger.info(f"Azure storage relation ({event.relation.name}) joined...")
+        if self.container is None:
+            self.container = f"relation-{event.relation.id}"
+        event_data = {"container": self.container}
+        self.relation_data.update_relation_data(event.relation.id, event_data)
+
+    def get_azure_connection_info(self) -> Dict[str, str]:
+        """Return the azure storage connection info as a dictionary."""
+        for relation in self.relations:
+            if relation and relation.app:
+                info = self.relation_data.fetch_relation_data([relation.id])[relation.id]
+                if not all([param in info for param in AZURE_STORAGE_REQUIRED_INFO]):
+                    continue
+                return info
+        return {}
+
+    def _on_relation_changed_event(self, event: RelationChangedEvent) -> None:
+        """Notify the charm about the presence of Azure credentials."""
+        logger.info(f"Azure storage relation ({event.relation.name}) changed...")
+
+        diff = self._diff(event)
+        if any(newval for newval in diff.added if self.relation_data._is_secret_field(newval)):
+            self.relation_data._register_secrets_to_relation(event.relation, diff.added)
+
+        # check if the mandatory options are in the relation data
+        contains_required_options = True
+        credentials = self.get_azure_connection_info()
+        missing_options = []
+        for configuration_option in AZURE_STORAGE_REQUIRED_INFO:
+            if configuration_option not in credentials:
+                contains_required_options = False
+                missing_options.append(configuration_option)
+
+        # emit credential change event only if all mandatory fields are present
+        if contains_required_options:
+            getattr(self.on, "storage_connection_info_changed").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+        else:
+            logger.warning(
+                f"Some mandatory fields: {missing_options} are not present, do not emit credential change event!"
+            )
+
+    def _on_secret_changed_event(self, event: SecretChangedEvent):
+        """Event handler for handling a new value of a secret."""
+        if not event.secret.label:
+            return
+
+        relation = self.relation_data._relation_from_secret_label(event.secret.label)
+        if not relation:
+            logging.info(
+                f"Received secret {event.secret.label} but couldn't parse, seems irrelevant."
+            )
+            return
+
+        if relation.app == self.charm.app:
+            logging.info("Secret changed event ignored for Secret Owner")
+
+        remote_unit = None
+        for unit in relation.units:
+            if unit.app != self.charm.app:
+                remote_unit = unit
+
+        # check if the mandatory options are in the relation data
+        contains_required_options = True
+        credentials = self.get_azure_connection_info()
+        missing_options = []
+        for configuration_option in AZURE_STORAGE_REQUIRED_INFO:
+            if configuration_option not in credentials:
+                contains_required_options = False
+                missing_options.append(configuration_option)
+
+        # emit credential change event only if all mandatory fields are present
+        if contains_required_options:
+            getattr(self.on, "storage_connection_info_changed").emit(
+                relation, app=relation.app, unit=remote_unit
+            )
+        else:
+            logger.warning(
+                f"Some mandatory fields: {missing_options} are not present, do not emit credential change event!"
+            )
+
+
+    def _on_relation_broken_event(self, event: RelationBrokenEvent) -> None:
+        """Event handler for handling relation_broken event."""
+        logger.info("Azure Storage relation broken...")
+        getattr(self.on, "storage_connection_info_gone").emit(event.relation, app=event.app, unit=event.unit)
+
+    @property
+    def relations(self) -> List[Relation]:
+        """The list of Relation instances associated with this relation_name."""
+        return list(self.charm.model.relations[self.relation_name])
+
+
+class AzureStorageRequires(AzureStorageRequirerData, AzureStorageRequirerEventHandlers):
+    """The requirer side of Azure Storage relation."""
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str,
+        container: Optional[str] = None,
+    ):
+        AzureStorageRequirerData.__init__(self, charm.model, relation_name, container)
+        AzureStorageRequirerEventHandlers.__init__(self, charm, self)
+
+
+class AzureStorageProviderData(ProviderData):
+    """The Data abstraction of the provider side of Azure storage relation."""
+    def __init__(self, model: Model, relation_name: str) -> None:
+        super().__init__(model, relation_name)
+
+
+class AzureStorageProviderEventHandlers(EventHandlers):
+    """The event handlers related to provider side of Azure Storage relation."""
+    on = AzureStorageProviderEvents()
+
+    def __init__(
+        self, charm: CharmBase, relation_data: AzureStorageProviderData, unique_key: str = ""
+    ):
+        super().__init__(charm, relation_data, unique_key)
+        self.relation_data = relation_data
+
+    def _on_relation_changed_event(self, event: RelationChangedEvent):
+        if not self.charm.unit.is_leader():
+            return
+        diff = self._diff(event)
+        if "container" in diff.added:
+            self.on.storage_connection_info_requested.emit(event.relation, app=event.app, unit=event.unit)
+
+
+class AzureStorageProvides(AzureStorageProviderData, AzureStorageProviderEventHandlers):
+    """The provider side of the Azure Storage relation."""
+    def __init__(self, charm: CharmBase, relation_name: str) -> None:
+        AzureStorageProviderData.__init__(self, charm.model, relation_name)
+        AzureStorageProviderEventHandlers.__init__(self, charm, self)

--- a/lib/charms/opensearch/v0/constants_charm.py
+++ b/lib/charms/opensearch/v0/constants_charm.py
@@ -65,10 +65,10 @@ PClusterWrongNodesCountForQuorum = (
 )
 PluginConfigError = "Unexpected error during plugin configuration, check the logs"
 BackupSetupFailed = "Backup setup failed, check logs for details"
-S3RelMissing = "Backup failover cluster missing S3 relation."
-S3RelShouldNotExist = "This unit should not be related to S3"
-S3RelDataIncomplete = "S3 relation data missing or incomplete."
-S3RelUneligible = "Only orchestrator clusters should relate to S3."
+BackupRelMissing = "Backup failover cluster missing backup relation."
+BackupRelShouldNotExist = "This unit should not be related to backup relation"
+BackupRelDataIncomplete = "Backup relation data missing or incomplete."
+BackupRelUneligible = "Only orchestrator clusters should relate to backup relation."
 
 # Wait status
 RequestUnitServiceOps = "Requesting lock on operation: {}"
@@ -121,4 +121,7 @@ OPENSEARCH_BACKUP_ID_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 S3_REPO_BASE_PATH = "/"
 S3_RELATION = "s3-credentials"
+AZURE_REPO_BASE_PATH = "/"
+AZURE_RELATION = "azure-credentials"
+
 PERFORMANCE_PROFILE = "profile"

--- a/lib/charms/opensearch/v0/constants_secrets.py
+++ b/lib/charms/opensearch/v0/constants_secrets.py
@@ -26,3 +26,5 @@ S3_PEER_SECRET_KEYS = [
     "s3-access-key",
     S3_CREDENTIALS,
 ]
+AZURE_CREDENTIALS = "azure-creds"
+AZURE_PEER_SECRET_KEYS = ["azure-storage-account", "azure-secret-key", "secret-key", "storage-account", AZURE_CREDENTIALS]

--- a/lib/charms/opensearch/v0/constants_secrets.py
+++ b/lib/charms/opensearch/v0/constants_secrets.py
@@ -27,4 +27,10 @@ S3_PEER_SECRET_KEYS = [
     S3_CREDENTIALS,
 ]
 AZURE_CREDENTIALS = "azure-creds"
-AZURE_PEER_SECRET_KEYS = ["azure-storage-account", "azure-secret-key", "secret-key", "storage-account", AZURE_CREDENTIALS]
+AZURE_PEER_SECRET_KEYS = [
+    "azure-storage-account",
+    "azure-secret-key",
+    "secret-key",
+    "storage-account",
+    AZURE_CREDENTIALS,
+]

--- a/lib/charms/opensearch/v0/models.py
+++ b/lib/charms/opensearch/v0/models.py
@@ -393,7 +393,7 @@ class AzureRelData(Model):
     storage_account: str = Field(alias="storage-account", default="")
     container: str = Field(default="")
     endpoint: Optional[str] = Field(default="")
-    path: Optional[str] = Field(default=AZURE_REPO_BASE_PATH)
+    base_path: Optional[str] = Field(alias="path", default=AZURE_REPO_BASE_PATH)
     connection_protocol: Optional[str] = Field(alias="connection-protocol", default=None)
     credentials: AzureRelDataCredentials = Field(
         alias=AZURE_CREDENTIALS, default=AzureRelDataCredentials()

--- a/lib/charms/opensearch/v0/models.py
+++ b/lib/charms/opensearch/v0/models.py
@@ -3,13 +3,14 @@
 
 """Cluster-related data structures / model classes."""
 import json
+import logging
 from abc import ABC
 from datetime import datetime
 from hashlib import md5
 from typing import Any, Dict, List, Literal, Optional
 
-from charms.opensearch.v0.constants_charm import S3_REPO_BASE_PATH
-from charms.opensearch.v0.constants_secrets import S3_CREDENTIALS
+from charms.opensearch.v0.constants_charm import AZURE_REPO_BASE_PATH, S3_REPO_BASE_PATH
+from charms.opensearch.v0.constants_secrets import AZURE_CREDENTIALS, S3_CREDENTIALS
 from charms.opensearch.v0.helper_enums import BaseStrEnum
 from pydantic import BaseModel, Field, root_validator, validator
 from pydantic.utils import ROOT_KEY
@@ -27,6 +28,9 @@ LIBPATCH = 1
 
 MIN_HEAP_SIZE = 1024 * 1024  # 1GB in KB
 MAX_HEAP_SIZE = 32 * MIN_HEAP_SIZE  # 32GB in KB
+
+
+logger = logging.getLogger(__name__)
 
 
 class Model(ABC, BaseModel):
@@ -316,7 +320,9 @@ class S3RelData(Model):
         ):
             raise ValueError("Missing fields: access_key, secret_key")
 
-        # Both bucket and endpoint must be set, or not.
+        # NOTE: Both bucket and endpoint must be set. If none of them are set,
+        # but credentials were found, this likely means that we are validating for a
+        # non cluster_manager application, which only needs credentials.
         if values.get("bucket") and not values.get("endpoint"):
             raise ValueError("Missing field: endpoint")
         if values.get("endpoint") and not values.get("bucket"):
@@ -366,6 +372,87 @@ class S3RelData(Model):
         )
 
 
+class AzureRelDataCredentials(Model):
+    """Model class for credentials passed on the Azure relation."""
+
+    storage_account: str = Field(alias="storage-account", default=None)
+    secret_key: str = Field(alias="secret-key", default=None)
+
+    class Config:
+        """Model config of this pydantic model."""
+
+        allow_population_by_field_name = True
+
+
+class AzureRelData(Model):
+    """Model class for the Azure relation data.
+
+    This model should receive the data directly from the relation and map it to a model.
+    """
+
+    storage_account: str = Field(alias="storage-account", default="")
+    container: str = Field(default="")
+    endpoint: Optional[str] = Field(default="")
+    path: Optional[str] = Field(default=AZURE_REPO_BASE_PATH)
+    connection_protocol: Optional[str] = Field(alias="connection-protocol", default=None)
+    credentials: AzureRelDataCredentials = Field(
+        alias=AZURE_CREDENTIALS, default=AzureRelDataCredentials()
+    )
+
+    class Config:
+        """Model config of this pydantic model."""
+
+        allow_population_by_field_name = True
+
+    @root_validator
+    def validate_core_fields(cls, values):  # noqa: N805
+        """Validate the core fields of the azure relation data."""
+        if (
+            not (creds := values.get("credentials"))
+            and not creds.storage_account
+            and not creds.secret_key
+        ):
+            raise ValueError("Missing fields: storage_account, secret_key")
+
+        # NOTE: Both storage_account and container must be set. If none of them are set,
+        # but credentials were found, this likely means that we are validating for a
+        # non cluster_manager application, which only needs credentials.
+        core_values = ["container"]
+        found = [item for item in core_values if values.get(item)]
+
+        if len(found) != len(core_values) and len(found) > 0:
+            raise ValueError(f"Missing fields: {set(core_values) - set(found)}")
+
+        return values
+
+    @validator(AZURE_CREDENTIALS, check_fields=False)
+    def ensure_secret_content(cls, conf: Dict[str, str] | AzureRelDataCredentials):  # noqa: N805
+        """Ensure the secret content is set."""
+        if not conf:
+            return None
+
+        data = conf
+        if isinstance(conf, dict):
+            data = AzureRelDataCredentials.from_dict(conf)
+
+        for value in data.dict().values():
+            if value.startswith("secret://"):
+                raise ValueError(f"The secret content must be passed, received {value} instead")
+        return data
+
+    @classmethod
+    def from_relation(cls, input_dict: Optional[Dict[str, Any]]):
+        """Create a new instance of this class from a json/dict repr.
+
+        This method creates a nested AzureRelDataCredentials object from the input dict.
+        """
+        if not input_dict:
+            return cls()
+
+        creds = AzureRelDataCredentials(**input_dict)
+        return cls.from_dict(dict(input_dict) | {AZURE_CREDENTIALS: creds.dict()})
+
+
 class PeerClusterRelDataCredentials(Model):
     """Model class for credentials passed on the PCluster relation."""
 
@@ -377,6 +464,7 @@ class PeerClusterRelDataCredentials(Model):
     monitor_password: Optional[str]
     admin_tls: Optional[Dict[str, Optional[str]]]
     s3: Optional[S3RelDataCredentials]
+    azure: Optional[AzureRelDataCredentials]
 
 
 class PeerClusterApp(Model):

--- a/lib/charms/opensearch/v0/models.py
+++ b/lib/charms/opensearch/v0/models.py
@@ -414,17 +414,6 @@ class AzureRelData(Model):
         ):
             raise ValueError("Missing fields: storage_account, secret_key")
 
-        # NOTE: Both storage_account and container must be set. If none of them are set,
-        # but credentials were found, this likely means that we are validating for a
-        # non cluster_manager application, which only needs credentials.
-        core_values = ["container"]
-        found = [item for item in core_values if values.get(item)]
-
-        if len(found) != len(core_values) and len(found) > 0:
-            raise ValueError(f"Missing fields: {set(core_values) - set(found)}")
-
-        return values
-
     @validator(AZURE_CREDENTIALS, check_fields=False)
     def ensure_secret_content(cls, conf: Dict[str, str] | AzureRelDataCredentials):  # noqa: N805
         """Ensure the secret content is set."""

--- a/lib/charms/opensearch/v0/models.py
+++ b/lib/charms/opensearch/v0/models.py
@@ -414,6 +414,8 @@ class AzureRelData(Model):
         ):
             raise ValueError("Missing fields: storage_account, secret_key")
 
+        return values
+
     @validator(AZURE_CREDENTIALS, check_fields=False)
     def ensure_secret_content(cls, conf: Dict[str, str] | AzureRelDataCredentials):  # noqa: N805
         """Ensure the secret content is set."""

--- a/lib/charms/opensearch/v0/opensearch_backups.py
+++ b/lib/charms/opensearch/v0/opensearch_backups.py
@@ -74,7 +74,7 @@ object that corresponds to its own case (cluster-manager, failover, data, etc).
 import json
 import logging
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Any, Dict, Optional, Set
 
 from charms.data_platform_libs.v0.object_storage import AzureStorageRequires
 from charms.data_platform_libs.v0.s3 import S3Requirer
@@ -181,14 +181,6 @@ class OpenSearchRestoreIndexClosingError(OpenSearchRestoreError):
     """Exception thrown when restore fails to close indices."""
 
 
-# TODO integrate into the class
-class BackupRepository(BaseStrEnum):
-    """Possible repositories for backups."""
-
-    S3 = "s3-repository"
-    AZURE = "azure-repository"
-
-
 class BackupServiceState(BaseStrEnum):
     """Enum for the states possible once plugin is enabled."""
 
@@ -213,89 +205,12 @@ class BackupServiceState(BaseStrEnum):
     SNAPSHOT_FAILED_UNKNOWN = "snapshot failed for unknown reason"
 
 
-# TODO: keep all API calls in this class
-class OpenSearchBackupAPI:
+class BackupManager:
     """API related requests service for Opensearch"""
 
-    def __init__(self, charm: "OpenSearchBaseCharm", repository: BackupRepository = None):
-        self._charm = charm
-        self.repository = repository
-
-
-class OpenSearchBackupBase(Object):
-    """Works as parent for all backup classes.
-
-    This class does a smooth transition between orchestrator and non-orchestrator clusters.
-    """
-
-    def __init__(self, charm: "OpenSearchBaseCharm", relation_name: str = PeerClusterRelationName):
-        """Initializes the opensearch backup base.
-
-        This class will not hold a s3_client or object_storage object, as it is not intended to
-        really manage the relation besides waiting for the deployment description.
-        """
-        super().__init__(charm, relation_name)
+    def __init__(self, charm: "OpenSearchBaseCharm", repository: str | None = None):
         self.charm = charm
-
-        # We can reuse the same method, as the plugin manager will apply configs accordingly.
-        self.framework.observe(self.charm.on.secret_changed, self._on_secret_changed)
-        self.framework.observe(self.charm.on.secret_remove, self._on_secret_changed)
-
-        for relation in (S3_RELATION, AZURE_RELATION):
-            for event in [
-                self.charm.on[relation].relation_joined,
-                self.charm.on[relation].relation_changed,
-                self.charm.on[relation].relation_departed,
-                self.charm.on[relation].relation_broken,
-            ]:
-                self.framework.observe(event, self._on_backup_relation_event)
-            self.framework.observe(
-                self.charm.on[relation].relation_created, self._on_backup_relation_created
-            )
-
-        for event in [
-            self.charm.on.create_backup_action,
-            self.charm.on.list_backups_action,
-            self.charm.on.restore_action,
-        ]:
-            self.framework.observe(event, self._on_backup_action)
-
-    def _on_secret_changed(self, event: SecretEvent) -> None:
-        pass
-
-    def _on_backup_relation_event(self, event: RelationEvent) -> None:
-        """Defers the backup relation events."""
-        logger.info("Deployment description not yet available, deferring backup relation event")
-        event.defer()
-
-    def _on_backup_relation_created(self, _: RelationEvent) -> None:
-        if self.charm.upgrade_in_progress:
-            logger.warning(
-                "Modifying relations during an upgrade is not supported. The charm may be in a broken, unrecoverable state"
-            )
-
-    def _on_backup_relation_broken(self, event: RelationEvent) -> None:
-        """Defers the backup relation broken events."""
-        raise NotImplementedError
-
-    def _on_backup_action(self, event: ActionEvent) -> None:
-        """No deployment description yet, fail any actions."""
-        logger.info("Deployment description not yet available, failing actions.")
-        event.fail("Failed: deployment description not yet available")
-
-    @property
-    def active_relation(self) -> str | None:
-        """Check which relation is active and return it's value."""
-        s3_rel = self.model.get_relation(S3_RELATION)
-        azure_rel = self.model.get_relation(AZURE_RELATION)
-
-        # XNOR for the relations. Both existing or both not existing is an exit condition.
-        if (s3_rel is None and azure_rel is None) or (s3_rel and azure_rel):
-            return None
-        if s3_rel:
-            return S3_RELATION
-        if azure_rel:
-            return AZURE_RELATION
+        self.repository = repository
 
     def is_restore_in_progress(self) -> bool:
         """Checks if the restore is currently in progress."""
@@ -336,7 +251,7 @@ class OpenSearchBackupBase(Object):
                     return BackupServiceState.RESTORE_IN_PROGRESS
         return BackupServiceState.SUCCESS
 
-    def _is_restore_complete(self) -> bool:
+    def is_restore_complete(self) -> bool:
         """Checks if the restore is finished.
 
         Essentially, check for each index shard: for all type=SNAPSHOT and stage=DONE, return True.
@@ -349,10 +264,10 @@ class OpenSearchBackupBase(Object):
                 timeout=10,
             )
         except OpenSearchHttpError:
-            raise OpenSearchRestoreCheckError("_is_restore_complete: failed to get indices status")
+            raise OpenSearchRestoreCheckError("is_restore_complete: failed to get indices status")
         if not indices_status:
             # No restore has happened. Raise an exception
-            raise OpenSearchRestoreCheckError("_is_restore_complete: failed to get indices status")
+            raise OpenSearchRestoreCheckError("is_restore_complete: failed to get indices status")
         return not self.is_restore_in_progress()
 
     def is_backup_in_progress(self) -> bool:
@@ -374,11 +289,10 @@ class OpenSearchBackupBase(Object):
         return False
 
     def _query_backup_status(self, backup_id: Optional[str] = None) -> BackupServiceState:
-        if not self.active_relation:
+        if not self.repository:
             return BackupServiceState.REPO_NOT_CREATED
-        repository = S3_REPOSITORY if self.active_relation == S3_RELATION else AZURE_REPOSITORY
         try:
-            target = f"_snapshot/{repository}/"
+            target = f"_snapshot/{self.repository}/"
             target += f"{backup_id.lower()}" if backup_id else "_all"
             output = self.charm.opensearch.request(
                 "GET",
@@ -477,7 +391,7 @@ class OpenSearchBackupBase(Object):
         try:
             output = self.charm.opensearch.request(
                 "GET",
-                f"_snapshot/{S3_REPOSITORY}",
+                f"_snapshot/{self.repository}",
                 retries=6,
                 timeout=10,
             )
@@ -494,11 +408,11 @@ class OpenSearchBackupBase(Object):
         """Checks if the backup system is idle."""
         return self.is_backup_in_progress() or self.is_restore_in_progress()
 
-    def _list_backups(self, repository: str) -> Dict[int, str]:
+    def list_backups(self) -> Dict[int, str]:
         """Returns a mapping of snapshot ids / state."""
         # Using the original request method, as we want to raise an http exception if we
         # cannot get the snapshot list.
-        response = self.charm.opensearch.request("GET", f"_snapshot/{repository}/_all")
+        response = self.charm.opensearch.request("GET", f"_snapshot/{self.repository}/_all")
         return {
             snapshot["snapshot"].upper(): {
                 "state": snapshot["state"],
@@ -507,14 +421,106 @@ class OpenSearchBackupBase(Object):
             for snapshot in response.get("snapshots", [])
         }
 
-    def _format_backup_list(self, backups: List[Tuple[Any]]) -> str:
-        """Formats provided list of backups as a table."""
-        output = ["{:<20s} | {:s}".format(" backup-id", "backup-status")]
-        output.append("-" * len(output[0]))
+    def check_snapshot_status(self) -> BackupServiceState:
+        """Check the snapshot."""
+        try:
+            response = self.charm.opensearch.request(
+                "GET",
+                "/_snapshot/_status",
+                retries=6,
+                timeout=10,
+            )
+            return self.get_snapshot_status(response)
+        except OpenSearchHttpError:
+            return BackupServiceState.RESPONSE_FAILED_NETWORK
 
-        for backup_id, backup_status in backups:
-            output.append("{:<20s} | {:s}".format(backup_id, backup_status))
-        return "\n".join(output)
+
+class OpenSearchBackupBase(Object):
+    """Works as parent for all backup classes.
+
+    This class does a smooth transition between orchestrator and non-orchestrator clusters.
+    """
+
+    def __init__(self, charm: "OpenSearchBaseCharm", relation_name: str = PeerClusterRelationName):
+        """Initializes the opensearch backup base.
+
+        This class will not hold a s3_client or object_storage object, as it is not intended to
+        really manage the relation besides waiting for the deployment description.
+        """
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.backup_manager = BackupManager(charm, repository=self.repository)
+
+        # We can reuse the same method, as the plugin manager will apply configs accordingly.
+        self.framework.observe(self.charm.on.secret_changed, self._on_secret_changed)
+        self.framework.observe(self.charm.on.secret_remove, self._on_secret_changed)
+
+        for relation in (S3_RELATION, AZURE_RELATION):
+            for event in [
+                self.charm.on[relation].relation_joined,
+                self.charm.on[relation].relation_changed,
+                self.charm.on[relation].relation_departed,
+                self.charm.on[relation].relation_broken,
+            ]:
+                self.framework.observe(event, self._on_backup_relation_event)
+            self.framework.observe(
+                self.charm.on[relation].relation_created, self._on_backup_relation_created
+            )
+
+        for event in [
+            self.charm.on.create_backup_action,
+            self.charm.on.list_backups_action,
+            self.charm.on.restore_action,
+        ]:
+            self.framework.observe(event, self._on_backup_action)
+
+    def _on_secret_changed(self, event: SecretEvent) -> None:
+        pass
+
+    def _on_backup_relation_event(self, event: RelationEvent) -> None:
+        """Defers the backup relation events."""
+        logger.info("Deployment description not yet available, deferring backup relation event")
+        event.defer()
+
+    def _on_backup_relation_created(self, _: RelationEvent) -> None:
+        if self.charm.upgrade_in_progress:
+            logger.warning(
+                "Modifying relations during an upgrade is not supported. The charm may be in a broken, unrecoverable state"
+            )
+
+    def _on_backup_relation_broken(self, event: RelationEvent) -> None:
+        """Defers the backup relation broken events."""
+        raise NotImplementedError
+
+    def _on_backup_action(self, event: ActionEvent) -> None:
+        """No deployment description yet, fail any actions."""
+        logger.info("Deployment description not yet available, failing actions.")
+        event.fail("Failed: deployment description not yet available")
+
+    @property
+    def repository(self) -> str | None:
+        """Return the repository to set."""
+        repository = None
+        if self.active_relation == S3_RELATION:
+            repository = S3_REPOSITORY
+        if self.active_relation == AZURE_RELATION:
+            repository = AZURE_REPOSITORY
+
+        return repository
+
+    @property
+    def active_relation(self) -> str | None:
+        """Check which relation is active and return it's value."""
+        s3_rel = self.model.get_relation(S3_RELATION)
+        azure_rel = self.model.get_relation(AZURE_RELATION)
+
+        # XNOR for the relations. Both existing or both not existing is an exit condition.
+        if (s3_rel is None and azure_rel is None) or (s3_rel and azure_rel):
+            return None
+        if s3_rel:
+            return S3_RELATION
+        if azure_rel:
+            return AZURE_RELATION
 
     def _generate_backup_list_output(self, backups: Dict[str, Any]) -> str:
         """Generates a list of backups in a formatted table.
@@ -526,9 +532,15 @@ class OpenSearchBackupBase(Object):
         """
         backup_list = []
         for id, backup in backups.items():
-            state = self.get_snapshot_status(backup["state"])
+            state = self.backup_manager.get_snapshot_status(backup["state"])
             backup_list.append((id, state.value))
-        return self._format_backup_list(backup_list)
+
+        output = ["{:<20s} | {:s}".format(" backup-id", "backup-status")]
+        output.append("-" * len(output[0]))
+
+        for backup_id, backup_status in backup_list:
+            output.append("{:<20s} | {:s}".format(backup_id, backup_status))
+        return "\n".join(output)
 
 
 class OpenSearchNonOrchestratorClusterBackup(OpenSearchBackupBase):
@@ -647,11 +659,6 @@ class OpenSearchS3Backup(OpenSearchBackupBase):
         if self.charm.opensearch_peer_cm.is_provider(typ="main"):
             self.charm.peer_cluster_provider.refresh_relation_data(event)
 
-    @override
-    def _on_backup_action(self, event: ActionEvent) -> None:
-        """Just overloads the base method, as we process each action in this class."""
-        pass
-
     @property
     def _plugin_status(self):
         return self.charm.plugin_manager.get_plugin_status(OpenSearchS3Plugin)
@@ -660,7 +667,7 @@ class OpenSearchS3Backup(OpenSearchBackupBase):
         """Returns the list of available backups to the user."""
         backups = {}
         try:
-            backups = self._list_backups(S3_REPOSITORY)
+            backups = self.backup_manager.list_backups()
         except OpenSearchError as e:
             event.fail(
                 f"List backups action failed - {str(e)} - check the application logs for the full stack trace."
@@ -712,7 +719,7 @@ class OpenSearchS3Backup(OpenSearchBackupBase):
         # Finally, we can state it is all good
         return True
 
-    def _close_indices_if_needed(self, backup_id: int) -> Set[str]:
+    def _close_indices_if_needed(self, backup_id: str) -> Set[str]:
         """Closes indices that will be restored.
 
         Returns a set of indices that were closed or raises an exception:
@@ -722,7 +729,7 @@ class OpenSearchS3Backup(OpenSearchBackupBase):
             OpenSearchHttpError
             OpenSearchRestoreIndexClosingError
         """
-        backup_indices = self._list_backups(S3_REPOSITORY).get(backup_id, {}).get("indices", {})
+        backup_indices = self.backup_manager.list_backups().get(backup_id, {}).get("indices", {})
         indices_to_close = set()
         for index, state in ClusterState.indices(self.charm.opensearch).items():
             if (
@@ -741,7 +748,7 @@ class OpenSearchS3Backup(OpenSearchBackupBase):
 
     def _restore(self, backup_id: str) -> Dict[str, Any]:
         """Runs the restore and processes the response."""
-        backup_indices = self._list_backups(S3_REPOSITORY).get(backup_id, {}).get("indices", {})
+        backup_indices = self.backup_manager.list_backups().get(backup_id, {}).get("indices", {})
         output = self.charm.opensearch.request(
             "POST",
             f"_snapshot/{S3_REPOSITORY}/{backup_id.lower()}/_restore?wait_for_completion=true",
@@ -769,11 +776,11 @@ class OpenSearchS3Backup(OpenSearchBackupBase):
 
     def _is_backup_available_for_restore(self, backup_id: str) -> bool:
         """Checks if the backup_id exists and is ready for a restore."""
-        backups = self._list_backups(S3_REPOSITORY)
+        backups = self.backup_manager.list_backups()
         try:
             return (
                 backup_id in backups.keys()
-                and self.get_snapshot_status(backups[backup_id]["state"])
+                and self.backup_manager.get_snapshot_status(backups[backup_id]["state"])
                 == BackupServiceState.SUCCESS
             )
         except OpenSearchListBackupError:
@@ -788,7 +795,7 @@ class OpenSearchS3Backup(OpenSearchBackupBase):
             event.fail("Failed: backup service is not configured yet")
             return
         try:
-            if not self._is_restore_complete():
+            if not self.backup_manager.is_restore_complete():
                 event.fail("Failed: previous restore is still in progress")
                 return
         except OpenSearchRestoreCheckError:
@@ -836,7 +843,9 @@ class OpenSearchS3Backup(OpenSearchBackupBase):
 
         try:
             msg = (
-                "Restore is complete" if self._is_restore_complete() else "Restore in progress..."
+                "Restore is complete"
+                if self.backup_manager.is_restore_complete()
+                else "Restore in progress..."
             )
         except OpenSearchRestoreCheckError:
             event.fail("Failed: error connecting to the cluster")
@@ -903,7 +912,7 @@ class OpenSearchS3Backup(OpenSearchBackupBase):
         if status != BackupServiceState.SUCCESS:
             logger.warning(f"Failed: repo status is {status}")
             return False
-        return not self.is_backup_in_progress()
+        return not self.backup_manager.is_backup_in_progress()
 
     def _on_backup_credentials_changed(self, event: EventBase) -> None:  # noqa: C901
         """Calls the plugin manager config handler.
@@ -1017,7 +1026,7 @@ class OpenSearchS3Backup(OpenSearchBackupBase):
             return
 
         self.charm.status.set(MaintenanceStatus(BackupInDisabling))
-        snapshot_status = self._check_snapshot_status()
+        snapshot_status = self.backup_manager.check_snapshot_status()
         if snapshot_status in [
             BackupServiceState.SNAPSHOT_IN_PROGRESS,
         ]:
@@ -1080,18 +1089,6 @@ class OpenSearchS3Backup(OpenSearchBackupBase):
         except OpenSearchHttpError:
             return BackupServiceState.RESPONSE_FAILED_NETWORK
 
-    def _check_snapshot_status(self) -> BackupServiceState:
-        try:
-            response = self.charm.opensearch.request(
-                "GET",
-                "/_snapshot/_status",
-                retries=6,
-                timeout=10,
-            )
-            return self.get_snapshot_status(response)
-        except OpenSearchHttpError:
-            return BackupServiceState.RESPONSE_FAILED_NETWORK
-
     def _register_snapshot_repo(self) -> BackupServiceState:
         """Registers the snapshot repo in the cluster."""
         try:
@@ -1115,7 +1112,9 @@ class OpenSearchS3Backup(OpenSearchBackupBase):
         self, response: dict[str, Any] | None
     ) -> BackupServiceState:
         """Returns the response status in a Enum."""
-        if (status := super().get_service_status(response)) == BackupServiceState.SUCCESS:
+        if (
+            status := self.backup_manager.get_service_status(response)
+        ) == BackupServiceState.SUCCESS:
             return BackupServiceState.SUCCESS
         if (
             "bucket" in self.s3_client.get_s3_connection_info()
@@ -1163,11 +1162,6 @@ class OpenSearchAzureBackup(OpenSearchBackupBase):
         if self.charm.opensearch_peer_cm.is_provider(typ="main"):
             self.charm.peer_cluster_provider.refresh_relation_data(event)
 
-    @override
-    def _on_backup_action(self, event: ActionEvent) -> None:
-        """Just overloads the base method, as we process each action in this class."""
-        pass
-
     @property
     def _plugin_status(self):
         return self.charm.plugin_manager.get_plugin_status(OpenSearchAzurePlugin)
@@ -1176,7 +1170,7 @@ class OpenSearchAzureBackup(OpenSearchBackupBase):
         """Returns the list of available backups to the user."""
         backups = {}
         try:
-            backups = self._list_backups(AZURE_REPOSITORY)
+            backups = self.backup_manager.list_backups()
         except OpenSearchError as e:
             event.fail(
                 f"List backups action failed - {str(e)} - check the application logs for the full stack trace."
@@ -1228,7 +1222,7 @@ class OpenSearchAzureBackup(OpenSearchBackupBase):
         # Finally, we can state it is all good
         return True
 
-    def _close_indices_if_needed(self, backup_id: int) -> Set[str]:
+    def _close_indices_if_needed(self, backup_id: str) -> Set[str]:
         """Closes indices that will be restored.
 
         Returns a set of indices that were closed or raises an exception:
@@ -1238,7 +1232,7 @@ class OpenSearchAzureBackup(OpenSearchBackupBase):
             OpenSearchHttpError
             OpenSearchRestoreIndexClosingError
         """
-        backup_indices = self._list_backups(AZURE_REPOSITORY).get(backup_id, {}).get("indices", {})
+        backup_indices = self.backup_manager.list_backups().get(backup_id, {}).get("indices", {})
         indices_to_close = set()
         for index, state in ClusterState.indices(self.charm.opensearch).items():
             if (
@@ -1255,9 +1249,9 @@ class OpenSearchAzureBackup(OpenSearchBackupBase):
             raise OpenSearchRestoreIndexClosingError(e)
         return indices_to_close
 
-    def _restore(self, backup_id: int) -> Dict[str, Any]:
+    def _restore(self, backup_id: str) -> Dict[str, Any]:
         """Runs the restore and processes the response."""
-        backup_indices = self._list_backups(AZURE_REPOSITORY).get(backup_id, {}).get("indices", {})
+        backup_indices = self.backup_manager.list_backups().get(backup_id, {}).get("indices", {})
         output = self.charm.opensearch.request(
             "POST",
             f"_snapshot/{AZURE_REPOSITORY}/{backup_id.lower()}/_restore?wait_for_completion=true",
@@ -1285,11 +1279,11 @@ class OpenSearchAzureBackup(OpenSearchBackupBase):
 
     def _is_backup_available_for_restore(self, backup_id: str) -> bool:
         """Checks if the backup_id exists and is ready for a restore."""
-        backups = self._list_backups(AZURE_REPOSITORY)
+        backups = self.backup_manager.list_backups()
         try:
             return (
                 backup_id in backups.keys()
-                and self.get_snapshot_status(backups[backup_id]["state"])
+                and self.backup_manager.get_snapshot_status(backups[backup_id]["state"])
                 == BackupServiceState.SUCCESS
             )
         except OpenSearchListBackupError:
@@ -1304,7 +1298,7 @@ class OpenSearchAzureBackup(OpenSearchBackupBase):
             event.fail("Failed: backup service is not configured yet")
             return
         try:
-            if not self._is_restore_complete():
+            if not self.backup_manager.is_restore_complete():
                 event.fail("Failed: previous restore is still in progress")
                 return
         except OpenSearchRestoreCheckError:
@@ -1352,7 +1346,9 @@ class OpenSearchAzureBackup(OpenSearchBackupBase):
 
         try:
             msg = (
-                "Restore is complete" if self._is_restore_complete() else "Restore in progress..."
+                "Restore is complete"
+                if self.backup_manager.is_restore_complete()
+                else "Restore in progress..."
             )
         except OpenSearchRestoreCheckError:
             event.fail("Failed: error connecting to the cluster")
@@ -1419,7 +1415,7 @@ class OpenSearchAzureBackup(OpenSearchBackupBase):
         if status != BackupServiceState.SUCCESS:
             logger.warning(f"Failed: repo status is {status}")
             return False
-        return not self.is_backup_in_progress()
+        return not self.backup_manager.is_backup_in_progress()
 
     def _on_azure_credentials_changed(self, event: EventBase) -> None:  # noqa: C901
         """Calls the plugin manager config handler.
@@ -1533,7 +1529,7 @@ class OpenSearchAzureBackup(OpenSearchBackupBase):
             return
 
         self.charm.status.set(MaintenanceStatus(BackupInDisabling))
-        snapshot_status = self._check_snapshot_status()
+        snapshot_status = self.backup_manager.check_snapshot_status()
         if snapshot_status in [
             BackupServiceState.SNAPSHOT_IN_PROGRESS,
         ]:
@@ -1596,18 +1592,6 @@ class OpenSearchAzureBackup(OpenSearchBackupBase):
         except OpenSearchHttpError:
             return BackupServiceState.RESPONSE_FAILED_NETWORK
 
-    def _check_snapshot_status(self) -> BackupServiceState:
-        try:
-            response = self.charm.opensearch.request(
-                "GET",
-                "/_snapshot/_status",
-                retries=6,
-                timeout=10,
-            )
-            return self.get_snapshot_status(response)
-        except OpenSearchHttpError:
-            return BackupServiceState.RESPONSE_FAILED_NETWORK
-
     def _register_snapshot_repo(self) -> BackupServiceState:
         """Registers the snapshot repo in the cluster."""
         try:
@@ -1633,7 +1617,9 @@ class OpenSearchAzureBackup(OpenSearchBackupBase):
         self, response: dict[str, Any] | None
     ) -> BackupServiceState:
         """Returns the response status in a Enum."""
-        if (status := super().get_service_status(response)) == BackupServiceState.SUCCESS:
+        if (
+            status := self.backup_manager.get_service_status(response)
+        ) == BackupServiceState.SUCCESS:
             return BackupServiceState.SUCCESS
         if (
             "container" in self.azure_client.get_azure_connection_info()

--- a/lib/charms/opensearch/v0/opensearch_backups.py
+++ b/lib/charms/opensearch/v0/opensearch_backups.py
@@ -95,9 +95,7 @@ from charms.opensearch.v0.constants_charm import (
     RestoreInProgress,
 )
 from charms.opensearch.v0.constants_secrets import (
-    AZURE_CREDENTIALS,
     AZURE_PEER_SECRET_KEYS,
-    S3_CREDENTIALS,
     S3_PEER_SECRET_KEYS,
 )
 from charms.opensearch.v0.helper_cluster import ClusterState, IndexStateEnum
@@ -108,7 +106,6 @@ from charms.opensearch.v0.opensearch_exceptions import (
     OpenSearchHttpError,
     OpenSearchNotFullyReadyError,
 )
-from charms.opensearch.v0.opensearch_internal_data import Scope
 from charms.opensearch.v0.opensearch_keystore import OpenSearchKeystoreNotReadyError
 from charms.opensearch.v0.opensearch_locking import OpenSearchNodeLock
 from charms.opensearch.v0.opensearch_plugins import (
@@ -593,7 +590,7 @@ class OpenSearchNonOrchestratorClusterBackup(OpenSearchBackupBase):
 
         for plugin in plugins:
             # Early check to avoid trying to configure both with empty credentials
-            if not plugin.data.credentials.secret_key:
+            if not plugin.data:
                 continue
             try:
                 if not self.charm.plugin_manager.is_ready_for_api():
@@ -1614,6 +1611,8 @@ class OpenSearchAzureBackup(OpenSearchBackupBase):
     def _register_snapshot_repo(self) -> BackupServiceState:
         """Registers the snapshot repo in the cluster."""
         try:
+            if not self.plugin.data:
+                return BackupServiceState.REPO_ERR_UNKNOWN
             to_include = {"container"}
             settings = {k: self.plugin.data.dict()[k] for k in to_include}
             response = self.charm.opensearch.request(

--- a/lib/charms/opensearch/v0/opensearch_backups.py
+++ b/lib/charms/opensearch/v0/opensearch_backups.py
@@ -659,6 +659,11 @@ class OpenSearchS3Backup(OpenSearchBackupBase):
         if self.charm.opensearch_peer_cm.is_provider(typ="main"):
             self.charm.peer_cluster_provider.refresh_relation_data(event)
 
+    @override
+    def _on_backup_action(self, event: ActionEvent) -> None:
+        """Just overloads the base method, as we process each action in this class."""
+        pass
+
     @property
     def _plugin_status(self):
         return self.charm.plugin_manager.get_plugin_status(OpenSearchS3Plugin)
@@ -1161,6 +1166,11 @@ class OpenSearchAzureBackup(OpenSearchBackupBase):
         """
         if self.charm.opensearch_peer_cm.is_provider(typ="main"):
             self.charm.peer_cluster_provider.refresh_relation_data(event)
+
+    @override
+    def _on_backup_action(self, event: ActionEvent) -> None:
+        """Just overloads the base method, as we process each action in this class."""
+        pass
 
     @property
     def _plugin_status(self):

--- a/lib/charms/opensearch/v0/opensearch_backups.py
+++ b/lib/charms/opensearch/v0/opensearch_backups.py
@@ -12,9 +12,9 @@ and configuration. It contains all the components for both small and large deplo
 #
 ###########################################################################################
 
-The OpenSearchBackup class listens to both relation changes from S3_RELATION and API calls
-and responses. The OpenSearchBackupPlugin holds the configuration info. The classes together
-manages the events related to backup/restore cycles.
+The OpenSearchBackup class listens to both relation changes from [AZURE_RELATION | S3_RELATION]
+and API calls and responses. The corresponding OpenSearchS3Plugin or OpenSearchAzurePlugin holds
+the configuration info. The classes together manage the events related to backup/restore cycles.
 
 The removal of backup only reverses step the API calls, to avoid accidentally deleting the
 existing snapshots in the S3 repo.
@@ -76,23 +76,30 @@ import logging
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
 
+from charms.data_platform_libs.v0.object_storage import AzureStorageRequires
 from charms.data_platform_libs.v0.s3 import S3Requirer
 from charms.opensearch.v0.constants_charm import (
+    AZURE_RELATION,
     OPENSEARCH_BACKUP_ID_FORMAT,
     S3_RELATION,
     BackupConfigureStart,
     BackupDeferRelBrokenAsInProgress,
     BackupInDisabling,
+    BackupRelDataIncomplete,
+    BackupRelMissing,
+    BackupRelShouldNotExist,
     BackupSetupFailed,
     BackupSetupStart,
     PeerClusterRelationName,
     PluginConfigError,
     RestoreInProgress,
-    S3RelDataIncomplete,
-    S3RelMissing,
-    S3RelShouldNotExist,
 )
-from charms.opensearch.v0.constants_secrets import S3_PEER_SECRET_KEYS
+from charms.opensearch.v0.constants_secrets import (
+    AZURE_CREDENTIALS,
+    AZURE_PEER_SECRET_KEYS,
+    S3_CREDENTIALS,
+    S3_PEER_SECRET_KEYS,
+)
 from charms.opensearch.v0.helper_cluster import ClusterState, IndexStateEnum
 from charms.opensearch.v0.helper_enums import BaseStrEnum
 from charms.opensearch.v0.models import DeploymentType
@@ -101,19 +108,24 @@ from charms.opensearch.v0.opensearch_exceptions import (
     OpenSearchHttpError,
     OpenSearchNotFullyReadyError,
 )
+from charms.opensearch.v0.opensearch_internal_data import Scope
 from charms.opensearch.v0.opensearch_keystore import OpenSearchKeystoreNotReadyError
 from charms.opensearch.v0.opensearch_locking import OpenSearchNodeLock
 from charms.opensearch.v0.opensearch_plugins import (
-    OpenSearchBackupPlugin,
+    OpenSearchAzurePlugin,
     OpenSearchPluginMissingConfigError,
     OpenSearchPluginMissingDepsError,
+    OpenSearchS3Plugin,
     PluginState,
 )
-from ops.charm import ActionEvent, RelationEvent, SecretEvent
-from ops.framework import Object
-from ops.model import (
+from ops import (
+    ActionEvent,
     BlockedStatus,
+    EventBase,
     MaintenanceStatus,
+    Object,
+    RelationEvent,
+    SecretEvent,
     SecretNotFoundError,
     WaitingStatus,
 )
@@ -137,6 +149,7 @@ if TYPE_CHECKING:
 
 # OpenSearch Backups
 S3_REPOSITORY = "s3-repository"
+AZURE_REPOSITORY = "azure-repository"
 
 
 INDICES_TO_EXCLUDE_AT_RESTORE = {
@@ -145,7 +158,7 @@ INDICES_TO_EXCLUDE_AT_RESTORE = {
     OpenSearchNodeLock.OPENSEARCH_INDEX,
 }
 
-REPO_NOT_CREATED_ERR = "repository type [s3] does not exist"
+REPO_NOT_CREATED_ERR = "repository type does not exist"
 REPO_NOT_ACCESS_ERR = "is not accessible"
 REPO_CREATING_ERR = "Could not determine repository generation from root blobs"
 RESTORE_OPEN_INDEX_WITH_SAME_NAME = "because an open index with same name already exists"
@@ -171,6 +184,14 @@ class OpenSearchRestoreIndexClosingError(OpenSearchRestoreError):
     """Exception thrown when restore fails to close indices."""
 
 
+# TODO integrate into the class
+class BackupRepository(BaseStrEnum):
+    """Possible repositories for backups."""
+
+    S3 = "s3-repository"
+    AZURE = "azure-repository"
+
+
 class BackupServiceState(BaseStrEnum):
     """Enum for the states possible once plugin is enabled."""
 
@@ -182,7 +203,7 @@ class BackupServiceState(BaseStrEnum):
     REPO_CREATION_ERR = "Failed creating repository"
     REPO_ERR_UNKNOWN = "Repository exception: unknown"
     REPO_MISSING = "repository is missing from request"
-    REPO_S3_UNREACHABLE = "repository s3 is unreachable"
+    REPO_UNREACHABLE = "backup repository is unreachable"
     ILLEGAL_ARGUMENT = "request contained wrong argument"
     SNAPSHOT_MISSING = "snapshot not found"
     SNAPSHOT_RESTORE_ERROR_INDEX_NOT_CLOSED = (
@@ -195,6 +216,15 @@ class BackupServiceState(BaseStrEnum):
     SNAPSHOT_FAILED_UNKNOWN = "snapshot failed for unknown reason"
 
 
+# TODO: keep all API calls in this class
+class OpenSearchBackupAPI:
+    """API related requests service for Opensearch"""
+
+    def __init__(self, charm: "OpenSearchBaseCharm", repository: BackupRepository = None):
+        self._charm = charm
+        self.repository = repository
+
+
 class OpenSearchBackupBase(Object):
     """Works as parent for all backup classes.
 
@@ -204,8 +234,8 @@ class OpenSearchBackupBase(Object):
     def __init__(self, charm: "OpenSearchBaseCharm", relation_name: str = PeerClusterRelationName):
         """Initializes the opensearch backup base.
 
-        This class will not hold a s3_client object, as it is not intended to really
-        manage the relation besides waiting for the deployment description.
+        This class will not hold a s3_client or object_storage object, as it is not intended to
+        really manage the relation besides waiting for the deployment description.
         """
         super().__init__(charm, relation_name)
         self.charm = charm
@@ -214,37 +244,61 @@ class OpenSearchBackupBase(Object):
         self.framework.observe(self.charm.on.secret_changed, self._on_secret_changed)
         self.framework.observe(self.charm.on.secret_remove, self._on_secret_changed)
 
-        for event in [
-            self.charm.on[S3_RELATION].relation_created,
-            self.charm.on[S3_RELATION].relation_joined,
-            self.charm.on[S3_RELATION].relation_changed,
-            self.charm.on[S3_RELATION].relation_departed,
-            self.charm.on[S3_RELATION].relation_broken,
-        ]:
-            self.framework.observe(event, self._on_s3_relation_event)
+        for relation in (S3_RELATION, AZURE_RELATION):
+            for event in [
+                self.charm.on[relation].relation_joined,
+                self.charm.on[relation].relation_changed,
+                self.charm.on[relation].relation_departed,
+                self.charm.on[relation].relation_broken,
+            ]:
+                self.framework.observe(event, self._on_backup_relation_event)
+            self.framework.observe(
+                self.charm.on[relation].relation_created, self._on_backup_relation_created
+            )
+
         for event in [
             self.charm.on.create_backup_action,
             self.charm.on.list_backups_action,
             self.charm.on.restore_action,
         ]:
-            self.framework.observe(event, self._on_s3_base_action)
+            self.framework.observe(event, self._on_backup_action)
 
     def _on_secret_changed(self, event: SecretEvent) -> None:
         pass
 
-    def _on_s3_relation_event(self, event: RelationEvent) -> None:
-        """Defers the s3 relation events."""
-        logger.info("Deployment description not yet available, deferring s3 relation event")
+    def _on_backup_relation_event(self, event: RelationEvent) -> None:
+        """Defers the backup relation events."""
+        logger.info("Deployment description not yet available, deferring backup relation event")
         event.defer()
 
-    def _on_s3_relation_broken(self, event: RelationEvent) -> None:
-        """Defers the s3 relation broken events."""
-        pass
+    def _on_backup_relation_created(self, _: RelationEvent) -> None:
+        if self.charm.upgrade_in_progress:
+            logger.warning(
+                "Modifying relations during an upgrade is not supported. The charm may be in a broken, unrecoverable state"
+            )
 
-    def _on_s3_base_action(self, event: ActionEvent) -> None:
+    def _on_backup_relation_broken(self, event: RelationEvent) -> None:
+        """Defers the backup relation broken events."""
+        raise NotImplementedError
+
+    def _on_backup_action(self, event: ActionEvent) -> None:
         """No deployment description yet, fail any actions."""
         logger.info("Deployment description not yet available, failing actions.")
         event.fail("Failed: deployment description not yet available")
+
+    @property
+    def active_relation(self) -> str | None:
+        """Check which relation is active and return it's value."""
+        s3_rel = self.model.get_relation(S3_RELATION)
+        azure_rel = self.model.get_relation(AZURE_RELATION)
+
+        # XNOR for the relations. Both existing or both not existing is an exit condition.
+        if (s3_rel is None and azure_rel is None) or (s3_rel and azure_rel):
+            return None
+        if s3_rel:
+            return S3_RELATION
+        if azure_rel:
+            return AZURE_RELATION
 
     def is_restore_in_progress(self) -> bool:
         """Checks if the restore is currently in progress."""
@@ -285,8 +339,30 @@ class OpenSearchBackupBase(Object):
                     return BackupServiceState.RESTORE_IN_PROGRESS
         return BackupServiceState.SUCCESS
 
+    def _is_restore_complete(self) -> bool:
+        """Checks if the restore is finished.
+
+        Essentially, check for each index shard: for all type=SNAPSHOT and stage=DONE, return True.
+        """
+        try:
+            indices_status = self.charm.opensearch.request(
+                "GET",
+                "/_recovery?human",
+                retries=6,
+                timeout=10,
+            )
+        except OpenSearchHttpError:
+            raise OpenSearchRestoreCheckError("_is_restore_complete: failed to get indices status")
+        if not indices_status:
+            # No restore has happened. Raise an exception
+            raise OpenSearchRestoreCheckError("_is_restore_complete: failed to get indices status")
+        return not self.is_restore_in_progress()
+
     def is_backup_in_progress(self) -> bool:
         """Returns True if backup is in progress, False otherwise.
+
+        This method assumes that a relation already exists, so a check for active_relation != None
+        should generally be done.
 
         We filter the _query_backup_status() and seek for the following states:
         - SNAPSHOT_IN_PROGRESS
@@ -301,8 +377,11 @@ class OpenSearchBackupBase(Object):
         return False
 
     def _query_backup_status(self, backup_id: Optional[str] = None) -> BackupServiceState:
+        if not self.active_relation:
+            return BackupServiceState.REPO_NOT_CREATED
+        repository = S3_REPOSITORY if self.active_relation == S3_RELATION else AZURE_REPOSITORY
         try:
-            target = f"_snapshot/{S3_REPOSITORY}/"
+            target = f"_snapshot/{repository}/"
             target += f"{backup_id.lower()}" if backup_id else "_all"
             output = self.charm.opensearch.request(
                 "GET",
@@ -362,7 +441,7 @@ class OpenSearchBackupBase(Object):
             case "repository_missing_exception":
                 return BackupServiceState.REPO_MISSING
             case "repository_verification_exception" if REPO_NOT_ACCESS_ERR in reason:
-                return BackupServiceState.REPO_S3_UNREACHABLE
+                return BackupServiceState.REPO_UNREACHABLE
             case "illegal_argument_exception":
                 return BackupServiceState.ILLEGAL_ARGUMENT
             case "snapshot_missing_exception":
@@ -418,123 +497,18 @@ class OpenSearchBackupBase(Object):
         """Checks if the backup system is idle."""
         return self.is_backup_in_progress() or self.is_restore_in_progress()
 
-
-class OpenSearchNonOrchestratorClusterBackup(OpenSearchBackupBase):
-    """Simpler implementation of backup relation for non-orchestrator clusters.
-
-    In a nutshell, non-orchestrator clusters should receive the backup information via
-    peer-cluster relation instead; and must fail any action or major s3-relation events.
-
-    This class means we are sure this juju app is a non-orchestrator. In this case, we must
-    manage the update status correctly if the user ever tries to relate the s3-credentials.
-    """
-
-    def __init__(self, charm: "OpenSearchBaseCharm", relation_name: str = PeerClusterRelationName):
-        """Manager of OpenSearch backup relations."""
-        super().__init__(charm, relation_name)
-        self.framework.observe(
-            self.charm.on[S3_RELATION].relation_broken, self._on_s3_relation_broken
-        )
-        for event in [
-            charm.on[PeerClusterRelationName].relation_joined,
-            charm.on[PeerClusterRelationName].relation_changed,
-            charm.on[PeerClusterRelationName].relation_broken,
-        ]:
-            # We need to keep track of the peer-cluster relation
-            # A unit-level secret will not trigger secret changes, nor an app-level secret
-            # change will trigger an update in its leader.
-
-            # Listening to the peer cluster relation is another alternative:
-            # Effectively it will call the common method that both _on_secret_changed and
-            # _on_peer_cluster_relation_event uses to update the keystore.
-            self.framework.observe(event, self._on_peer_cluster_relation_event)
-
-    @override
-    def _on_secret_changed(self, event: SecretEvent) -> None:
-        """Processes the secret changes."""
-        try:
-            if not any([k in S3_PEER_SECRET_KEYS for k in event.secret.get_content().keys()]):
-                logger.info(
-                    "Secret not relevant for backups, abandoning secret id %s", event.secret.id
-                )
-                return
-        except SecretNotFoundError:
-            logger.warning("Secret not found, abandoning secret event")
-            return
-        event.secret.get_content(refresh=True)
-
-        # s3_credentials = self.charm.opensearch_peer_cm.rel_data().credentials.s3
-
-        # if not s3_credentials:
-        #     logger.warning(f"Secret {S3_CREDENTIALS} found but missing s3-credentials set.")
-        #     return
-        self._on_peer_cluster_relation_event(event)
-
-    def _on_peer_cluster_relation_event(self, event: RelationEvent) -> None:
-        """Processes the peer-cluster relation events."""
-        try:
-            self.charm.plugin_manager.apply_config(
-                OpenSearchBackupPlugin(
-                    charm=self.charm,
-                ).config(),
-            )
-        except (OpenSearchKeystoreNotReadyError, OpenSearchPluginMissingConfigError):
-            logger.info("Keystore not ready yet, we wait for another peer cluster.")
-
-    @override
-    def _on_s3_relation_event(self, event: RelationEvent) -> None:
-        """Processes the non-orchestrator cluster events."""
-        if self.charm.unit.is_leader():
-            self.charm.status.set(BlockedStatus(S3RelShouldNotExist), app=True)
-        logger.info("Non-orchestrator cluster, abandon s3 relation event")
-
-    @override
-    def _on_s3_relation_broken(self, event: RelationEvent) -> None:
-        """Processes the non-orchestrator cluster events."""
-        self.charm.status.clear(S3RelMissing)
-        if self.charm.unit.is_leader():
-            self.charm.status.clear(S3RelShouldNotExist, app=True)
-        logger.info("Non-orchestrator cluster, abandon s3 relation event")
-
-
-class OpenSearchBackup(OpenSearchBackupBase):
-    """Implements backup relation and API management."""
-
-    def __init__(self, charm: "OpenSearchBaseCharm", relation_name: str = S3_RELATION):
-        """Manager of OpenSearch backup relations."""
-        super().__init__(charm, relation_name)
-        self.s3_client = S3Requirer(self.charm, relation_name)
-        self.plugin = OpenSearchBackupPlugin(self.charm)
-
-        # s3 relation handles the config options for s3 backups
-        self.framework.observe(self.charm.on[S3_RELATION].relation_created, self._on_s3_created)
-        self.framework.observe(
-            self.charm.on[S3_RELATION].relation_broken, self._on_s3_relation_broken
-        )
-        self.framework.observe(
-            self.s3_client.on.credentials_changed, self._on_s3_credentials_changed
-        )
-        self.framework.observe(self.charm.on.create_backup_action, self._on_create_backup_action)
-        self.framework.observe(self.charm.on.list_backups_action, self._on_list_backups_action)
-        self.framework.observe(self.charm.on.restore_action, self._on_restore_backup_action)
-
-    @override
-    def _on_s3_relation_event(self, event: RelationEvent) -> None:
-        """Overrides the parent method to process the s3 relation events, as we use s3_client.
-
-        We run the peer cluster orchestrator's refresh on every new s3 information.
-        """
-        if self.charm.opensearch_peer_cm.is_provider(typ="main"):
-            self.charm.peer_cluster_provider.refresh_relation_data(event)
-
-    @override
-    def _on_s3_base_action(self, event: ActionEvent) -> None:
-        """Just overloads the base method, as we process each action in this class."""
-        pass
-
-    @property
-    def _plugin_status(self):
-        return self.charm.plugin_manager.get_plugin_status(OpenSearchBackupPlugin)
+    def _list_backups(self, repository: str) -> Dict[int, str]:
+        """Returns a mapping of snapshot ids / state."""
+        # Using the original request method, as we want to raise an http exception if we
+        # cannot get the snapshot list.
+        response = self.charm.opensearch.request("GET", f"_snapshot/{repository}/_all")
+        return {
+            snapshot["snapshot"].upper(): {
+                "state": snapshot["state"],
+                "indices": snapshot.get("indices", []),
+            }
+            for snapshot in response.get("snapshots", [])
+        }
 
     def _format_backup_list(self, backups: List[Tuple[Any]]) -> str:
         """Formats provided list of backups as a table."""
@@ -559,11 +533,137 @@ class OpenSearchBackup(OpenSearchBackupBase):
             backup_list.append((id, state.value))
         return self._format_backup_list(backup_list)
 
+
+class OpenSearchNonOrchestratorClusterBackup(OpenSearchBackupBase):
+    """Simpler implementation of backup relation for non-orchestrator clusters.
+
+    In a nutshell, non-orchestrator clusters should receive the backup information via
+    peer-cluster relation instead; and must fail any action or major backup relation events.
+
+    This class means we are sure this juju app is a non-orchestrator. In this case, we must
+    manage the update status correctly if the user ever tries to relate the backup credentials.
+    """
+
+    def __init__(self, charm: "OpenSearchBaseCharm", relation_name: str = PeerClusterRelationName):
+        """Manager of OpenSearch backup relations."""
+        super().__init__(charm, relation_name)
+        for relation in [S3_RELATION, AZURE_RELATION]:
+            self.framework.observe(
+                self.charm.on[relation].relation_broken, self._on_backup_relation_broken
+            )
+
+        for event in [
+            charm.on[PeerClusterRelationName].relation_joined,
+            charm.on[PeerClusterRelationName].relation_changed,
+            charm.on[PeerClusterRelationName].relation_broken,
+        ]:
+            # We need to keep track of the peer-cluster relation
+            # A unit-level secret will not trigger secret changes, nor an app-level secret
+            # change will trigger an update in its leader.
+
+            # Listening to the peer cluster relation is another alternative:
+            # Effectively it will call the common method that both _on_secret_changed and
+            # _on_peer_cluster_relation_event uses to update the keystore.
+            self.framework.observe(event, self._on_peer_cluster_relation_event)
+
+    @override
+    def _on_secret_changed(self, event: SecretEvent) -> None:
+        """Processes the secret changes."""
+        try:
+            if not any(
+                [
+                    k in S3_PEER_SECRET_KEYS + AZURE_PEER_SECRET_KEYS
+                    for k in event.secret.get_content().keys()
+                ]
+            ):
+                logger.info(
+                    f"Secret not relevant for backups, abandoning secret id {event.secret.id}"
+                )
+                return
+        except SecretNotFoundError:
+            logger.warning("Secret not found, abandoning secret event")
+            return
+
+        event.secret.get_content(refresh=True)
+        self._on_peer_cluster_relation_event(event)
+
+    def _on_peer_cluster_relation_event(self, event):
+        """Processes the peer-cluster relation events."""
+        plugins = [OpenSearchS3Plugin(charm=self.charm), OpenSearchAzurePlugin(charm=self.charm)]
+
+        for plugin in plugins:
+            # Early check to avoid trying to configure both with empty credentials
+            if not plugin.data.credentials.secret_key:
+                continue
+            try:
+                if not self.charm.plugin_manager.is_ready_for_api():
+                    raise OpenSearchNotFullyReadyError()
+                self.charm.plugin_manager.apply_config(plugin.config())
+            except (OpenSearchKeystoreNotReadyError, OpenSearchNotFullyReadyError):
+                logger.info(f"{plugin.name}: not ready, we wait for another peer cluster.")
+            except OpenSearchPluginMissingConfigError as e:
+                logger.info(f"Missing configs for {plugin.name}: {e}")
+
+    @override
+    def _on_backup_relation_event(self, event: RelationEvent) -> None:
+        """Processes the non-orchestrator cluster events."""
+        if self.charm.unit.is_leader():
+            self.charm.status.set(BlockedStatus(BackupRelShouldNotExist), app=True)
+        logger.info("Non-orchestrator cluster, abandon relation event")
+
+    @override
+    def _on_backup_relation_broken(self, event: RelationEvent) -> None:
+        """Processes the non-orchestrator cluster events."""
+        self.charm.status.clear(BackupRelMissing)
+        self.charm.status.clear(BackupRelDataIncomplete)
+        if self.charm.unit.is_leader():
+            self.charm.status.clear(BackupRelShouldNotExist, app=True)
+        logger.info("Non-orchestrator cluster, abandon relation event")
+
+
+class OpenSearchS3Backup(OpenSearchBackupBase):
+    """Implements backup relation and API management."""
+
+    def __init__(self, charm: "OpenSearchBaseCharm", relation_name: str = S3_RELATION):
+        """Manager of OpenSearch backup relations."""
+        super().__init__(charm, relation_name)
+        self.s3_client = S3Requirer(self.charm, S3_RELATION)
+        self.plugin = OpenSearchS3Plugin(self.charm)
+
+        # relation handles the config options for backups
+        self.framework.observe(
+            self.charm.on[S3_RELATION].relation_broken, self._on_backup_relation_broken
+        )
+        self.framework.observe(
+            self.s3_client.on.credentials_changed, self._on_backup_credentials_changed
+        )
+        self.framework.observe(self.charm.on.create_backup_action, self._on_create_backup_action)
+        self.framework.observe(self.charm.on.list_backups_action, self._on_list_backups_action)
+        self.framework.observe(self.charm.on.restore_action, self._on_restore_backup_action)
+
+    @override
+    def _on_backup_relation_event(self, event: RelationEvent) -> None:
+        """Overrides the parent method to process the s3 relation events, as we use s3_client.
+
+        We run the peer cluster orchestrator's refresh on every new s3 information.
+        """
+        if self.charm.opensearch_peer_cm.is_provider(typ="main"):
+            self.charm.peer_cluster_provider.refresh_relation_data(event)
+
+    @override
+    def _on_backup_action(self, event: ActionEvent) -> None:
+        """Just overloads the base method, as we process each action in this class."""
+        pass
+
+    @property
+    def _plugin_status(self):
+        return self.charm.plugin_manager.get_plugin_status(OpenSearchS3Plugin)
+
     def _on_list_backups_action(self, event: ActionEvent) -> None:
         """Returns the list of available backups to the user."""
         backups = {}
         try:
-            backups = self._list_backups()
+            backups = self._list_backups(S3_REPOSITORY)
         except OpenSearchError as e:
             event.fail(
                 f"List backups action failed - {str(e)} - check the application logs for the full stack trace."
@@ -625,7 +725,7 @@ class OpenSearchBackup(OpenSearchBackupBase):
             OpenSearchHttpError
             OpenSearchRestoreIndexClosingError
         """
-        backup_indices = self._list_backups().get(backup_id, {}).get("indices", {})
+        backup_indices = self._list_backups(S3_REPOSITORY).get(backup_id, {}).get("indices", {})
         indices_to_close = set()
         for index, state in ClusterState.indices(self.charm.opensearch).items():
             if (
@@ -644,7 +744,7 @@ class OpenSearchBackup(OpenSearchBackupBase):
 
     def _restore(self, backup_id: str) -> Dict[str, Any]:
         """Runs the restore and processes the response."""
-        backup_indices = self._list_backups().get(backup_id, {}).get("indices", {})
+        backup_indices = self._list_backups(S3_REPOSITORY).get(backup_id, {}).get("indices", {})
         output = self.charm.opensearch.request(
             "POST",
             f"_snapshot/{S3_REPOSITORY}/{backup_id.lower()}/_restore?wait_for_completion=true",
@@ -670,28 +770,9 @@ class OpenSearchBackup(OpenSearchBackupBase):
 
         return output["snapshot"]
 
-    def _is_restore_complete(self) -> bool:
-        """Checks if the restore is finished.
-
-        Essentially, check for each index shard: for all type=SNAPSHOT and stage=DONE, return True.
-        """
-        try:
-            indices_status = self.charm.opensearch.request(
-                "GET",
-                "/_recovery?human",
-                retries=6,
-                timeout=10,
-            )
-        except OpenSearchHttpError:
-            raise OpenSearchRestoreCheckError("_is_restore_complete: failed to get indices status")
-        if not indices_status:
-            # No restore has happened. Raise an exception
-            raise OpenSearchRestoreCheckError("_is_restore_complete: failed to get indices status")
-        return not self.is_restore_in_progress()
-
     def _is_backup_available_for_restore(self, backup_id: str) -> bool:
         """Checks if the backup_id exists and is ready for a restore."""
-        backups = self._list_backups()
+        backups = self._list_backups(S3_REPOSITORY)
         try:
             return (
                 backup_id in backups.keys()
@@ -827,20 +908,7 @@ class OpenSearchBackup(OpenSearchBackupBase):
             return False
         return not self.is_backup_in_progress()
 
-    def _list_backups(self) -> Dict[int, str]:
-        """Returns a mapping of snapshot ids / state."""
-        # Using the original request method, as we want to raise an http exception if we
-        # cannot get the snapshot list.
-        response = self.charm.opensearch.request("GET", f"_snapshot/{S3_REPOSITORY}/_all")
-        return {
-            snapshot["snapshot"].upper(): {
-                "state": snapshot["state"],
-                "indices": snapshot.get("indices", []),
-            }
-            for snapshot in response.get("snapshots", [])
-        }
-
-    def _on_s3_credentials_changed(self, event: RelationEvent) -> None:  # noqa: C901
+    def _on_backup_credentials_changed(self, event: EventBase) -> None:  # noqa: C901
         """Calls the plugin manager config handler.
 
         This method will iterate over the s3 relation and check:
@@ -867,7 +935,7 @@ class OpenSearchBackup(OpenSearchBackupBase):
             event.defer()
             return
         except (OpenSearchPluginMissingConfigError, OpenSearchPluginMissingDepsError) as e:
-            self.charm.status.set(BlockedStatus(S3RelDataIncomplete))
+            self.charm.status.set(BlockedStatus(BackupRelDataIncomplete))
             logger.error(e)
             return
         except OpenSearchError as e:
@@ -889,7 +957,7 @@ class OpenSearchBackup(OpenSearchBackupBase):
             # Plugin is configured locally for this unit. Now the leader proceed.
             self.charm.status.clear(PluginConfigError)
             self.charm.status.clear(BackupSetupStart)
-            self.charm.status.clear(S3RelDataIncomplete)
+            self.charm.status.clear(BackupRelDataIncomplete)
             return
 
         # Leader configures this plugin
@@ -899,7 +967,7 @@ class OpenSearchBackup(OpenSearchBackupBase):
             # Finish here and wait for the user to reconfigure it and retrigger a new event
             event.defer()
             return
-        self.charm.status.clear(S3RelDataIncomplete)
+        self.charm.status.clear(BackupRelDataIncomplete)
         self.charm.status.clear(PluginConfigError)
         self.charm.status.clear(BackupSetupStart)
 
@@ -930,14 +998,8 @@ class OpenSearchBackup(OpenSearchBackupBase):
             self.charm.status.clear(BackupSetupFailed, app=True)
         self.charm.status.clear(BackupConfigureStart)
 
-    def _on_s3_created(self, _):
-        if self.charm.upgrade_in_progress:
-            logger.warning(
-                "Modifying relations during an upgrade is not supported. The charm may be in a broken, unrecoverable state"
-            )
-
     @override
-    def _on_s3_relation_broken(self, event: RelationEvent) -> None:  # noqa: C901
+    def _on_backup_relation_broken(self, event: RelationEvent) -> None:  # noqa: C901
         """Processes the broken s3 relation.
 
         It runs the reverse process of on_s3_change:
@@ -1033,14 +1095,6 @@ class OpenSearchBackup(OpenSearchBackupBase):
         except OpenSearchHttpError:
             return BackupServiceState.RESPONSE_FAILED_NETWORK
 
-    def _get_endpoint_protocol(self, endpoint: str) -> str:
-        """Returns the protocol based on the endpoint."""
-        if endpoint.startswith("http://"):
-            return "http"
-        if endpoint.startswith("https://"):
-            return "https"
-        return "https"
-
     def _register_snapshot_repo(self) -> BackupServiceState:
         """Registers the snapshot repo in the cluster."""
         try:
@@ -1077,25 +1131,549 @@ class OpenSearchBackup(OpenSearchBackupBase):
         return status
 
 
+class OpenSearchAzureBackup(OpenSearchBackupBase):
+    """Implements backup relation and API management."""
+
+    def __init__(self, charm: "OpenSearchBaseCharm", relation_name: str = AZURE_RELATION):
+        """Manager of OpenSearch backup relations."""
+        super().__init__(charm, relation_name)
+        self.azure_client = AzureStorageRequires(self.charm, AZURE_RELATION)
+        self.plugin = OpenSearchAzurePlugin(self.charm)
+
+        # relation handles the config options for azure backups
+        self.framework.observe(
+            self.charm.on[AZURE_RELATION].relation_broken, self._on_backup_relation_broken
+        )
+        self.framework.observe(
+            self.azure_client.on.storage_connection_info_changed,
+            self._on_azure_credentials_changed,
+        )
+        self.framework.observe(
+            self.azure_client.on.storage_connection_info_gone,
+            self._on_azure_credentials_changed,
+        )
+
+        self.framework.observe(self.charm.on.create_backup_action, self._on_create_backup_action)
+        self.framework.observe(self.charm.on.list_backups_action, self._on_list_backups_action)
+        self.framework.observe(self.charm.on.restore_action, self._on_restore_backup_action)
+
+    @override
+    def _on_backup_relation_event(self, event: RelationEvent) -> None:
+        """Overrides to process the azure relation events, as we use azure_client.
+
+        We run the peer cluster orchestrator's refresh on every new azure information.
+        """
+        if self.charm.opensearch_peer_cm.is_provider(typ="main"):
+            self.charm.peer_cluster_provider.refresh_relation_data(event)
+
+    @override
+    def _on_backup_action(self, event: ActionEvent) -> None:
+        """Just overloads the base method, as we process each action in this class."""
+        pass
+
+    @property
+    def _plugin_status(self):
+        return self.charm.plugin_manager.get_plugin_status(OpenSearchAzurePlugin)
+
+    def _on_list_backups_action(self, event: ActionEvent) -> None:
+        """Returns the list of available backups to the user."""
+        backups = {}
+        try:
+            backups = self._list_backups(AZURE_REPOSITORY)
+        except OpenSearchError as e:
+            event.fail(
+                f"List backups action failed - {str(e)} - check the application logs for the full stack trace."
+            )
+        if event.params.get("output").lower() == "json":
+            event.set_results({"backups": json.dumps(backups)})
+        elif event.params.get("output").lower() == "table":
+            event.set_results({"backups": self._generate_backup_list_output(backups)})
+        else:
+            event.fail("Failed: invalid output format, must be either json or table")
+
+    def _close_indices(self, indices: Set[str]) -> bool:
+        """Close a list of indices and return their status."""
+        if not indices:
+            # The indices is empty, we do not need to check
+            return True
+        resp = self.charm.opensearch.request(
+            "POST",
+            f"{','.join(indices)}/_close",
+            payload={
+                "ignore_unavailable": "true",
+            },
+            retries=6,
+            timeout=10,
+        )
+
+        # Trivial case, something went wrong
+        if not resp or not resp.get("acknowledged", False):
+            return False
+
+        # There are two options here we return True:
+        # 1) ack=True and shards_ack=False with empty indices
+        #    This means the indices are already closed
+        if not resp.get("shards_acknowledged", False):
+            if not resp.get("indices", {}):
+                return True
+            return False
+
+        # 2) ack=True and shards_ack=True with each index in resp["indices"]
+        #    marked as closed=True
+        # The statement of explicit "is True" below assures we have a boolean
+        # as the response has the form of "true" or "false" originally
+        all_closed = all(
+            [state and state.get("closed") for state in resp.get("indices", {}).values()]
+        )
+        if not all_closed:
+            return False
+
+        # Finally, we can state it is all good
+        return True
+
+    def _close_indices_if_needed(self, backup_id: int) -> Set[str]:
+        """Closes indices that will be restored.
+
+        Returns a set of indices that were closed or raises an exception:
+        - OpenSearchRestoreIndexClosingError if any of the indices could not be closed.
+
+        Raises:
+            OpenSearchHttpError
+            OpenSearchRestoreIndexClosingError
+        """
+        backup_indices = self._list_backups(AZURE_REPOSITORY).get(backup_id, {}).get("indices", {})
+        indices_to_close = set()
+        for index, state in ClusterState.indices(self.charm.opensearch).items():
+            if (
+                index in backup_indices
+                and state["status"] != IndexStateEnum.CLOSED
+                and index not in INDICES_TO_EXCLUDE_AT_RESTORE
+            ):
+                indices_to_close.add(index)
+
+        try:
+            if not self._close_indices(indices_to_close):
+                raise OpenSearchRestoreIndexClosingError()
+        except OpenSearchError as e:
+            raise OpenSearchRestoreIndexClosingError(e)
+        return indices_to_close
+
+    def _restore(self, backup_id: int) -> Dict[str, Any]:
+        """Runs the restore and processes the response."""
+        backup_indices = self._list_backups(AZURE_REPOSITORY).get(backup_id, {}).get("indices", {})
+        output = self.charm.opensearch.request(
+            "POST",
+            f"_snapshot/{AZURE_REPOSITORY}/{backup_id.lower()}/_restore?wait_for_completion=true",
+            payload={
+                "indices": ",".join(
+                    [f"-{idx}" for idx in INDICES_TO_EXCLUDE_AT_RESTORE & set(backup_indices)]
+                ),
+                "partial": False,  # It is the default value, but we want to avoid partial restores
+            },
+            retries=6,
+            timeout=10,
+        )
+        logger.debug(f"_restore: restore call returned {output}")
+        if (
+            self.get_service_status(output)
+            == BackupServiceState.SNAPSHOT_RESTORE_ERROR_INDEX_NOT_CLOSED
+        ):
+            to_close = output["error"]["reason"].split("[")[2].split("]")[0]
+            raise OpenSearchRestoreIndexClosingError(f"_restore: fails to close {to_close}")
+
+        if "snapshot" not in output or "shards" not in output.get("snapshot"):
+            raise OpenSearchRestoreCheckError(f"_restore: unexpected response {output}")
+
+        return output["snapshot"]
+
+    def _is_backup_available_for_restore(self, backup_id: str) -> bool:
+        """Checks if the backup_id exists and is ready for a restore."""
+        backups = self._list_backups(AZURE_REPOSITORY)
+        try:
+            return (
+                backup_id in backups.keys()
+                and self.get_snapshot_status(backups[backup_id]["state"])
+                == BackupServiceState.SUCCESS
+            )
+        except OpenSearchListBackupError:
+            return False
+
+    def _on_restore_backup_action(self, event: ActionEvent) -> None:  # noqa #C901
+        """Restores a backup to the current cluster."""
+        if self.charm.upgrade_in_progress:
+            event.fail("Restore not supported while upgrade in-progress")
+            return
+        if not self._can_unit_perform_backup(event):
+            event.fail("Failed: backup service is not configured yet")
+            return
+        try:
+            if not self._is_restore_complete():
+                event.fail("Failed: previous restore is still in progress")
+                return
+        except OpenSearchRestoreCheckError:
+            event.fail("Failed: error connecting to the cluster")
+            return
+        # Now, validate the backup is working
+        backup_id = event.params.get("backup-id")
+        if not self._is_backup_available_for_restore(backup_id):
+            event.fail(f"Failed: no backup-id {backup_id}")
+            return
+
+        self.charm.status.set(MaintenanceStatus(RestoreInProgress))
+
+        # Restore will try to close indices if there is a matching name.
+        # The goal is to leave the cluster in a running state, even if the restore fails.
+        # In case of failure, then restore action must return a list of closed indices
+        closed_idx = set()
+        try:
+            closed_idx = self._close_indices_if_needed(backup_id)
+            output = self._restore(backup_id)
+            logger.debug(f"Restore action: received response: {output}")
+            logger.info(f"Restore action succeeded for backup_id {backup_id}")
+        except (
+            OpenSearchHttpError,
+            OpenSearchRestoreIndexClosingError,
+            OpenSearchRestoreCheckError,
+        ) as e:
+            self.charm.status.clear(RestoreInProgress)
+            event.fail(f"Failed: {e}")
+            return
+
+        # Post execution checks
+        # Was the call successful?
+        state = self.get_service_status(output)
+        if state != BackupServiceState.SUCCESS:
+            event.fail(f"Restore failed with {state}")
+            self.charm.status.clear(RestoreInProgress)
+            return
+
+        shards = output.get("shards", {})
+        if shards.get("successful", -1) != shards.get("total", 0):
+            event.fail("Failed to restore all the shards")
+            self.charm.status.clear(RestoreInProgress)
+            return
+
+        try:
+            msg = (
+                "Restore is complete" if self._is_restore_complete() else "Restore in progress..."
+            )
+        except OpenSearchRestoreCheckError:
+            event.fail("Failed: error connecting to the cluster")
+            return
+        self.charm.status.clear(RestoreInProgress)
+        event.set_results(
+            {"backup-id": backup_id, "status": msg, "closed-indices": str(closed_idx)}
+        )
+
+    def _on_create_backup_action(self, event: ActionEvent) -> None:  # noqa: C901
+        """Creates a backup from the current cluster."""
+        if self.charm.upgrade_in_progress:
+            event.fail("Backup not supported while upgrade in-progress")
+            return
+        if not self._can_unit_perform_backup(event):
+            event.fail("Failed: backup service is not configured or busy")
+            return
+
+        new_backup_id = datetime.now().strftime(OPENSEARCH_BACKUP_ID_FORMAT)
+        try:
+            logger.debug(
+                f"Create backup action request id {new_backup_id} response is:"
+                + self.get_service_status(
+                    self.charm.opensearch.request(
+                        "PUT",
+                        f"_snapshot/{AZURE_REPOSITORY}/{new_backup_id.lower()}?wait_for_completion=false",
+                        payload={
+                            "indices": "*",  # Take all indices
+                            "partial": False,  # It is the default value, but we want to avoid partial backups
+                        },
+                        retries=6,
+                        timeout=10,
+                    )
+                )
+            )
+
+            logger.info(f"Backup request submitted with backup-id {new_backup_id}")
+        except (
+            OpenSearchHttpError,
+            OpenSearchListBackupError,
+        ) as e:
+            event.fail(f"Failed with exception: {e}")
+            return
+        event.set_results({"backup-id": new_backup_id, "status": "Backup is running."})
+
+    def _can_unit_perform_backup(self, _: ActionEvent) -> bool:
+        """Checks if the actions run from this unit can be executed or not.
+
+        If not, then register the reason as a failure in the event and returns False.
+        Returns True otherwise.
+
+        This method does not check if the unit is a leader, as list backups action does
+        not demand it.
+        """
+        # First, validate the plugin is present and correctly configured.
+        if self._plugin_status != PluginState.ENABLED:
+            logger.warning(
+                f"Failed: plugin is not ready yet, current status is {self._plugin_status}"
+            )
+            return False
+
+        # Then, check the repo status
+        status = self._check_repo_status()
+        if status != BackupServiceState.SUCCESS:
+            logger.warning(f"Failed: repo status is {status}")
+            return False
+        return not self.is_backup_in_progress()
+
+    def _on_azure_credentials_changed(self, event: EventBase) -> None:  # noqa: C901
+        """Calls the plugin manager config handler.
+
+        This method will iterate over the azure relation and check:
+        1) Is Azure fully configured? If not, we can abandon this event
+        2) Try to enable the plugin
+        3) If the plugin is not enabled, then defer the event
+        4) Send the API calls to setup the backup service
+        """
+        if not self.plugin.requested_to_enable():
+            # Always check if a relation actually exists and if options are available
+            # in this case, seems one of the conditions above is not yet present
+            # abandon this restart event, as it will be called later once azure configuration
+            # is correctly set
+            return
+
+        self.charm.status.set(MaintenanceStatus(BackupSetupStart))
+
+        try:
+            if not self.charm.plugin_manager.is_ready_for_api():
+                raise OpenSearchNotFullyReadyError()
+            self.charm.plugin_manager.apply_config(self.plugin.config())
+        except (OpenSearchKeystoreNotReadyError, OpenSearchNotFullyReadyError):
+            logger.warning("azure-changed: cluster not ready yet")
+            event.defer()
+            return
+        except (OpenSearchPluginMissingConfigError, OpenSearchPluginMissingDepsError) as e:
+            self.charm.status.set(BlockedStatus(BackupRelDataIncomplete))
+            logger.error(e)
+            return
+        except OpenSearchError as e:
+            self.charm.status.set(BlockedStatus(PluginConfigError))
+            # There was an unexpected error, log it and block the unit
+            logger.error(e)
+            event.defer()
+            return
+
+        if self._plugin_status not in [
+            PluginState.ENABLED,
+            PluginState.WAITING_FOR_UPGRADE,
+        ]:
+            logger.warning("_on_azure_credentials_changed: plugin is not enabled.")
+            event.defer()
+            return
+
+        if not self.charm.unit.is_leader():
+            # Plugin is configured locally for this unit. Now the leader proceed.
+            self.charm.status.clear(PluginConfigError)
+            self.charm.status.clear(BackupSetupStart)
+            self.charm.status.clear(BackupRelDataIncomplete)
+            return
+
+        # Leader configures this plugin
+        try:
+            self.apply_api_config_if_needed()
+        except OpenSearchBackupError:
+            # Finish here and wait for the user to reconfigure it and retrigger a new event
+            event.defer()
+            return
+        self.charm.status.clear(BackupRelDataIncomplete)
+        self.charm.status.clear(PluginConfigError)
+        self.charm.status.clear(BackupSetupStart)
+
+    def apply_api_config_if_needed(self) -> None:
+        """Runs the post restart routine and API calls needed to setup/disable backup.
+
+        This method should be called by the charm in its restart callback resolution.
+        """
+        if not self.charm.unit.is_leader():
+            logger.debug("apply_api_config_if_needed: only leader can run this method")
+            return
+        # Backup relation has been recently made available with all the parameters needed.
+        # Steps:
+        #     (1) set up as maintenance;
+        self.charm.status.set(MaintenanceStatus(BackupConfigureStart))
+        #     (2) run the request; and
+        state = self._register_snapshot_repo()
+        #     (3) based on the response, set the message status
+        if state != BackupServiceState.SUCCESS:
+            logger.error(f"Failed to setup backup service with state {state}")
+            self.charm.status.clear(BackupConfigureStart)
+            self.charm.status.set(BlockedStatus(BackupSetupFailed))
+            self.charm.status.set(BlockedStatus(BackupSetupFailed), app=True)
+            raise OpenSearchBackupError()
+        self.charm.status.clear(BackupSetupFailed)
+        self.charm.status.clear(BackupSetupFailed, app=True)
+        self.charm.status.clear(BackupConfigureStart)
+
+    @override
+    def _on_backup_relation_broken(self, event: RelationEvent) -> None:  # noqa: C901
+        """Processes the broken azure relation.
+
+        It runs the reverse process of on_azure_change:
+        1) Check if the cluster is currently taking a snapshot, if yes, set status as blocked
+           and defer this event.
+        2) If leader, run API calls to signal disable is needed
+        """
+        self.charm.status.clear(BackupRelDataIncomplete)
+
+        if self.charm.upgrade_in_progress:
+            logger.warning(
+                "Modifying relations during an upgrade is not supported. The charm may be in a broken, unrecoverable state"
+            )
+
+        if (
+            self.charm.model.get_relation(AZURE_RELATION)
+            and self.charm.model.get_relation(AZURE_RELATION).units
+        ):
+            event.defer()
+            return
+
+        self.charm.status.set(MaintenanceStatus(BackupInDisabling))
+        snapshot_status = self._check_snapshot_status()
+        if snapshot_status in [
+            BackupServiceState.SNAPSHOT_IN_PROGRESS,
+        ]:
+            # 1) snapshot is either in progress or partially taken: block and defer this event
+            self.charm.status.set(WaitingStatus(BackupDeferRelBrokenAsInProgress))
+            event.defer()
+            return
+        self.charm.status.clear(BackupDeferRelBrokenAsInProgress)
+
+        if snapshot_status in [
+            BackupServiceState.SNAPSHOT_PARTIALLY_TAKEN,
+        ]:
+            logger.warning(
+                "Snapshot has been partially taken, but not completed. Continuing with relation removal..."
+            )
+
+        # Run the check here, instead of the start of this hook, as we want all the
+        # units to keep deferring the event if needed.
+        # That avoids a condition where we have:
+        # 1) A long snapshot is taking place
+        # 2) Relation is removed
+        # 3) Only leader is checking for that and deferring the event
+        # 4) The leader is lost or removed
+        # 5) The snapshot is removed: self._execute_azure_broken_calls() never happens
+        # That is why we are running the leader check here and not at first
+        if self.charm.unit.is_leader():
+            # 2) Run the API calls
+            self._execute_azure_broken_calls()
+
+        try:
+            if self.charm.plugin_manager.status(self.plugin) == PluginState.ENABLED:
+                self.charm.plugin_manager.apply_config(self.plugin.disable())
+        except OpenSearchKeystoreNotReadyError:
+            logger.warning("azure-changed: keystore not ready yet")
+            event.defer()
+            return
+        except OpenSearchError as e:
+            self.charm.status.set(BlockedStatus(PluginConfigError))
+            # There was an unexpected error, log it and block the unit
+            logger.error(e)
+            event.defer()
+            return
+
+        self.charm.status.clear(BackupInDisabling)
+        self.charm.status.clear(PluginConfigError)
+
+    def _execute_azure_broken_calls(self):
+        """Executes the azure broken API calls."""
+        return  # do not execute anything as we intend to keep the backups untouched
+
+    def _check_repo_status(self) -> BackupServiceState:
+        try:
+            response = self.charm.opensearch.request(
+                "GET",
+                f"_snapshot/{AZURE_REPOSITORY}",
+                retries=6,
+                timeout=10,
+            )
+            return self.get_service_status(response)
+        except OpenSearchHttpError:
+            return BackupServiceState.RESPONSE_FAILED_NETWORK
+
+    def _check_snapshot_status(self) -> BackupServiceState:
+        try:
+            response = self.charm.opensearch.request(
+                "GET",
+                "/_snapshot/_status",
+                retries=6,
+                timeout=10,
+            )
+            return self.get_snapshot_status(response)
+        except OpenSearchHttpError:
+            return BackupServiceState.RESPONSE_FAILED_NETWORK
+
+    def _register_snapshot_repo(self) -> BackupServiceState:
+        """Registers the snapshot repo in the cluster."""
+        try:
+            to_include = {"container"}
+            settings = {k: self.plugin.data.dict()[k] for k in to_include}
+            response = self.charm.opensearch.request(
+                "PUT",
+                f"_snapshot/{AZURE_REPOSITORY}/",
+                payload={
+                    "type": "azure",
+                    "settings": settings,
+                },
+                retries=6,
+                timeout=10,
+            )
+        except OpenSearchHttpError:
+            return BackupServiceState.REPO_ERR_UNKNOWN
+        return self.get_service_status(response)
+
+    def get_service_status(  # noqa: C901
+        self, response: dict[str, Any] | None
+    ) -> BackupServiceState:
+        """Returns the response status in a Enum."""
+        if (status := super().get_service_status(response)) == BackupServiceState.SUCCESS:
+            return BackupServiceState.SUCCESS
+        if (
+            "container" in self.azure_client.get_azure_connection_info()
+            and AZURE_REPOSITORY in response
+            and "settings" in response[AZURE_REPOSITORY]
+            and self.azure_client.get_azure_connection_info()["container"]
+            == response[AZURE_REPOSITORY]["settings"]["container"]
+        ):
+            return BackupServiceState.REPO_NOT_CREATED_ALREADY_EXISTS
+        return status
+
+
 def backup(charm: "OpenSearchBaseCharm") -> OpenSearchBackupBase:
     """Implements the logic that returns the correct class according to the cluster type.
 
-    This class is solely responsible for the creation of the correct S3 client manager.
+    This class is solely responsible for the creation of the correct azure client manager.
 
     If this cluster is an orchestrator or failover cluster, then return the OpenSearchBackup.
     Otherwise, return the OpenSearchNonOrchestratorBackup.
 
-    There is also the condition where the deployment description does not exist yet. In this
-    case, return the base class OpenSearchBackupBase. This class solely defers all s3-related
-    events until the deployment description is available and the actual S3 object is allocated.
+    There is also the condition where the deployment description does not exist yet. In this case,
+    return the base class OpenSearchBackupBase. This class solely defers all backup related events
+    until the deployment description is available and the actual S3/Azure object is allocated.
     """
+    backup_base = OpenSearchBackupBase(charm)
     if not charm.opensearch_peer_cm.deployment_desc():
         # Temporary condition: we are waiting for CM to show up and define which type
         # of cluster are we. Once we have that defined, then we will process.
-        return OpenSearchBackupBase(charm)
+        # Additionally, we might not know yet which relation is active for the charm. If both
+        # relations are active, let the actions fail and report it to the user.
+        return backup_base
     elif charm.opensearch_peer_cm.deployment_desc().typ == DeploymentType.MAIN_ORCHESTRATOR:
         # Using the deployment_desc() method instead of is_provider()
         # In both cases: (1) small deployments or (2) large deployments where this cluster is the
         # main orchestrator, we want to instantiate the OpenSearchBackup class.
-        return OpenSearchBackup(charm)
+        if not backup_base.active_relation:
+            return backup_base
+        if backup_base.active_relation == S3_RELATION:
+            return OpenSearchS3Backup(charm)
+        if backup_base.active_relation == AZURE_RELATION:
+            return OpenSearchAzureBackup(charm)
     return OpenSearchNonOrchestratorClusterBackup(charm)

--- a/lib/charms/opensearch/v0/opensearch_backups.py
+++ b/lib/charms/opensearch/v0/opensearch_backups.py
@@ -1613,7 +1613,7 @@ class OpenSearchAzureBackup(OpenSearchBackupBase):
         try:
             if not self.plugin.data:
                 return BackupServiceState.REPO_ERR_UNKNOWN
-            to_include = {"container"}
+            to_include = {"container", "base_path"}
             settings = {k: self.plugin.data.dict()[k] for k in to_include}
             response = self.charm.opensearch.request(
                 "PUT",

--- a/lib/charms/opensearch/v0/opensearch_peer_clusters.py
+++ b/lib/charms/opensearch/v0/opensearch_peer_clusters.py
@@ -651,4 +651,19 @@ class OpenSearchPeerClustersManager:
                 .get_content()
                 .get("s3-secret-key")
             )
+        if (
+            "azure" in credentials
+            and credentials["azure"].get("storage-account")
+            and credentials["azure"].get("secret-key")
+        ):
+            credentials["azure"]["storage-account"] = (
+                self._charm.model.get_secret(id=credentials["azure"]["storage-account"])
+                .get_content()
+                .get("azure-storage-account")
+            )
+            credentials["azure"]["secret-key"] = (
+                self._charm.model.get_secret(id=credentials["azure"]["secret-key"])
+                .get_content()
+                .get("azure-secret-key")
+            )
         return PeerClusterRelData.from_dict(content)

--- a/lib/charms/opensearch/v0/opensearch_plugin_manager.py
+++ b/lib/charms/opensearch/v0/opensearch_plugin_manager.py
@@ -26,7 +26,7 @@ from charms.opensearch.v0.opensearch_keystore import (
     OpenSearchKeystoreNotReadyError,
 )
 from charms.opensearch.v0.opensearch_plugins import (
-    OpenSearchBackupPlugin,
+    OpenSearchAzurePlugin,
     OpenSearchKnn,
     OpenSearchPlugin,
     OpenSearchPluginConfig,
@@ -35,6 +35,7 @@ from charms.opensearch.v0.opensearch_plugins import (
     OpenSearchPluginMissingConfigError,
     OpenSearchPluginMissingDepsError,
     OpenSearchPluginRemoveError,
+    OpenSearchS3Plugin,
     PluginState,
 )
 
@@ -58,7 +59,11 @@ ConfigExposedPlugins = {
         "config": "plugin_opensearch_knn",
     },
     "repository-s3": {
-        "class": OpenSearchBackupPlugin,
+        "class": OpenSearchS3Plugin,
+        "config": None,
+    },
+    "repository-azure": {
+        "class": OpenSearchAzurePlugin,
         "config": None,
     },
 }
@@ -201,6 +206,7 @@ class OpenSearchPluginManager:
                 raise OpenSearchPluginMissingDepsError(plugin.name, missing_deps)
 
             self._opensearch.run_bin("plugin", f"install --batch {plugin.name}")
+            self._clean_cache_if_needed()
         except KeyError as e:
             raise OpenSearchPluginMissingConfigError(e)
         except OpenSearchCmdError as e:
@@ -437,6 +443,7 @@ class OpenSearchPluginManager:
         """Remove a plugin without restarting the node."""
         try:
             self._opensearch.run_bin("plugin", f"remove {plugin.name}")
+            self._clean_cache_if_needed()
 
         except OpenSearchCmdError as e:
             if "not found" in str(e):

--- a/lib/charms/opensearch/v0/opensearch_plugins.py
+++ b/lib/charms/opensearch/v0/opensearch_plugins.py
@@ -675,7 +675,7 @@ class OpenSearchPluginAzureDataProvider(OpenSearchPluginDataProvider):
                 relation_name=AZURE_RELATION,
                 additional_secret_fields=["secret-key"],
             )
-            result = azure_data_endpoint.fetch_relation_data()[self._relation.id]
+            result = azure_data_endpoint.fetch_relation_data()[self._relation.id] or {}
         # Case where we are on a non cluster_manager.
         else:
             result = dict(self.get_relation().data[self._relation.app]) or {}
@@ -698,11 +698,6 @@ class OpenSearchAzurePlugin(OpenSearchPlugin):
     """
 
     MODEL = AzureRelData
-    MANDATORY_CONFS = [
-        "container",
-        "credentials",
-    ]
-
     DATA_PROVIDER = OpenSearchPluginAzureDataProvider
 
     def __init__(self, charm):
@@ -710,6 +705,7 @@ class OpenSearchAzurePlugin(OpenSearchPlugin):
         super().__init__(charm)
         self.dp = self.DATA_PROVIDER(charm)
         self.repo_name = "default"
+        self.charm = charm
 
     def requested_to_enable(self) -> bool:
         """Returns True if the plugin is enabled."""
@@ -720,10 +716,14 @@ class OpenSearchAzurePlugin(OpenSearchPlugin):
         """Returns the data from the relation databag."""
         self._relation = self.dp.get_relation()
         try:
-            return self.MODEL.from_relation(self.dp.get_data())
-        except ValidationError as e:
-            logger.warning(f"Validation of fields failed: {e}")
-            return self.MODEL()
+            if self.dp.is_main_orchestrator:
+                return self.MODEL.from_relation(self.dp.get_data())
+            if peer_data := self.charm.opensearch_peer_cm.rel_data():
+                return peer_data.credentials.azure
+            return None
+
+        except ValidationError:
+            return None
 
     @property
     def name(self) -> str:
@@ -732,40 +732,25 @@ class OpenSearchAzurePlugin(OpenSearchPlugin):
 
     def config(self) -> OpenSearchPluginConfig:
         """Returns OpenSearchPluginConfig composed of configs used at plugin configuration."""
-        conf = self.data.credentials.dict()
-        # First, let's check if credentials are set
-        if any([val is None for val in conf.values()]):
-            raise OpenSearchPluginMissingConfigError(
-                "Plugin {} missing credentials".format(
-                    self.name,
-                )
-            )
+        if not self.data:
+            # Nothing to do, the backup is not enabled anyways
+            return self.disable()
 
+        # This is the main orchestrator
         if self.dp.is_main_orchestrator:
-            conf = self.data.dict()
-            # Check any mandatory config is missing
-            if any([val is None and key in self.MANDATORY_CONFS for key, val in conf.items()]):
-                raise OpenSearchPluginMissingConfigError(
-                    "Plugin {} missing: {}".format(
-                        self.name,
-                        [key for key, val in conf.items() if val is None],
-                    )
-                )
-
-        if not self.dp.is_main_orchestrator:
             return OpenSearchPluginConfig(
+                config_entries={},
                 secret_entries={
                     f"azure.client.{self.repo_name}.account": self.data.credentials.storage_account,
                     f"azure.client.{self.repo_name}.key": self.data.credentials.secret_key,
                 },
             )
 
-        # This is the main orchestrator
         return OpenSearchPluginConfig(
             config_entries={},
             secret_entries={
-                f"azure.client.{self.repo_name}.account": self.data.credentials.storage_account,
-                f"azure.client.{self.repo_name}.key": self.data.credentials.secret_key,
+                f"azure.client.{self.repo_name}.account": self.data.storage_account,
+                f"azure.client.{self.repo_name}.key": self.data.secret_key,
             },
         )
 

--- a/lib/charms/opensearch/v0/opensearch_plugins.py
+++ b/lib/charms/opensearch/v0/opensearch_plugins.py
@@ -291,10 +291,15 @@ import logging
 from abc import abstractmethod
 from typing import Any, Dict, List, Optional
 
-from charms.opensearch.v0.constants_charm import S3_RELATION, PeerRelationName
-from charms.opensearch.v0.constants_secrets import S3_CREDENTIALS
+from charms.data_platform_libs.v0.data_interfaces import RequirerData
+from charms.opensearch.v0.constants_charm import (
+    AZURE_RELATION,
+    S3_RELATION,
+    PeerRelationName,
+)
+from charms.opensearch.v0.constants_secrets import AZURE_CREDENTIALS, S3_CREDENTIALS
 from charms.opensearch.v0.helper_enums import BaseStrEnum
-from charms.opensearch.v0.models import DeploymentType, S3RelData
+from charms.opensearch.v0.models import AzureRelData, DeploymentType, S3RelData
 from charms.opensearch.v0.opensearch_exceptions import OpenSearchError
 from charms.opensearch.v0.opensearch_internal_data import Scope
 from jproperties import Properties
@@ -502,7 +507,7 @@ class OpenSearchKnn(OpenSearchPlugin):
         return "opensearch-knn"
 
 
-class OpenSearchPluginBackupDataProvider(OpenSearchPluginDataProvider):
+class OpenSearchPluginS3DataProvider(OpenSearchPluginDataProvider):
     """Responsible to decide which data to use for the backup plugin.
 
     Backups should check different relations depending on their role in the cluster:
@@ -512,7 +517,7 @@ class OpenSearchPluginBackupDataProvider(OpenSearchPluginDataProvider):
     """
 
     def __init__(self, charm):
-        """Creates the OpenSearchPluginBackupDataProvider object."""
+        """Creates the OpenSearchPluginS3DataProvider object."""
         super().__init__(charm)
         self._relation = None
         if not self._charm.opensearch_peer_cm.deployment_desc():
@@ -547,7 +552,7 @@ class OpenSearchPluginBackupDataProvider(OpenSearchPluginDataProvider):
         return result
 
 
-class OpenSearchBackupPlugin(OpenSearchPlugin):
+class OpenSearchS3Plugin(OpenSearchPlugin):
     """Manage backup configurations.
 
     This class must load the opensearch plugin: repository-s3 and configure it.
@@ -558,8 +563,7 @@ class OpenSearchBackupPlugin(OpenSearchPlugin):
     """
 
     MODEL = S3RelData
-
-    DATA_PROVIDER = OpenSearchPluginBackupDataProvider
+    DATA_PROVIDER = OpenSearchPluginS3DataProvider
 
     def __init__(self, charm):
         """Creates the OpenSearchBackupPlugin object."""
@@ -622,5 +626,155 @@ class OpenSearchBackupPlugin(OpenSearchPlugin):
             secret_entries={
                 f"s3.client.{self.repo_name}.access_key": None,
                 f"s3.client.{self.repo_name}.secret_key": None,
+            },
+        )
+
+
+class OpenSearchPluginAzureDataProvider(OpenSearchPluginDataProvider):
+    """Responsible to decide which data to use for the backup plugin.
+
+    Backups should check different relations depending on their role in the cluster:
+    * main orchestrator
+    * failover orchestrator
+    * other
+    """
+
+    def __init__(self, charm):
+        """Creates the OpenSearchPluginAzureDataProvider object."""
+        super().__init__(charm)
+        self._relation = None
+        if not self._charm.opensearch_peer_cm.deployment_desc():
+            # Temporary condition: we are waiting for CM to show up and define which type
+            # of cluster are we. Once we have that defined, then we will process.
+            raise OpenSearchPluginMissingConfigError("Missing deployment description in peer CM")
+
+        self.is_main_orchestrator = (
+            self._charm.opensearch_peer_cm.deployment_desc().typ
+            == DeploymentType.MAIN_ORCHESTRATOR
+        )
+
+    def get_relation(self) -> Any:
+        """Updates the relation object if needed."""
+        self._relation = self._charm.model.get_relation(AZURE_RELATION)
+        if not self.is_main_orchestrator:
+            self._relation = self._charm.model.get_relation(PeerRelationName)
+        return self._relation
+
+    def get_data(self) -> Dict[str, Any]:
+        """Returns the data from the relation databag.
+
+        Exceptions:
+            ValueError: if the data is not valid
+        """
+        if not self.get_relation():
+            return {}
+
+        if self._relation.name == AZURE_RELATION:
+            azure_data_endpoint = RequirerData(
+                model=self._charm.model,
+                relation_name=AZURE_RELATION,
+                additional_secret_fields=["secret-key"],
+            )
+            result = azure_data_endpoint.fetch_relation_data()[self._relation.id]
+        # Case where we are on a non cluster_manager.
+        else:
+            result = dict(self.get_relation().data[self._relation.app]) or {}
+
+        if not self.is_main_orchestrator:
+            # Peer relations exchange secrets via peer-cluster secret
+            result |= self._charm.secrets.get_object(Scope.APP, AZURE_CREDENTIALS) or {}
+
+        return result
+
+
+class OpenSearchAzurePlugin(OpenSearchPlugin):
+    """Manage backup configurations.
+
+    This class must load the opensearch plugin: repository-azure and configure it.
+
+    The plugin is responsible for managing the backup configuration, which includes relation
+    databag or only the secrets' content, as backup changes behavior depending on the juju app
+    role within the cluster.
+    """
+
+    MODEL = AzureRelData
+    MANDATORY_CONFS = [
+        "container",
+        "credentials",
+    ]
+
+    DATA_PROVIDER = OpenSearchPluginAzureDataProvider
+
+    def __init__(self, charm):
+        """Creates the OpenSearchAzurePlugin object."""
+        super().__init__(charm)
+        self.dp = self.DATA_PROVIDER(charm)
+        self.repo_name = "default"
+
+    def requested_to_enable(self) -> bool:
+        """Returns True if the plugin is enabled."""
+        return self.dp.get_relation() is not None
+
+    @property
+    def data(self) -> BaseModel:
+        """Returns the data from the relation databag."""
+        self._relation = self.dp.get_relation()
+        try:
+            return self.MODEL.from_relation(self.dp.get_data())
+        except ValidationError as e:
+            logger.warning(f"Validation of fields failed: {e}")
+            return self.MODEL()
+
+    @property
+    def name(self) -> str:
+        """Returns the name of the plugin."""
+        return "repository-azure"
+
+    def config(self) -> OpenSearchPluginConfig:
+        """Returns OpenSearchPluginConfig composed of configs used at plugin configuration."""
+        conf = self.data.credentials.dict()
+        # First, let's check if credentials are set
+        if any([val is None for val in conf.values()]):
+            raise OpenSearchPluginMissingConfigError(
+                "Plugin {} missing credentials".format(
+                    self.name,
+                )
+            )
+
+        if self.dp.is_main_orchestrator:
+            conf = self.data.dict()
+            # Check any mandatory config is missing
+            if any([val is None and key in self.MANDATORY_CONFS for key, val in conf.items()]):
+                raise OpenSearchPluginMissingConfigError(
+                    "Plugin {} missing: {}".format(
+                        self.name,
+                        [key for key, val in conf.items() if val is None],
+                    )
+                )
+
+        if not self.dp.is_main_orchestrator:
+            return OpenSearchPluginConfig(
+                secret_entries={
+                    f"azure.client.{self.repo_name}.account": self.data.credentials.storage_account,
+                    f"azure.client.{self.repo_name}.key": self.data.credentials.secret_key,
+                },
+            )
+
+        # This is the main orchestrator
+        return OpenSearchPluginConfig(
+            config_entries={},
+            secret_entries={
+                f"azure.client.{self.repo_name}.account": self.data.credentials.storage_account,
+                f"azure.client.{self.repo_name}.key": self.data.credentials.secret_key,
+            },
+        )
+
+    def disable(self) -> OpenSearchPluginConfig:
+        """Returns OpenSearchPluginConfig composed of configs used at plugin removal."""
+        return OpenSearchPluginConfig(
+            config_entries={},
+            secret_entries={
+                f"azure.client.{self.repo_name}.account": None,
+                f"azure.client.{self.repo_name}.key": None,
             },
         )

--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -9,13 +9,15 @@ from hashlib import sha1
 from typing import TYPE_CHECKING, Any, Dict, List, MutableMapping, Optional, Union
 
 from charms.opensearch.v0.constants_charm import (
+    AZURE_RELATION,
+    S3_RELATION,
     AdminUser,
     COSUser,
     KibanaserverUser,
     PeerClusterOrchestratorRelationName,
     PeerClusterRelationName,
 )
-from charms.opensearch.v0.constants_secrets import S3_CREDENTIALS
+from charms.opensearch.v0.constants_secrets import AZURE_CREDENTIALS, S3_CREDENTIALS
 from charms.opensearch.v0.constants_tls import CertType
 from charms.opensearch.v0.helper_charm import (
     RelDepartureReason,
@@ -25,6 +27,7 @@ from charms.opensearch.v0.helper_charm import (
 )
 from charms.opensearch.v0.helper_cluster import ClusterTopology
 from charms.opensearch.v0.models import (
+    AzureRelDataCredentials,
     DeploymentDescription,
     DeploymentType,
     Node,
@@ -36,7 +39,6 @@ from charms.opensearch.v0.models import (
     S3RelDataCredentials,
     StartMode,
 )
-from charms.opensearch.v0.opensearch_backups import S3_RELATION
 from charms.opensearch.v0.opensearch_exceptions import OpenSearchHttpError
 from charms.opensearch.v0.opensearch_internal_data import Scope
 from ops import (
@@ -396,6 +398,42 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
                 Scope.APP, "cluster_fleet_apps_rels", cluster_fleet_apps_rels
             )
 
+    def _azure_credentials(
+        self, deployment_desc: DeploymentDescription
+    ) -> Optional[AzureRelDataCredentials]:
+        if deployment_desc.typ == DeploymentType.MAIN_ORCHESTRATOR:
+            if not self.charm.model.get_relation(AZURE_RELATION):
+                return None
+
+            if not self.charm.backup.azure_client.get_azure_connection_info().get(
+                "storage-account"
+            ):
+                return None
+
+            # As the main orchestrator, this application must set the S3 information.
+            storage_account = self.charm.backup.azure_client.get_azure_connection_info().get(
+                "storage-account"
+            )
+            secret_key = self.charm.backup.azure_client.get_azure_connection_info().get(
+                "secret-key"
+            )
+
+            # set the secrets in the charm
+            # TODO Move this to azure relation and include both in one secret
+            self.charm.secrets.put(Scope.APP, "azure-storage-account", storage_account)
+            self.charm.secrets.put(Scope.APP, "azure-secret-key", secret_key)
+
+            return AzureRelDataCredentials(storage_account=storage_account, secret_key=secret_key)
+
+        if not self.charm.secrets.get(Scope.APP, "azure-storage-account"):
+            return None
+
+        # Return what we have received from the peer relation
+        return AzureRelDataCredentials(
+            storage_account=self.charm.secrets.get(Scope.APP, "azure-access-key"),
+            secret_key=self.charm.secrets.get(Scope.APP, "azure-secret-key"),
+        )
+
     def _s3_credentials(
         self, deployment_desc: DeploymentDescription
     ) -> Optional[S3RelDataCredentials]:
@@ -415,10 +453,7 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
             self.charm.secrets.put(Scope.APP, "s3-access-key", access_key)
             self.charm.secrets.put(Scope.APP, "s3-secret-key", secret_key)
 
-            return S3RelDataCredentials(
-                access_key=access_key,
-                secret_key=secret_key,
-            )
+            return S3RelDataCredentials(access_key=access_key, secret_key=secret_key)
 
         if not self.charm.secrets.get(Scope.APP, "s3-access-key"):
             return None
@@ -464,6 +499,7 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
                     ),
                     admin_tls=self.secrets.get_object(Scope.APP, CertType.APP_ADMIN.val),
                     s3=self._s3_credentials(deployment_desc),
+                    azure=self._azure_credentials(deployment_desc),
                 ),
                 deployment_desc=deployment_desc,
                 security_index_initialised=self._get_security_index_initialised(),
@@ -609,10 +645,20 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
                 "access-key": self.secrets.get_secret_id(Scope.APP, "s3-access-key"),
                 "secret-key": self.secrets.get_secret_id(Scope.APP, "s3-secret-key"),
             }
+        if (
+            rel_data.credentials.azure
+            and rel_data.credentials.azure.storage_account
+            and rel_data.credentials.azure.secret_key
+        ):
+            # TODO Move this to azure relation and include both in one secret
+            redacted_dict["credentials"]["azure"] = {
+                "storage-account": self.secrets.get_secret_id(Scope.APP, "azure-storage-account"),
+                "secret-key": self.secrets.get_secret_id(Scope.APP, "azure-secret-key"),
+            }
 
         return redacted_dict
 
-    def _grant_rel_data_secrets(
+    def _grant_rel_data_secrets(  # noqa: C901
         self, rel_data_secret_content: dict[str, Any], all_rel_ids: list[int]
     ):
         """Grant the secrets to all the related apps."""
@@ -628,6 +674,15 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
                         if secret_id["access-key"]:
                             self.secrets.grant_secret_to_relation(
                                 secret_id["access-key"], relation
+                            )
+                        if secret_id["secret-key"]:
+                            self.secrets.grant_secret_to_relation(
+                                secret_id["secret-key"], relation
+                            )
+                    elif key == "azure":
+                        if secret_id["storage-account"]:
+                            self.secrets.grant_secret_to_relation(
+                                secret_id["storage-account"], relation
                             )
                         if secret_id["secret-key"]:
                             self.secrets.grant_secret_to_relation(
@@ -806,6 +861,18 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
                 Scope.APP,
                 S3_CREDENTIALS,
                 S3RelDataCredentials().to_dict(by_alias=True),
+            )
+
+        if azure_creds := data.credentials.azure:
+            self.charm.secrets.put_object(
+                Scope.APP, AZURE_CREDENTIALS, azure_creds.to_dict(by_alias=True)
+            )
+        else:
+            # Set Azure credentials to empty
+            self.charm.secrets.put_object(
+                Scope.APP,
+                AZURE_CREDENTIALS,
+                AzureRelDataCredentials().to_dict(by_alias=True),
             )
 
     def _orchestrators(

--- a/lib/charms/opensearch/v0/opensearch_secrets.py
+++ b/lib/charms/opensearch/v0/opensearch_secrets.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Dict, Optional, Union
 
 from charms.opensearch.v0.constants_charm import KibanaserverUser, OpenSearchSystemUsers
 from charms.opensearch.v0.constants_secrets import (
+    AZURE_CREDENTIALS,
     HASH_POSTFIX,
     PW_POSTFIX,
     S3_CREDENTIALS,
@@ -79,7 +80,7 @@ class OpenSearchSecrets(Object, RelationDataStore):
             logging.info(f"Label {event.secret.label} was meaningless for us, returning")
             return
 
-        # We need to take action on 3 secret types
+        # We need to take action on 5 secret types
         # 1. TLS credentials change
         #     - Action: update credentials files
         # 2. 'kibanaserver' user credentials change
@@ -89,6 +90,8 @@ class OpenSearchSecrets(Object, RelationDataStore):
         #     - Note: Leader is updated already
         # 4.  S3 credentials (secret / access keys) in large relations
         #     - Action: write them into the opensearch.yml by running backup module
+        #
+        # 5.  Azure credentials (storage account / secret key)
 
         system_user_hash_keys = [
             self._charm.secrets.hash_key(user) for user in OpenSearchSystemUsers
@@ -97,6 +100,7 @@ class OpenSearchSecrets(Object, RelationDataStore):
             CertType.APP_ADMIN.val,
             self._charm.secrets.password_key(KibanaserverUser),
             S3_CREDENTIALS,
+            AZURE_CREDENTIALS,
         ]
 
         # Variables for better readability

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -46,6 +46,9 @@ requires:
   s3-credentials:
     interface: s3
     limit: 1
+  azure-credentials:
+    interface: azure
+    limit: 1
 
 storage:
   opensearch-data:

--- a/poetry.lock
+++ b/poetry.lock
@@ -90,6 +90,66 @@ tests = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4
 tests-mypy = ["mypy (>=1.11.1)", "pytest-mypy-plugins"]
 
 [[package]]
+name = "azure-core"
+version = "1.32.0"
+description = "Microsoft Azure Core Library for Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["integration"]
+files = [
+    {file = "azure_core-1.32.0-py3-none-any.whl", hash = "sha256:eac191a0efb23bfa83fddf321b27b122b4ec847befa3091fa736a5c32c50d7b4"},
+    {file = "azure_core-1.32.0.tar.gz", hash = "sha256:22b3c35d6b2dae14990f6c1be2912bf23ffe50b220e708a28ab1bb92b1c730e5"},
+]
+
+[package.dependencies]
+requests = ">=2.21.0"
+six = ">=1.11.0"
+typing-extensions = ">=4.6.0"
+
+[package.extras]
+aio = ["aiohttp (>=3.0)"]
+
+[[package]]
+name = "azure-identity"
+version = "1.19.0"
+description = "Microsoft Azure Identity Library for Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["integration"]
+files = [
+    {file = "azure_identity-1.19.0-py3-none-any.whl", hash = "sha256:e3f6558c181692d7509f09de10cca527c7dce426776454fb97df512a46527e81"},
+    {file = "azure_identity-1.19.0.tar.gz", hash = "sha256:500144dc18197d7019b81501165d4fa92225f03778f17d7ca8a2a180129a9c83"},
+]
+
+[package.dependencies]
+azure-core = ">=1.31.0"
+cryptography = ">=2.5"
+msal = ">=1.30.0"
+msal-extensions = ">=1.2.0"
+typing-extensions = ">=4.0.0"
+
+[[package]]
+name = "azure-storage-blob"
+version = "12.24.0"
+description = "Microsoft Azure Blob Storage Client Library for Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["integration"]
+files = [
+    {file = "azure_storage_blob-12.24.0-py3-none-any.whl", hash = "sha256:4f0bb4592ea79a2d986063696514c781c9e62be240f09f6397986e01755bc071"},
+    {file = "azure_storage_blob-12.24.0.tar.gz", hash = "sha256:eaaaa1507c8c363d6e1d1342bd549938fdf1adec9b1ada8658c8f5bf3aea844e"},
+]
+
+[package.dependencies]
+azure-core = ">=1.30.0"
+cryptography = ">=2.1.4"
+isodate = ">=0.6.1"
+typing-extensions = ">=4.6.0"
+
+[package.extras]
+aio = ["azure-core[aio] (>=1.30.0)"]
+
+[[package]]
 name = "backports-strenum"
 version = "1.3.1"
 description = "Base class for creating enumerated constants that are also subclasses of str"
@@ -892,6 +952,18 @@ test = ["packaging", "pickleshare", "pytest", "pytest-asyncio (<0.22)", "testpat
 test-extra = ["curio", "ipython[test]", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.23)", "pandas", "trio"]
 
 [[package]]
+name = "isodate"
+version = "0.7.2"
+description = "An ISO 8601 date/time/duration parser and formatter"
+optional = false
+python-versions = ">=3.7"
+groups = ["integration"]
+files = [
+    {file = "isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15"},
+    {file = "isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6"},
+]
+
+[[package]]
 name = "isort"
 version = "5.13.2"
 description = "A Python utility / library to sort Python imports."
@@ -1185,6 +1257,42 @@ files = [
 ]
 
 [[package]]
+name = "msal"
+version = "1.31.1"
+description = "The Microsoft Authentication Library (MSAL) for Python library enables your app to access the Microsoft Cloud by supporting authentication of users with Microsoft Azure Active Directory accounts (AAD) and Microsoft Accounts (MSA) using industry standard OAuth2 and OpenID Connect."
+optional = false
+python-versions = ">=3.7"
+groups = ["integration"]
+files = [
+    {file = "msal-1.31.1-py3-none-any.whl", hash = "sha256:29d9882de247e96db01386496d59f29035e5e841bcac892e6d7bf4390bf6bd17"},
+    {file = "msal-1.31.1.tar.gz", hash = "sha256:11b5e6a3f802ffd3a72107203e20c4eac6ef53401961b880af2835b723d80578"},
+]
+
+[package.dependencies]
+cryptography = ">=2.5,<46"
+PyJWT = {version = ">=1.0.0,<3", extras = ["crypto"]}
+requests = ">=2.0.0,<3"
+
+[package.extras]
+broker = ["pymsalruntime (>=0.14,<0.18)", "pymsalruntime (>=0.17,<0.18)"]
+
+[[package]]
+name = "msal-extensions"
+version = "1.2.0"
+description = "Microsoft Authentication Library extensions (MSAL EX) provides a persistence API that can save your data on disk, encrypted on Windows, macOS and Linux. Concurrent data access will be coordinated by a file lock mechanism."
+optional = false
+python-versions = ">=3.7"
+groups = ["integration"]
+files = [
+    {file = "msal_extensions-1.2.0-py3-none-any.whl", hash = "sha256:cf5ba83a2113fa6dc011a254a72f1c223c88d7dfad74cc30617c4679a417704d"},
+    {file = "msal_extensions-1.2.0.tar.gz", hash = "sha256:6f41b320bfd2933d631a215c91ca0dd3e67d84bd1a2f50ce917d5874ec646bef"},
+]
+
+[package.dependencies]
+msal = ">=1.29,<2"
+portalocker = ">=1.4,<3"
+
+[[package]]
 name = "mypy-extensions"
 version = "1.0.0"
 description = "Type system extensions for programs checked with the mypy type checker."
@@ -1423,6 +1531,26 @@ files = [
 ]
 
 [[package]]
+name = "portalocker"
+version = "2.10.1"
+description = "Wraps the portalocker recipe for easy usage"
+optional = false
+python-versions = ">=3.8"
+groups = ["integration"]
+files = [
+    {file = "portalocker-2.10.1-py3-none-any.whl", hash = "sha256:53a5984ebc86a025552264b459b46a2086e269b21823cb572f8f28ee759e45bf"},
+    {file = "portalocker-2.10.1.tar.gz", hash = "sha256:ef1bf844e878ab08aee7e40184156e1151f228f103aa5c6bd0724cc330960f8f"},
+]
+
+[package.dependencies]
+pywin32 = {version = ">=226", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+docs = ["sphinx (>=1.7.1)"]
+redis = ["redis"]
+tests = ["pytest (>=5.4.1)", "pytest-cov (>=2.8.1)", "pytest-mypy (>=0.8.0)", "pytest-timeout (>=2.1.0)", "redis", "sphinx (>=6.0.0)", "types-redis"]
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.50"
 description = "Library for building powerful interactive command lines in Python"
@@ -1649,6 +1777,27 @@ files = [
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
+name = "pyjwt"
+version = "2.10.1"
+description = "JSON Web Token implementation in Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["integration"]
+files = [
+    {file = "PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb"},
+    {file = "pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953"},
+]
+
+[package.dependencies]
+cryptography = {version = ">=3.4.0", optional = true, markers = "extra == \"crypto\""}
+
+[package.extras]
+crypto = ["cryptography (>=3.4.0)"]
+dev = ["coverage[toml] (==5.0.4)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=6.0.0,<7.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
+docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
+tests = ["coverage[toml] (==5.0.4)", "pytest (>=6.0.0,<7.0.0)"]
 
 [[package]]
 name = "pymacaroons"
@@ -1889,6 +2038,35 @@ groups = ["integration"]
 files = [
     {file = "pytz-2024.2-py2.py3-none-any.whl", hash = "sha256:31c7c1817eb7fae7ca4b8c7ee50c72f93aa2dd863de768e1ef4245d426aa0725"},
     {file = "pytz-2024.2.tar.gz", hash = "sha256:2aa355083c50a0f93fa581709deac0c9ad65cca8a9e9beac660adcbd493c798a"},
+]
+
+[[package]]
+name = "pywin32"
+version = "308"
+description = "Python for Window Extensions"
+optional = false
+python-versions = "*"
+groups = ["integration"]
+markers = "platform_system == \"Windows\""
+files = [
+    {file = "pywin32-308-cp310-cp310-win32.whl", hash = "sha256:796ff4426437896550d2981b9c2ac0ffd75238ad9ea2d3bfa67a1abd546d262e"},
+    {file = "pywin32-308-cp310-cp310-win_amd64.whl", hash = "sha256:4fc888c59b3c0bef905ce7eb7e2106a07712015ea1c8234b703a088d46110e8e"},
+    {file = "pywin32-308-cp310-cp310-win_arm64.whl", hash = "sha256:a5ab5381813b40f264fa3495b98af850098f814a25a63589a8e9eb12560f450c"},
+    {file = "pywin32-308-cp311-cp311-win32.whl", hash = "sha256:5d8c8015b24a7d6855b1550d8e660d8daa09983c80e5daf89a273e5c6fb5095a"},
+    {file = "pywin32-308-cp311-cp311-win_amd64.whl", hash = "sha256:575621b90f0dc2695fec346b2d6302faebd4f0f45c05ea29404cefe35d89442b"},
+    {file = "pywin32-308-cp311-cp311-win_arm64.whl", hash = "sha256:100a5442b7332070983c4cd03f2e906a5648a5104b8a7f50175f7906efd16bb6"},
+    {file = "pywin32-308-cp312-cp312-win32.whl", hash = "sha256:587f3e19696f4bf96fde9d8a57cec74a57021ad5f204c9e627e15c33ff568897"},
+    {file = "pywin32-308-cp312-cp312-win_amd64.whl", hash = "sha256:00b3e11ef09ede56c6a43c71f2d31857cf7c54b0ab6e78ac659497abd2834f47"},
+    {file = "pywin32-308-cp312-cp312-win_arm64.whl", hash = "sha256:9b4de86c8d909aed15b7011182c8cab38c8850de36e6afb1f0db22b8959e3091"},
+    {file = "pywin32-308-cp313-cp313-win32.whl", hash = "sha256:1c44539a37a5b7b21d02ab34e6a4d314e0788f1690d65b48e9b0b89f31abbbed"},
+    {file = "pywin32-308-cp313-cp313-win_amd64.whl", hash = "sha256:fd380990e792eaf6827fcb7e187b2b4b1cede0585e3d0c9e84201ec27b9905e4"},
+    {file = "pywin32-308-cp313-cp313-win_arm64.whl", hash = "sha256:ef313c46d4c18dfb82a2431e3051ac8f112ccee1a34f29c263c583c568db63cd"},
+    {file = "pywin32-308-cp37-cp37m-win32.whl", hash = "sha256:1f696ab352a2ddd63bd07430080dd598e6369152ea13a25ebcdd2f503a38f1ff"},
+    {file = "pywin32-308-cp37-cp37m-win_amd64.whl", hash = "sha256:13dcb914ed4347019fbec6697a01a0aec61019c1046c2b905410d197856326a6"},
+    {file = "pywin32-308-cp38-cp38-win32.whl", hash = "sha256:5794e764ebcabf4ff08c555b31bd348c9025929371763b2183172ff4708152f0"},
+    {file = "pywin32-308-cp38-cp38-win_amd64.whl", hash = "sha256:3b92622e29d651c6b783e368ba7d6722b1634b8e70bd376fd7610fe1992e19de"},
+    {file = "pywin32-308-cp39-cp39-win32.whl", hash = "sha256:7873ca4dc60ab3287919881a7d4f88baee4a6e639aa6962de25a98ba6b193341"},
+    {file = "pywin32-308-cp39-cp39-win_amd64.whl", hash = "sha256:71b3322d949b4cc20776436a9c9ba0eeedcbc9c650daa536df63f0ff111bb920"},
 ]
 
 [[package]]
@@ -2194,7 +2372,6 @@ files = [
     {file = "ruamel.yaml.clib-0.2.12-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f66efbc1caa63c088dead1c4170d148eabc9b80d95fb75b6c92ac0aad2437d76"},
     {file = "ruamel.yaml.clib-0.2.12-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:22353049ba4181685023b25b5b51a574bce33e7f51c759371a7422dcae5402a6"},
     {file = "ruamel.yaml.clib-0.2.12-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:932205970b9f9991b34f55136be327501903f7c66830e9760a8ffb15b07f05cd"},
-    {file = "ruamel.yaml.clib-0.2.12-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a52d48f4e7bf9005e8f0a89209bf9a73f7190ddf0489eee5eb51377385f59f2a"},
     {file = "ruamel.yaml.clib-0.2.12-cp310-cp310-win32.whl", hash = "sha256:3eac5a91891ceb88138c113f9db04f3cebdae277f5d44eaa3651a4f573e6a5da"},
     {file = "ruamel.yaml.clib-0.2.12-cp310-cp310-win_amd64.whl", hash = "sha256:ab007f2f5a87bd08ab1499bdf96f3d5c6ad4dcfa364884cb4549aa0154b13a28"},
     {file = "ruamel.yaml.clib-0.2.12-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:4a6679521a58256a90b0d89e03992c15144c5f3858f40d7c18886023d7943db6"},
@@ -2203,7 +2380,6 @@ files = [
     {file = "ruamel.yaml.clib-0.2.12-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:811ea1594b8a0fb466172c384267a4e5e367298af6b228931f273b111f17ef52"},
     {file = "ruamel.yaml.clib-0.2.12-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:cf12567a7b565cbf65d438dec6cfbe2917d3c1bdddfce84a9930b7d35ea59642"},
     {file = "ruamel.yaml.clib-0.2.12-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:7dd5adc8b930b12c8fc5b99e2d535a09889941aa0d0bd06f4749e9a9397c71d2"},
-    {file = "ruamel.yaml.clib-0.2.12-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1492a6051dab8d912fc2adeef0e8c72216b24d57bd896ea607cb90bb0c4981d3"},
     {file = "ruamel.yaml.clib-0.2.12-cp311-cp311-win32.whl", hash = "sha256:bd0a08f0bab19093c54e18a14a10b4322e1eacc5217056f3c063bd2f59853ce4"},
     {file = "ruamel.yaml.clib-0.2.12-cp311-cp311-win_amd64.whl", hash = "sha256:a274fb2cb086c7a3dea4322ec27f4cb5cc4b6298adb583ab0e211a4682f241eb"},
     {file = "ruamel.yaml.clib-0.2.12-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:20b0f8dc160ba83b6dcc0e256846e1a02d044e13f7ea74a3d1d56ede4e48c632"},
@@ -2212,7 +2388,6 @@ files = [
     {file = "ruamel.yaml.clib-0.2.12-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:749c16fcc4a2b09f28843cda5a193e0283e47454b63ec4b81eaa2242f50e4ccd"},
     {file = "ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:bf165fef1f223beae7333275156ab2022cffe255dcc51c27f066b4370da81e31"},
     {file = "ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:32621c177bbf782ca5a18ba4d7af0f1082a3f6e517ac2a18b3974d4edf349680"},
-    {file = "ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b82a7c94a498853aa0b272fd5bc67f29008da798d4f93a2f9f289feb8426a58d"},
     {file = "ruamel.yaml.clib-0.2.12-cp312-cp312-win32.whl", hash = "sha256:e8c4ebfcfd57177b572e2040777b8abc537cdef58a2120e830124946aa9b42c5"},
     {file = "ruamel.yaml.clib-0.2.12-cp312-cp312-win_amd64.whl", hash = "sha256:0467c5965282c62203273b838ae77c0d29d7638c8a4e3a1c8bdd3602c10904e4"},
     {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4c8c5d82f50bb53986a5e02d1b3092b03622c02c2eb78e29bec33fd9593bae1a"},
@@ -2221,7 +2396,6 @@ files = [
     {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:96777d473c05ee3e5e3c3e999f5d23c6f4ec5b0c38c098b3a5229085f74236c6"},
     {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:3bc2a80e6420ca8b7d3590791e2dfc709c88ab9152c00eeb511c9875ce5778bf"},
     {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:e188d2699864c11c36cdfdada94d781fd5d6b0071cd9c427bceb08ad3d7c70e1"},
-    {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f6f3eac23941b32afccc23081e1f50612bdbe4e982012ef4f5797986828cd01"},
     {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-win32.whl", hash = "sha256:6442cb36270b3afb1b4951f060eccca1ce49f3d087ca1ca4563a6eb479cb3de6"},
     {file = "ruamel.yaml.clib-0.2.12-cp313-cp313-win_amd64.whl", hash = "sha256:e5b8daf27af0b90da7bb903a876477a9e6d7270be6146906b276605997c7e9a3"},
     {file = "ruamel.yaml.clib-0.2.12-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:fc4b630cd3fa2cf7fce38afa91d7cfe844a9f75d7f0f36393fa98815e911d987"},
@@ -2230,7 +2404,6 @@ files = [
     {file = "ruamel.yaml.clib-0.2.12-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e2f1c3765db32be59d18ab3953f43ab62a761327aafc1594a2a1fbe038b8b8a7"},
     {file = "ruamel.yaml.clib-0.2.12-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:d85252669dc32f98ebcd5d36768f5d4faeaeaa2d655ac0473be490ecdae3c285"},
     {file = "ruamel.yaml.clib-0.2.12-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:e143ada795c341b56de9418c58d028989093ee611aa27ffb9b7f609c00d813ed"},
-    {file = "ruamel.yaml.clib-0.2.12-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:2c59aa6170b990d8d2719323e628aaf36f3bfbc1c26279c0eeeb24d05d2d11c7"},
     {file = "ruamel.yaml.clib-0.2.12-cp39-cp39-win32.whl", hash = "sha256:beffaed67936fbbeffd10966a4eb53c402fafd3d6833770516bf7314bc6ffa12"},
     {file = "ruamel.yaml.clib-0.2.12-cp39-cp39-win_amd64.whl", hash = "sha256:040ae85536960525ea62868b642bdb0c2cc6021c9f9d507810c0c604e66f5a7b"},
     {file = "ruamel.yaml.clib-0.2.12.tar.gz", hash = "sha256:6c8fbb13ec503f99a91901ab46e0b07ae7941cd527393187039aec586fdfd36f"},
@@ -2591,4 +2764,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "7644d60b14494d0f2d403cbdcedb3296151ce669a21621826880d4289bf5b469"
+content-hash = "ce2c745233e77ed955393b4368522385b37ff5f9966276fed0b4598d408b1495"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ jproperties = "2.1.1"
 pydantic = "^1.10.17, <2"
 cryptography = "^43.0.0"
 jsonschema = "^4.23.0"
-poetry-core = "^1.9.0"
 data-platform-helpers = "^0.1.4"
+poetry-core = "<2.0.0"
 
 
 [tool.poetry.group.charm-libs.dependencies]
@@ -84,6 +84,9 @@ protobuf = "^5.27.2"
 opensearch-py = "^2.6.0"
 allure-pytest = "^2.13.5"
 allure-pytest-collection-report = {git = "https://github.com/canonical/data-platform-workflows", tag = "v29.0.0", subdirectory = "python/pytest_plugins/allure_pytest_collection_report"}
+# Azure integration tests
+azure-identity = "^1.19"
+azure-storage-blob = "^12.24"
 
 [tool.coverage.run]
 branch = true

--- a/src/upgrade.py
+++ b/src/upgrade.py
@@ -291,7 +291,10 @@ class Upgrade(abc.ABC):
             ):
                 raise PrecheckFailed("Not all units are online for the current app.")
 
-            if self._charm.backup.is_set() and not self._charm.backup.is_idle():
+            if (
+                self._charm.backup.backup_manager.is_set()
+                and not self._charm.backup.backup_manager.is_idle()
+            ):
                 raise PrecheckFailed("Backup or restore is in progress")
 
         except OpenSearchHttpError:

--- a/tests/integration/ha/helpers.py
+++ b/tests/integration/ha/helpers.py
@@ -10,7 +10,6 @@ import time
 from typing import Dict, List, Optional
 
 from charms.opensearch.v0.models import App, Node
-from charms.opensearch.v0.opensearch_backups import S3_REPOSITORY
 from pytest_operator.plugin import OpsTest
 from tenacity import (
     RetryError,
@@ -508,15 +507,15 @@ async def wait_for_backup_system_to_settle(
                         raise Exception(f"Recovery failed for shard {shard}")
 
 
-async def delete_backup(ops_test: OpsTest, backup_id: int) -> None:
-    """Deletes a backup."""
-    # Now, check if we have finished the restore
-    unit_ip = await get_leader_unit_ip(ops_test)
-    await http_request(
-        ops_test,
-        "DELETE",
-        f"https://{unit_ip}:9200/_snapshot/{S3_REPOSITORY}/{backup_id}",
-    )
+# async def delete_backup(ops_test: OpsTest, backup_id: int, repository: str) -> None:
+#     """Deletes a backup."""
+#     # Now, check if we have finished the restore
+#     unit_ip = await get_leader_unit_ip(ops_test)
+#     await http_request(
+#         ops_test,
+#         "DELETE",
+#         f"https://{unit_ip}:9200/_snapshot/{repository}/{backup_id}",
+#     )
 
 
 async def assert_start_and_check_continuous_writes(
@@ -595,3 +594,19 @@ async def assert_restore_indices_and_compare_consistency(
     # We expect that new_count has a loss of documents and the numbers are different.
     # Check if we have data but not all of it.
     assert 0 < new_count < original_count
+
+
+async def add_juju_secret(
+    ops_test: OpsTest, charm_name: str, secret_label: str, data: Dict[str, str]
+) -> str:
+    """Add a new juju secret."""
+    logger.info(f"Data keys to insert: {data.keys()}")
+    key_values = " ".join([f"{key}={value}" for key, value in data.items()])
+    command = f"add-secret {secret_label} {key_values}"
+    _, stdout, _ = await ops_test.juju(*command.split())
+    logger.info(f"Add secret output: {stdout}")
+    secret_uri = stdout.strip()
+    logger.info(f"Secret uri: {secret_uri}")
+    command = f"grant-secret {secret_label} {charm_name}"
+    _, stdout, _ = await ops_test.juju(*command.split())
+    return secret_uri

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -901,6 +901,9 @@ async def test_change_config_and_backup_restore(
 
     initial_count: int = 0
     for cloud_name in cloud_configs.keys():
+        # Azure has no different config setups at this point
+        if cloud_name == "azure":
+            continue
         logger.debug(
             f"Index {ContinuousWrites.INDEX_NAME} has {initial_count} documents, starting there"
         )

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -283,8 +283,8 @@ async def _configure_azure(
     local_label = "".join(random.choice(string.ascii_letters) for _ in range(10))
     credentials_secret_uri = await add_juju_secret(
         ops_test,
+        AZURE_INTEGRATOR,
         local_label,
-        "azure-secret",
         {"secret-key": credentials["secret-key"]},
     )
     logger.info(

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -17,6 +17,8 @@ different cloud.
 
 import asyncio
 import logging
+import random
+import string
 import subprocess
 import time
 import uuid
@@ -25,10 +27,11 @@ from typing import Dict
 
 import boto3
 import pytest
+from azure.storage.blob import BlobServiceClient
 from charms.opensearch.v0.constants_charm import (
     OPENSEARCH_BACKUP_ID_FORMAT,
+    BackupRelShouldNotExist,
     BackupSetupFailed,
-    S3RelShouldNotExist,
 )
 from charms.opensearch.v0.opensearch_backups import S3_REPOSITORY
 from pytest_operator.plugin import OpsTest
@@ -48,6 +51,7 @@ from ..helpers import (
 from ..helpers_deployments import get_application_units, wait_until
 from ..tls.test_tls import TLS_CERTIFICATES_APP_NAME
 from .helpers import (
+    add_juju_secret,
     app_name,
     assert_continuous_writes_consistency,
     assert_continuous_writes_increasing,
@@ -80,17 +84,26 @@ ALL_GROUPS = {
             ),
         ],
     )
-    for cloud_name in ["microceph", "aws"]
+    for cloud_name in ["microceph", "aws", "azure"]
     for deploy_type in ["large", "small"]
 }
 
 ALL_DEPLOYMENTS_ALL_CLOUDS = list(ALL_GROUPS.values())
-SMALL_DEPLOYMENTS_ALL_CLOUDS = [ALL_GROUPS[(cloud, "small")] for cloud in ["aws", "microceph"]]
-LARGE_DEPLOYMENTS_ALL_CLOUDS = [ALL_GROUPS[(cloud, "large")] for cloud in ["aws", "microceph"]]
+SMALL_DEPLOYMENTS_ALL_CLOUDS = [
+    ALL_GROUPS[(cloud, "small")] for cloud in ["aws", "microceph", "azure"]
+]
+LARGE_DEPLOYMENTS_ALL_CLOUDS = [
+    ALL_GROUPS[(cloud, "large")] for cloud in ["aws", "microceph", "azure"]
+]
 
 
 S3_INTEGRATOR = "s3-integrator"
 S3_INTEGRATOR_CHANNEL = "latest/edge"
+S3_RELATION = "s3-credentials"
+AZURE_INTEGRATOR = "azure-storage-integrator"
+AZURE_INTEGRATOR_CHANNEL = "latest/edge"
+AZURE_RELATION = "azure-credentials"
+
 TIMEOUT = 20 * 60
 BackupsPath = f"opensearch/{uuid.uuid4()}"
 
@@ -140,6 +153,12 @@ def cloud_configs(
             "path": BackupsPath,
             "region": "us-east-1",
         }
+    if "AZURE_SECRET_KEY" in github_secrets:
+        results["azure"] = {
+            "connection-protocol": "abfss",
+            "container": "data-charms-testing",
+            "path": BackupsPath,
+        }
     return results
 
 
@@ -159,11 +178,16 @@ def cloud_credentials(
             "access-key": github_secrets["AWS_ACCESS_KEY"],
             "secret-key": github_secrets["AWS_SECRET_KEY"],
         }
+    if "AZURE_SECRET_KEY" in github_secrets:
+        results["azure"] = {
+            "secret-key": github_secrets["AZURE_SECRET_KEY"],
+            "storage-account": github_secrets["AZURE_STORAGE_ACCOUNT"],
+        }
     return results
 
 
 @pytest.fixture(scope="session", autouse=True)
-def remove_backups(
+def remove_backups(  # noqa C901
     # ops_test: OpsTest,
     cloud_configs: Dict[str, Dict[str, str]],
     cloud_credentials: Dict[str, Dict[str, str]],
@@ -173,32 +197,58 @@ def remove_backups(
 
     logger.info("Cleaning backups from cloud buckets")
     for cloud_name, config in cloud_configs.items():
-        if (
-            cloud_name not in cloud_credentials
-            or "access-key" not in cloud_credentials[cloud_name]
-            or "secret-key" not in cloud_credentials[cloud_name]
-        ):
-            # This cloud has not been used in this test run
+        if cloud_name not in cloud_credentials:
             continue
 
-        session = boto3.session.Session(
-            aws_access_key_id=cloud_credentials[cloud_name]["access-key"],
-            aws_secret_access_key=cloud_credentials[cloud_name]["secret-key"],
-            region_name=config["region"],
-        )
-        s3 = session.resource("s3", endpoint_url=config["endpoint"])
-        bucket = s3.Bucket(config["bucket"])
+        if cloud_name == "aws" or cloud_name == "microceph":
+            if (
+                "access-key" not in cloud_credentials[cloud_name]
+                or "secret-key" not in cloud_credentials[cloud_name]
+            ):
+                # This cloud has not been used in this test run
+                continue
 
-        # Some of our runs target only a single cloud, therefore, they will
-        # raise errors on the other cloud's bucket. We catch and log them.
-        try:
-            bucket.objects.filter(Prefix=f"{BackupsPath}/").delete()
-        except Exception as e:
-            logger.warning(f"Failed to clean up backups: {e}")
+            session = boto3.session.Session(
+                aws_access_key_id=cloud_credentials[cloud_name]["access-key"],
+                aws_secret_access_key=cloud_credentials[cloud_name]["secret-key"],
+                region_name=config["region"],
+            )
+            s3 = session.resource("s3", endpoint_url=config["endpoint"])
+            bucket = s3.Bucket(config["bucket"])
+
+            # Some of our runs target only a single cloud, therefore, they will
+            # raise errors on the other cloud's bucket. We catch and log them.
+            try:
+                bucket.objects.filter(Prefix=f"{BackupsPath}/").delete()
+            except Exception as e:
+                logger.warning(f"Failed to clean up backups: {e}")
+
+        if cloud_name == "azure":
+            if (
+                "secret-key" not in cloud_credentials[cloud_name]
+                or "storage-account" not in cloud_credentials[cloud_name]
+            ):
+                # This cloud has not been used in this test run
+                continue
+
+            storage_account = cloud_credentials[cloud_name]["storage-account"]
+            secret_key = cloud_credentials[cloud_name]["secret-key"]
+            connection_string = f"DefaultEndpointsProtocol=https;AccountName={storage_account};AccountKey={secret_key};EndpointSuffix=core.windows.net"
+            blob_service_client = BlobServiceClient.from_connection_string(connection_string)
+            container_client = blob_service_client.get_container_client(config["container"])
+
+            # List and delete blobs with the specified prefix
+            blobs_to_delete = container_client.list_blobs(name_starts_with=BackupsPath)
+
+            try:
+                for blob in blobs_to_delete:
+                    container_client.delete_blob(blob.name)
+            except Exception as e:
+                logger.warning(f"Failed to clean up backups: {e}")
 
 
 async def _configure_s3(
-    ops_test: OpsTest, config: Dict[str, str], credentials: Dict[str, str], app_name: str
+    ops_test: OpsTest, config: Dict[str, str], credentials: Dict[str, str], app_name: str = None
 ) -> None:
     await ops_test.model.applications[S3_INTEGRATOR].set_config(config)
     s3_integrator_id = (await get_application_units(ops_test, S3_INTEGRATOR))[
@@ -211,8 +261,47 @@ async def _configure_s3(
         params=credentials,
         app=S3_INTEGRATOR,
     )
+
+    apps = [S3_INTEGRATOR] if app_name is None else [S3_INTEGRATOR, app_name]
     await ops_test.model.wait_for_idle(
-        apps=[app_name, S3_INTEGRATOR],
+        apps=apps,
+        status="active",
+        timeout=TIMEOUT,
+    )
+
+
+async def _configure_azure(
+    ops_test: OpsTest,
+    config: Dict[str, str],
+    credentials: Dict[str, str],
+    app_name: str = None,
+) -> None:
+    await ops_test.model.applications[AZURE_INTEGRATOR].set_config(config)
+    logger.info("Adding Juju secret for secret-key config option for azure-storage-integrator")
+
+    # Creates a new secret for each test
+    local_label = "".join(random.choice(string.ascii_letters) for _ in range(10))
+    credentials_secret_uri = await add_juju_secret(
+        ops_test,
+        local_label,
+        "azure-secret",
+        {"secret-key": credentials["secret-key"]},
+    )
+    logger.info(
+        f"Juju secret for secret-key config option for azure-storage-integrator added. Secret URI: {credentials_secret_uri}"
+    )
+
+    configuration_parameters = {
+        "storage-account": credentials["storage-account"],
+        "credentials": credentials_secret_uri,
+    }
+    # apply new configuration options
+    logger.info("Setting up configuration for azure-storage-integrator charm...")
+    await ops_test.model.applications[AZURE_INTEGRATOR].set_config(configuration_parameters)
+
+    apps = [AZURE_INTEGRATOR] if app_name is None else [AZURE_INTEGRATOR, app_name]
+    await ops_test.model.wait_for_idle(
+        apps=apps,
         status="active",
         timeout=TIMEOUT,
     )
@@ -233,9 +322,14 @@ async def test_small_deployment_build_and_deploy(
     # Deploy TLS Certificates operator.
     config = {"ca-common-name": "CN_CA"}
 
+    backup_integrator = AZURE_INTEGRATOR if cloud_name == "azure" else S3_INTEGRATOR
+    backup_integrator_channel = (
+        AZURE_INTEGRATOR_CHANNEL if cloud_name == "azure" else S3_INTEGRATOR_CHANNEL
+    )
+
     await asyncio.gather(
         ops_test.model.deploy(TLS_CERTIFICATES_APP_NAME, channel="stable", config=config),
-        ops_test.model.deploy(S3_INTEGRATOR, channel=S3_INTEGRATOR_CHANNEL),
+        ops_test.model.deploy(backup_integrator, channel=backup_integrator_channel),
         ops_test.model.deploy(my_charm, num_units=3, series=SERIES, config=CONFIG_OPTS),
     )
 
@@ -249,7 +343,7 @@ async def test_small_deployment_build_and_deploy(
     )
     # Credentials not set yet, this will move the opensearch to blocked state
     # Credentials are set per test scenario
-    await ops_test.model.integrate(APP_NAME, S3_INTEGRATOR)
+    await ops_test.model.integrate(APP_NAME, backup_integrator)
 
 
 @pytest.mark.parametrize("cloud_name,deploy_type", LARGE_DEPLOYMENTS_ALL_CLOUDS)
@@ -286,9 +380,14 @@ async def test_large_deployment_build_and_deploy(
     }
     data_hot_conf = {"cluster_name": "backup-test", "init_hold": True, "roles": "data.hot"}
 
+    backup_integrator = AZURE_INTEGRATOR if cloud_name == "azure" else S3_INTEGRATOR
+    backup_integrator_channel = (
+        AZURE_INTEGRATOR_CHANNEL if cloud_name == "azure" else S3_INTEGRATOR_CHANNEL
+    )
+
     await asyncio.gather(
         ops_test.model.deploy(TLS_CERTIFICATES_APP_NAME, channel="stable", config=tls_config),
-        ops_test.model.deploy(S3_INTEGRATOR, channel=S3_INTEGRATOR_CHANNEL),
+        ops_test.model.deploy(backup_integrator, channel=backup_integrator_channel),
         ops_test.model.deploy(
             my_charm,
             application_name="main",
@@ -342,7 +441,7 @@ async def test_large_deployment_build_and_deploy(
 
     # Credentials not set yet, this will move the opensearch to blocked state
     # Credentials are set per test scenario
-    await ops_test.model.integrate("main", S3_INTEGRATOR)
+    await ops_test.model.integrate("main", backup_integrator)
 
 
 @pytest.mark.parametrize("cloud_name,deploy_type", LARGE_DEPLOYMENTS_ALL_CLOUDS)
@@ -353,31 +452,30 @@ async def test_large_setups_relations_with_misconfiguration(
     deploy_type: str,
 ) -> None:
     """Tests the different blocked messages expected in large deployments."""
-    config = {
-        "endpoint": "http://localhost",
-        "bucket": "error",
-        "path": "/",
-        "region": "default",
-    }
-    credentials = {
-        "access-key": "error",
-        "secret-key": "error",
-    }
+    if cloud_name == "azure":
+        config = {
+            "connection-protocol": "abfss",
+            "container": "error",
+            "path": "/",
+        }
+        credentials = {
+            "storage-account": "error",
+            "secret-key": "error",
+        }
+        await _configure_azure(ops_test=ops_test, config=config, credentials=credentials)
+    else:
+        config = {
+            "endpoint": "http://localhost",
+            "bucket": "error",
+            "path": "/",
+            "region": "default",
+        }
+        credentials = {
+            "access-key": "error",
+            "secret-key": "error",
+        }
+        await _configure_s3(ops_test=ops_test, config=config, credentials=credentials)
 
-    # Not using _configure_s3 as this method will cause opensearch to block
-    await ops_test.model.applications[S3_INTEGRATOR].set_config(config)
-    await run_action(
-        ops_test,
-        0,
-        "sync-s3-credentials",
-        params=credentials,
-        app=S3_INTEGRATOR,
-    )
-    await ops_test.model.wait_for_idle(
-        apps=[S3_INTEGRATOR],
-        status="active",
-        timeout=TIMEOUT,
-    )
     await wait_until(
         ops_test,
         apps=["main"],
@@ -386,28 +484,32 @@ async def test_large_setups_relations_with_misconfiguration(
         idle_period=IDLE_PERIOD,
     )
 
-    # Now, relate failover cluster to s3-integrator and review the status
-    await ops_test.model.integrate("failover:s3-credentials", S3_INTEGRATOR)
-    await ops_test.model.integrate(f"{APP_NAME}:s3-credentials", S3_INTEGRATOR)
+    backup_integrator = AZURE_INTEGRATOR if cloud_name == "azure" else S3_INTEGRATOR
+    backup_relation = AZURE_RELATION if cloud_name == "azure" else S3_RELATION
+    # Now, relate failover cluster to backup-integrator and review the status
+
+    await ops_test.model.integrate(f"failover:{backup_relation}", backup_integrator)
+    await ops_test.model.integrate(f"{APP_NAME}:{backup_relation}", backup_integrator)
     await wait_until(
         ops_test,
         apps=["main", "failover", APP_NAME],
         apps_statuses=["blocked"],
         apps_full_statuses={
             "main": {"blocked": [BackupSetupFailed]},
-            "failover": {"blocked": [S3RelShouldNotExist]},
-            APP_NAME: {"blocked": [S3RelShouldNotExist]},
+            "failover": {"blocked": [BackupRelShouldNotExist]},
+            APP_NAME: {"blocked": [BackupRelShouldNotExist]},
         },
         idle_period=IDLE_PERIOD,
     )
 
     # Reverting should return it to normal
     await ops_test.model.applications[APP_NAME].destroy_relation(
-        f"{APP_NAME}:s3-credentials", S3_INTEGRATOR
+        f"{APP_NAME}:{backup_relation}", backup_integrator
     )
     await ops_test.model.applications["failover"].destroy_relation(
-        "failover:s3-credentials", S3_INTEGRATOR
+        f"failover:{backup_relation}", backup_integrator
     )
+
     await wait_until(
         ops_test,
         apps=["main"],
@@ -442,7 +544,10 @@ async def test_create_backup_and_restore(
     config = cloud_configs[cloud_name]
 
     logger.info(f"Syncing credentials for {cloud_name}")
-    await _configure_s3(ops_test, config, cloud_credentials[cloud_name], app)
+    if cloud_name == "azure":
+        await _configure_azure(ops_test, config, cloud_credentials[cloud_name], app)
+    else:
+        await _configure_s3(ops_test, config, cloud_credentials[cloud_name], app)
 
     date_before_backup = datetime.utcnow()
     assert (
@@ -474,7 +579,7 @@ async def test_create_backup_and_restore(
 
 @pytest.mark.parametrize("cloud_name,deploy_type", ALL_DEPLOYMENTS_ALL_CLOUDS)
 @pytest.mark.abort_on_fail
-async def test_remove_and_readd_s3_relation(
+async def test_remove_and_readd_backup_relation(
     ops_test: OpsTest,
     c_writes: ContinuousWrites,
     c_writes_runner,
@@ -483,7 +588,7 @@ async def test_remove_and_readd_s3_relation(
     cloud_name: str,
     deploy_type: str,
 ) -> None:
-    """Removes and re-adds the s3-credentials relation to test backup and restore."""
+    """Removes and re-adds the backup relation to test backup and restore."""
     app = (await app_name(ops_test) or APP_NAME) if deploy_type == "small" else "main"
     apps = [app] if deploy_type == "small" else [app, APP_NAME]
 
@@ -491,10 +596,13 @@ async def test_remove_and_readd_s3_relation(
     unit_ip: str = await get_leader_unit_ip(ops_test, app=app)
     config: Dict[str, str] = cloud_configs[cloud_name]
 
-    logger.info("Remove s3-credentials relation")
+    backup_integrator = AZURE_INTEGRATOR if cloud_name == "azure" else S3_INTEGRATOR
+    backup_relation = AZURE_RELATION if cloud_name == "azure" else S3_RELATION
+
+    logger.info("Remove backup relation")
     # Remove relation
     await ops_test.model.applications[app].destroy_relation(
-        "s3-credentials", f"{S3_INTEGRATOR}:s3-credentials"
+        backup_relation, f"{backup_integrator}:{backup_relation}"
     )
     await ops_test.model.wait_for_idle(
         apps=[app],
@@ -503,8 +611,8 @@ async def test_remove_and_readd_s3_relation(
         idle_period=IDLE_PERIOD,
     )
 
-    logger.info("Re-add s3-credentials relation")
-    await ops_test.model.integrate(app, S3_INTEGRATOR)
+    logger.info("Re-add backup credentials relation")
+    await ops_test.model.integrate(app, backup_integrator)
     await ops_test.model.wait_for_idle(
         apps=[app],
         status="active",
@@ -513,7 +621,10 @@ async def test_remove_and_readd_s3_relation(
     )
 
     logger.info(f"Syncing credentials for {cloud_name}")
-    await _configure_s3(ops_test, config, cloud_credentials[cloud_name], app)
+    if cloud_name == "azure":
+        await _configure_azure(ops_test, config, cloud_credentials[cloud_name], app)
+    else:
+        await _configure_s3(ops_test, config, cloud_credentials[cloud_name], app)
 
     date_before_backup = datetime.utcnow()
     assert (
@@ -562,10 +673,14 @@ async def test_restore_to_new_cluster(
     2) Try to write to that new index.
     """
     app = (await app_name(ops_test) or APP_NAME) if deploy_type == "small" else "main"
+    backup_integrator = AZURE_INTEGRATOR if cloud_name == "azure" else S3_INTEGRATOR
+    backup_integrator_channel = (
+        AZURE_INTEGRATOR_CHANNEL if cloud_name == "azure" else S3_INTEGRATOR_CHANNEL
+    )
+
     logging.info("Destroying the application")
-    # Now, remove the applications
     await asyncio.gather(
-        ops_test.model.remove_application(S3_INTEGRATOR, block_until_done=True),
+        ops_test.model.remove_application(backup_integrator, block_until_done=True),
         ops_test.model.remove_application(app, block_until_done=True),
         ops_test.model.remove_application(TLS_CERTIFICATES_APP_NAME, block_until_done=True),
     )
@@ -578,7 +693,7 @@ async def test_restore_to_new_cluster(
 
     await asyncio.gather(
         ops_test.model.deploy(TLS_CERTIFICATES_APP_NAME, channel="stable", config=config),
-        ops_test.model.deploy(S3_INTEGRATOR, channel=S3_INTEGRATOR_CHANNEL),
+        ops_test.model.deploy(backup_integrator, channel=backup_integrator_channel),
         ops_test.model.deploy(my_charm, num_units=3, series=SERIES, config=CONFIG_OPTS),
     )
 
@@ -592,14 +707,17 @@ async def test_restore_to_new_cluster(
     )
     # Credentials not set yet, this will move the opensearch to blocked state
     # Credentials are set per test scenario
-    await ops_test.model.integrate(app, S3_INTEGRATOR)
+    await ops_test.model.integrate(app, backup_integrator)
 
     leader_id = await get_leader_unit_id(ops_test, app=app)
     unit_ip = await get_leader_unit_ip(ops_test, app=app)
     config: Dict[str, str] = cloud_configs[cloud_name]
 
     logger.info(f"Syncing credentials for {cloud_name}")
-    await _configure_s3(ops_test, config, cloud_credentials[cloud_name], app)
+    if cloud_name == "azure":
+        await _configure_azure(ops_test, config, cloud_credentials[cloud_name], app)
+    else:
+        await _configure_s3(ops_test, config, cloud_credentials[cloud_name], app)
     backups = await list_backups(ops_test, leader_id, app=app)
 
     global cwrites_backup_doc_count

--- a/tests/integration/plugins/test_plugins.py
+++ b/tests/integration/plugins/test_plugins.py
@@ -230,6 +230,25 @@ async def test_config_switch_before_cluster_ready(ops_test: OpsTest, deploy_type
 
 @pytest.mark.parametrize("deploy_type", SMALL_DEPLOYMENTS)
 @pytest.mark.abort_on_fail
+async def test_config_switch_before_cluster_ready(ops_test: OpsTest, deploy_type) -> None:
+    """Configuration change before cluster is ready.
+
+    We hold the cluster without starting its unit services by not relating to tls-operator.
+    """
+    await ops_test.model.applications[APP_NAME].set_config({"plugin_opensearch_knn": "true"})
+    await wait_until(
+        ops_test,
+        apps=[APP_NAME],
+        units_statuses=["blocked"],
+        wait_for_exact_units={APP_NAME: 3},
+        timeout=3400,
+        idle_period=IDLE_PERIOD,
+    )
+    await assert_knn_config_updated(ops_test, True, check_api=False)
+
+
+@pytest.mark.parametrize("deploy_type", SMALL_DEPLOYMENTS)
+@pytest.mark.abort_on_fail
 async def test_prometheus_exporter_enabled_by_default(ops_test, deploy_type: str):
     """Test that Prometheus Exporter is running before the relation is there.
 

--- a/tests/integration/plugins/test_plugins.py
+++ b/tests/integration/plugins/test_plugins.py
@@ -208,7 +208,6 @@ async def test_build_and_deploy_small_deployment(ops_test: OpsTest, deploy_type:
 @pytest.mark.abort_on_fail
 async def test_config_switch_before_cluster_ready(ops_test: OpsTest, deploy_type) -> None:
     """Configuration change before cluster is ready.
-
     We hold the cluster without starting its unit services by not relating to tls-operator.
     """
     await ops_test.model.applications[APP_NAME].set_config({"plugin_opensearch_knn": "true"})
@@ -221,11 +220,17 @@ async def test_config_switch_before_cluster_ready(ops_test: OpsTest, deploy_type
         idle_period=IDLE_PERIOD,
     )
     await assert_knn_config_updated(ops_test, True, check_api=False)
+
     # Deploy TLS Certificates operator.
     config = {"ca-common-name": "CN_CA"}
     await asyncio.gather(
         ops_test.model.deploy(TLS_CERTIFICATES_APP_NAME, channel="stable", config=config),
     )
+
+    # Relate it to OpenSearch to set up TLS.
+    await ops_test.model.integrate(APP_NAME, TLS_CERTIFICATES_APP_NAME)
+    await _wait_for_units(ops_test, deploy_type)
+    assert len(ops_test.model.applications[APP_NAME].units) == 3
 
 
 @pytest.mark.parametrize("deploy_type", SMALL_DEPLOYMENTS)

--- a/tests/integration/plugins/test_plugins.py
+++ b/tests/integration/plugins/test_plugins.py
@@ -224,9 +224,6 @@ async def test_config_switch_before_cluster_ready(ops_test: OpsTest, deploy_type
 
     # Deploy TLS Certificates operator.
     config = {"ca-common-name": "CN_CA"}
-    await asyncio.gather(
-        ops_test.model.deploy(TLS_CERTIFICATES_APP_NAME, channel="stable", config=config),
-    )
 
     # Relate it to OpenSearch to set up TLS.
     await ops_test.model.integrate(APP_NAME, TLS_CERTIFICATES_APP_NAME)

--- a/tests/integration/plugins/test_plugins.py
+++ b/tests/integration/plugins/test_plugins.py
@@ -222,9 +222,6 @@ async def test_config_switch_before_cluster_ready(ops_test: OpsTest, deploy_type
     )
     await assert_knn_config_updated(ops_test, True, check_api=False)
 
-    # Deploy TLS Certificates operator.
-    config = {"ca-common-name": "CN_CA"}
-
     # Relate it to OpenSearch to set up TLS.
     await ops_test.model.integrate(APP_NAME, TLS_CERTIFICATES_APP_NAME)
     await _wait_for_units(ops_test, deploy_type)

--- a/tests/integration/plugins/test_plugins.py
+++ b/tests/integration/plugins/test_plugins.py
@@ -208,6 +208,7 @@ async def test_build_and_deploy_small_deployment(ops_test: OpsTest, deploy_type:
 @pytest.mark.abort_on_fail
 async def test_config_switch_before_cluster_ready(ops_test: OpsTest, deploy_type) -> None:
     """Configuration change before cluster is ready.
+
     We hold the cluster without starting its unit services by not relating to tls-operator.
     """
     await ops_test.model.applications[APP_NAME].set_config({"plugin_opensearch_knn": "true"})

--- a/tests/integration/plugins/test_plugins.py
+++ b/tests/integration/plugins/test_plugins.py
@@ -221,30 +221,11 @@ async def test_config_switch_before_cluster_ready(ops_test: OpsTest, deploy_type
         idle_period=IDLE_PERIOD,
     )
     await assert_knn_config_updated(ops_test, True, check_api=False)
-
-    # Relate it to OpenSearch to set up TLS.
-    await ops_test.model.integrate(APP_NAME, TLS_CERTIFICATES_APP_NAME)
-    await _wait_for_units(ops_test, deploy_type)
-    assert len(ops_test.model.applications[APP_NAME].units) == 3
-
-
-@pytest.mark.parametrize("deploy_type", SMALL_DEPLOYMENTS)
-@pytest.mark.abort_on_fail
-async def test_config_switch_before_cluster_ready(ops_test: OpsTest, deploy_type) -> None:
-    """Configuration change before cluster is ready.
-
-    We hold the cluster without starting its unit services by not relating to tls-operator.
-    """
-    await ops_test.model.applications[APP_NAME].set_config({"plugin_opensearch_knn": "true"})
-    await wait_until(
-        ops_test,
-        apps=[APP_NAME],
-        units_statuses=["blocked"],
-        wait_for_exact_units={APP_NAME: 3},
-        timeout=3400,
-        idle_period=IDLE_PERIOD,
+    # Deploy TLS Certificates operator.
+    config = {"ca-common-name": "CN_CA"}
+    await asyncio.gather(
+        ops_test.model.deploy(TLS_CERTIFICATES_APP_NAME, channel="stable", config=config),
     )
-    await assert_knn_config_updated(ops_test, True, check_api=False)
 
 
 @pytest.mark.parametrize("deploy_type", SMALL_DEPLOYMENTS)

--- a/tests/unit/lib/test_backups.py
+++ b/tests/unit/lib/test_backups.py
@@ -173,7 +173,7 @@ def test_can_unit_perform_backup_backup_in_progress(harness, caplog):
         harness.charm.backup._check_repo_status = MagicMock(
             return_value=BackupServiceState.SUCCESS
         )
-        harness.charm.backup.is_backup_in_progress = MagicMock(return_value=True)
+        harness.charm.backup.backup_manager.is_backup_in_progress = MagicMock(return_value=True)
         result = harness.charm.backup._can_unit_perform_backup(event)
     assert not caplog.records
     assert not result
@@ -259,7 +259,7 @@ def test_can_unit_perform_backup_backup_in_progress(harness, caplog):
 def test_restore_finished_true(harness, mock_request, leader, request_value, result_value):
     harness.charm.backup.charm.unit.is_leader = MagicMock(return_value=leader)
     mock_request.return_value = request_value
-    assert harness.charm.backup._is_restore_complete() == result_value
+    assert harness.charm.backup.backup_manager.is_restore_complete() == result_value
 
 
 @pytest.mark.parametrize(
@@ -385,7 +385,7 @@ def test_restore_finished_true(harness, mock_request, leader, request_value, res
 def test_close_indices_if_needed(
     harness, mock_request, list_backup_response, cluster_state, req_response, exception_raised
 ):
-    harness.charm.backup._list_backups = MagicMock(return_value=list_backup_response)
+    harness.charm.backup.backup_manager.list_backups = MagicMock(return_value=list_backup_response)
     charms.opensearch.v0.opensearch_backups.ClusterState.indices = MagicMock(
         return_value=cluster_state
     )
@@ -464,7 +464,9 @@ def test_on_s3_broken_steps(
     harness.charm.plugin_manager.apply_config = (
         MagicMock(side_effect=apply_config_exc) if apply_config_exc else MagicMock()
     )
-    harness.charm.backup._check_snapshot_status = MagicMock(return_value=snapshot_status)
+    harness.charm.backup.backup_manager.check_snapshot_status = MagicMock(
+        return_value=snapshot_status
+    )
     harness.charm.unit.is_leader = MagicMock(return_value=is_leader)
     harness.charm.plugin_manager.get_plugin = MagicMock()
     harness.charm.plugin_manager.status = MagicMock(return_value=PluginState.ENABLED)
@@ -563,7 +565,9 @@ class TestBackups(unittest.TestCase):
     def test_on_list_backups_action_in_json_format(self, _):
         event = MagicMock()
         event.params = {"output": "json"}
-        self.charm.backup._list_backups = MagicMock(return_value={"backup1": {"state": "SUCCESS"}})
+        self.charm.backup.backup_manager.list_backups = MagicMock(
+            return_value={"backup1": {"state": "SUCCESS"}}
+        )
         self.charm.backup._generate_backup_list_output = MagicMock(
             return_value="backup1 | finished"
         )
@@ -580,7 +584,7 @@ class TestBackups(unittest.TestCase):
             "index2": {"shards": [{"type": "SNAPSHOT", "stage": "DONE"}]},
             "index3": {"shards": [{"type": "PRIMARY", "stage": "DONE"}]},
         }
-        result = self.charm.backup._is_restore_complete()
+        result = self.charm.backup.backup_manager.is_restore_complete()
         self.assertTrue(result)
 
     @patch("charms.opensearch.v0.opensearch_backups.OpenSearchS3Backup.apply_api_config_if_needed")
@@ -630,7 +634,7 @@ class TestBackups(unittest.TestCase):
                 ]
             }
         )
-        backups = self.charm.backup._list_backups(S3_REPOSITORY)
+        backups = self.charm.backup.backup_manager.list_backups()
         self.assertEqual(
             self.charm.backup._generate_backup_list_output(backups), LIST_BACKUPS_TRIAL
         )
@@ -675,7 +679,7 @@ class TestBackups(unittest.TestCase):
     def test_on_create_backup_action_backup_in_progress(self, _):
         event = MagicMock()
         self.charm.backup._check_repo_status = MagicMock(return_value=BackupServiceState.SUCCESS)
-        self.charm.backup.is_backup_in_progress = MagicMock(return_value=True)
+        self.charm.backup.backup_manager.is_backup_in_progress = MagicMock(return_value=True)
         plugin_method = "charms.opensearch.v0.opensearch_backups.OpenSearchS3Backup._plugin_status"
         with patch(plugin_method, new_callable=PropertyMock) as mock_plugin_status:
             mock_plugin_status.return_value = PluginState.ENABLED
@@ -687,7 +691,7 @@ class TestBackups(unittest.TestCase):
     def test_on_create_backup_action_exception(self, mock_request, _):
         event = MagicMock()
         self.charm.backup._can_unit_perform_backup = MagicMock(return_value=True)
-        self.charm.backup.is_backup_in_progress = MagicMock(return_value=False)
+        self.charm.backup.backup_manager.is_backup_in_progress = MagicMock(return_value=False)
         mock_request.side_effect = OpenSearchHttpError(500, "Internal Server Error")
         self.charm.backup._on_create_backup_action(event)
         event.fail.assert_called_with(
@@ -701,7 +705,7 @@ class TestBackups(unittest.TestCase):
 
         # Mocking helper methods
         self.charm.backup._can_unit_perform_backup = MagicMock(return_value=True)
-        self.charm.backup._is_restore_complete = MagicMock(return_value=True)
+        self.charm.backup.backup_manager.is_restore_complete = MagicMock(return_value=True)
         self.charm.backup._is_backup_available_for_restore = MagicMock(return_value=True)
         self.charm.backup._close_indices_if_needed = MagicMock(return_value=set())
         self.charm.backup._restore = MagicMock(
@@ -751,7 +755,7 @@ class TestBackups(unittest.TestCase):
         event.params = {"backup-id": "2023-01-01T00:00:00Z"}
         self.charm.backup._can_unit_perform_backup = MagicMock(return_value=True)
         self.charm.backup._close_indices_if_needed = MagicMock(return_value=set())
-        self.charm.backup._is_restore_complete = MagicMock(return_value=False)
+        self.charm.backup.backup_manager.is_restore_complete = MagicMock(return_value=False)
         self.charm.backup._restore = MagicMock()
         self.charm.status = MagicMock()
 
@@ -768,7 +772,7 @@ class TestBackups(unittest.TestCase):
         event.params = {"backup-id": "2023-01-01T00:00:00Z"}
         self.charm.backup._can_unit_perform_backup = MagicMock(return_value=True)
         self.charm.backup._close_indices_if_needed = MagicMock(return_value=set())
-        self.charm.backup._is_restore_complete = MagicMock(return_value=True)
+        self.charm.backup.backup_manager.is_restore_complete = MagicMock(return_value=True)
         self.charm.backup._is_backup_available_for_restore = MagicMock(return_value=False)
         self.charm.backup._restore = MagicMock()
         self.charm.status = MagicMock()
@@ -786,7 +790,7 @@ class TestBackups(unittest.TestCase):
         event.params = {"backup-id": "2023-01-01T00:00:00Z"}
         self.charm.backup._can_unit_perform_backup = MagicMock(return_value=True)
         self.charm.backup._close_indices_if_needed = MagicMock(return_value=set())
-        self.charm.backup._is_restore_complete = MagicMock(return_value=True)
+        self.charm.backup.backup_manager.is_restore_complete = MagicMock(return_value=True)
         self.charm.backup._is_backup_available_for_restore = MagicMock(return_value=True)
         self.charm.backup._restore = MagicMock(
             side_effect=OpenSearchRestoreCheckError("_restore: unexpected response")

--- a/tests/unit/lib/test_backups.py
+++ b/tests/unit/lib/test_backups.py
@@ -29,9 +29,9 @@ from charms.opensearch.v0.opensearch_exceptions import (
 )
 from charms.opensearch.v0.opensearch_health import HealthColors
 from charms.opensearch.v0.opensearch_plugins import (
-    OpenSearchBackupPlugin,
     OpenSearchPluginConfig,
     OpenSearchPluginError,
+    OpenSearchS3Plugin,
     PluginState,
 )
 from ops.model import MaintenanceStatus, WaitingStatus
@@ -79,8 +79,18 @@ def create_deployment_desc(*args, **kwargs):
     )
 
 
+@pytest.fixture(scope="module")
+def active_relation(relation: str = S3_RELATION):
+    with patch(
+        "charms.opensearch.v0.opensearch_backups.OpenSearchBackupBase.active_relation",
+        new_callable=PropertyMock,
+        return_value=relation,
+    ) as mock:
+        yield mock
+
+
 @pytest.fixture(scope="function")
-def harness():
+def harness(active_relation):
     harness_obj = Harness(OpenSearchOperatorCharm)
     with patch(
         "charms.opensearch.v0.opensearch_base_charm.OpenSearchPeerClustersManager.deployment_desc",
@@ -94,7 +104,7 @@ def harness():
         # Override the ConfigExposedPlugins
         charms.opensearch.v0.opensearch_plugin_manager.ConfigExposedPlugins = {
             "repository-s3": {
-                "class": OpenSearchBackupPlugin,
+                "class": OpenSearchS3Plugin,
                 "config": None,
                 "relation": "s3-credentials",
             },
@@ -115,7 +125,6 @@ def harness():
         harness_obj.set_leader(is_leader=True)
 
         yield harness_obj
-        # return harness_obj
 
 
 @pytest.fixture(scope="function")
@@ -125,7 +134,7 @@ def mock_request():
 
 
 def test_can_unit_perform_backup_plugin_not_ready(harness, caplog):
-    plugin_method = "charms.opensearch.v0.opensearch_backups.OpenSearchBackup._plugin_status"
+    plugin_method = "charms.opensearch.v0.opensearch_backups.OpenSearchS3Backup._plugin_status"
     event = MagicMock()
     with patch(plugin_method, new_callable=PropertyMock) as mock_plugin_status:
         mock_plugin_status.return_value = PluginState.DISABLED
@@ -140,7 +149,7 @@ def test_can_unit_perform_backup_plugin_not_ready(harness, caplog):
 
 
 def test_can_unit_perform_backup_repo_status_failed(harness, caplog):
-    plugin_method = "charms.opensearch.v0.opensearch_backups.OpenSearchBackup._plugin_status"
+    plugin_method = "charms.opensearch.v0.opensearch_backups.OpenSearchS3Backup._plugin_status"
     event = MagicMock()
     with patch(plugin_method, new_callable=PropertyMock) as mock_plugin_status:
         mock_plugin_status.return_value = PluginState.ENABLED
@@ -157,7 +166,7 @@ def test_can_unit_perform_backup_repo_status_failed(harness, caplog):
 
 
 def test_can_unit_perform_backup_backup_in_progress(harness, caplog):
-    plugin_method = "charms.opensearch.v0.opensearch_backups.OpenSearchBackup._plugin_status"
+    plugin_method = "charms.opensearch.v0.opensearch_backups.OpenSearchS3Backup._plugin_status"
     event = MagicMock()
     with patch(plugin_method, new_callable=PropertyMock) as mock_plugin_status:
         mock_plugin_status.return_value = PluginState.ENABLED
@@ -462,7 +471,7 @@ def test_on_s3_broken_steps(
     harness.charm.status.set = MagicMock()
 
     # Call the method
-    harness.charm.backup._on_s3_relation_broken(event)
+    harness.charm.backup._on_backup_relation_broken(event)
 
     if test_type == "s3-still-units-present":
         event.defer.assert_called()
@@ -491,7 +500,12 @@ def test_on_s3_broken_steps(
 class TestBackups(unittest.TestCase):
     maxDiff = None
 
-    def setUp(self) -> None:
+    @patch(
+        "charms.opensearch.v0.opensearch_backups.OpenSearchBackupBase.active_relation",
+        new_callable=PropertyMock,
+        return_value=S3_RELATION,
+    )
+    def setUp(self, _) -> None:
         self.harness = Harness(OpenSearchOperatorCharm)
         self.addCleanup(self.harness.cleanup)
         with patch(
@@ -508,7 +522,7 @@ class TestBackups(unittest.TestCase):
             # Override the ConfigExposedPlugins
             charms.opensearch.v0.opensearch_plugin_manager.ConfigExposedPlugins = {
                 "repository-s3": {
-                    "class": OpenSearchBackupPlugin,
+                    "class": OpenSearchS3Plugin,
                     "config": None,
                     "relation": "s3-credentials",
                 },
@@ -575,10 +589,10 @@ class TestBackups(unittest.TestCase):
         result = self.charm.backup._is_restore_complete()
         self.assertTrue(result)
 
-    @patch("charms.opensearch.v0.opensearch_backups.OpenSearchBackup.apply_api_config_if_needed")
+    @patch("charms.opensearch.v0.opensearch_backups.OpenSearchS3Backup.apply_api_config_if_needed")
     @patch("charms.opensearch.v0.opensearch_plugin_manager.OpenSearchPluginManager.apply_config")
     @patch("charms.opensearch.v0.opensearch_distro.OpenSearchDistribution.request")
-    @patch("charms.opensearch.v0.opensearch_backups.OpenSearchBackup._execute_s3_broken_calls")
+    @patch("charms.opensearch.v0.opensearch_backups.OpenSearchS3Backup._execute_s3_broken_calls")
     @patch("charms.opensearch.v0.opensearch_plugin_manager.OpenSearchPluginManager.status")
     def test_relation_broken(
         self,
@@ -622,13 +636,13 @@ class TestBackups(unittest.TestCase):
                 ]
             }
         )
-        backups = self.charm.backup._list_backups()
+        backups = self.charm.backup._list_backups(S3_REPOSITORY)
         self.assertEqual(
             self.charm.backup._generate_backup_list_output(backups), LIST_BACKUPS_TRIAL
         )
 
     def test_can_unit_perform_backup_success(self, _):
-        plugin_method = "charms.opensearch.v0.opensearch_backups.OpenSearchBackup._plugin_status"
+        plugin_method = "charms.opensearch.v0.opensearch_backups.OpenSearchS3Backup._plugin_status"
         event = MagicMock()
         with patch(plugin_method, new_callable=PropertyMock) as mock_plugin_status:
             mock_plugin_status.return_value = PluginState.ENABLED
@@ -668,7 +682,7 @@ class TestBackups(unittest.TestCase):
         event = MagicMock()
         self.charm.backup._check_repo_status = MagicMock(return_value=BackupServiceState.SUCCESS)
         self.charm.backup.is_backup_in_progress = MagicMock(return_value=True)
-        plugin_method = "charms.opensearch.v0.opensearch_backups.OpenSearchBackup._plugin_status"
+        plugin_method = "charms.opensearch.v0.opensearch_backups.OpenSearchS3Backup._plugin_status"
         with patch(plugin_method, new_callable=PropertyMock) as mock_plugin_status:
             mock_plugin_status.return_value = PluginState.ENABLED
             self.charm.backup._on_create_backup_action(event)

--- a/tests/unit/lib/test_backups.py
+++ b/tests/unit/lib/test_backups.py
@@ -550,12 +550,6 @@ class TestBackups(unittest.TestCase):
             self.harness.add_relation_unit(self.s3_rel_id, "s3-integrator/0")
             mock_pm_run.assert_not_called()
 
-    def test_get_endpoint_protocol(self, _) -> None:
-        """Tests the get_endpoint_protocol method."""
-        assert self.charm.backup._get_endpoint_protocol("http://10.0.0.1:8000") == "http"
-        assert self.charm.backup._get_endpoint_protocol("https://10.0.0.2:8000") == "https"
-        assert self.charm.backup._get_endpoint_protocol("test.not-valid-url") == "https"
-
     def test_on_list_backups_action(self, _):
         event = MagicMock()
         event.params = {"output": "table"}

--- a/tests/unit/lib/test_opensearch_base_charm.py
+++ b/tests/unit/lib/test_opensearch_base_charm.py
@@ -388,8 +388,8 @@ class TestOpenSearchBaseCharm(unittest.TestCase):
             start.assert_called_once()
             _post_start_init.assert_called_once()
 
-    @patch(f"{BASE_LIB_PATH}.opensearch_backups.OpenSearchBackupBase.is_backup_in_progress")
-    @patch(f"{BASE_LIB_PATH}.opensearch_backups.OpenSearchBackupBase._is_restore_complete")
+    @patch(f"{BASE_LIB_PATH}.opensearch_backups.BackupManager.is_backup_in_progress")
+    @patch(f"{BASE_LIB_PATH}.opensearch_backups.BackupManager.is_restore_complete")
     @patch(f"{BASE_CHARM_CLASS}._stop_opensearch")
     @patch(f"{BASE_LIB_PATH}.opensearch_base_charm.cert_expiration_remaining_hours")
     @patch(

--- a/tests/unit/lib/test_opensearch_base_charm.py
+++ b/tests/unit/lib/test_opensearch_base_charm.py
@@ -388,8 +388,8 @@ class TestOpenSearchBaseCharm(unittest.TestCase):
             start.assert_called_once()
             _post_start_init.assert_called_once()
 
-    @patch(f"{BASE_LIB_PATH}.opensearch_backups.OpenSearchBackup.is_backup_in_progress")
-    @patch(f"{BASE_LIB_PATH}.opensearch_backups.OpenSearchBackup._is_restore_complete")
+    @patch(f"{BASE_LIB_PATH}.opensearch_backups.OpenSearchBackupBase.is_backup_in_progress")
+    @patch(f"{BASE_LIB_PATH}.opensearch_backups.OpenSearchBackupBase._is_restore_complete")
     @patch(f"{BASE_CHARM_CLASS}._stop_opensearch")
     @patch(f"{BASE_LIB_PATH}.opensearch_base_charm.cert_expiration_remaining_hours")
     @patch(

--- a/tests/unit/resources/config/opensearch-security/internal_users.yml
+++ b/tests/unit/resources/config/opensearch-security/internal_users.yml
@@ -9,12 +9,8 @@ _meta:
 
 ## Demo users
 
-kibanaserver:
-  hash: $2b$12$Hkolu1OXUP6oHAkZ5VfZyuaIGDbVnyDT6cuzM2Hph.sYAT1UqkcX6
-  reserved: false
-  description: Kibanaserver user
 admin:
-  hash: $2b$12$wKVn61JciXkD2ZPLJebs/ujiAC3f7e6tFObM8oOFGaboZZaz1pZkK
+  hash: $2b$12$EvZtNb9SCoETOwkcSmEWf.t5ajBjlTgZ0Tr71TBZnojtW5kn3BGeO
   reserved: false
   backend_roles:
   - admin
@@ -22,3 +18,7 @@ admin:
   - security_rest_api_access
   - all_access
   description: Admin user
+kibanaserver:
+  hash: $2b$12$6FZ/pncpY8VCNW2Wh/mofeACxbI1IPd56jLV1CA0sKveQ8mINlkwG
+  reserved: false
+  description: Kibanaserver user

--- a/tests/unit/resources/config/opensearch-security/internal_users.yml
+++ b/tests/unit/resources/config/opensearch-security/internal_users.yml
@@ -10,11 +10,11 @@ _meta:
 ## Demo users
 
 kibanaserver:
-  hash: $2b$12$VNfTvrDDZ5JjT9.BZDqRTOh6sZoUxdMmgLueB4X0H93E0/e9FinRC
+  hash: $2b$12$Hkolu1OXUP6oHAkZ5VfZyuaIGDbVnyDT6cuzM2Hph.sYAT1UqkcX6
   reserved: false
   description: Kibanaserver user
 admin:
-  hash: $2b$12$3wL/WsFm7y0S2jyfiyHV4elgGEg2jeXrPFUmYdZGkj5aDF9hpCPFi
+  hash: $2b$12$wKVn61JciXkD2ZPLJebs/ujiAC3f7e6tFObM8oOFGaboZZaz1pZkK
   reserved: false
   backend_roles:
   - admin


### PR DESCRIPTION
Implements Azure storage integration.

Changes:
- All general objects (`OpenSearchBackups<nameOfClass>`) that worked under S3 integration have been renamed to be specific about S3.
- `OpenSearchBackupBase` is now generic for both Azure and S3 integrators.
- On `OpenSearchBaseCharm`, `self.backup()` is reworked to take into account both relations existing, or not. It will then generate the correct sub class for the appropriate relation.
- Constants and error messages are a bit more generic to allow use on both relation error scenarios
- New model `AzureRelData` for the integrator databag.