### PR TITLE
[DPE-6603] Add extra checks for `DeploymentDescription` existence

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_backups.py
+++ b/lib/charms/opensearch/v0/opensearch_backups.py
@@ -536,7 +536,7 @@ class OpenSearchBackup(OpenSearchBackupBase):
 
     def _on_list_backups_action(self, event: ActionEvent) -> None:
         """Returns the list of available backups to the user."""
-        if not (deployment_desc := self.charm.opensearch_peer_cm.deployment_desc()):
+        if not self.charm.opensearch_peer_cm.deployment_desc():
             event.fail("The action can be run only after the deployment is finished.")
             return
         backups = {}
@@ -684,7 +684,7 @@ class OpenSearchBackup(OpenSearchBackupBase):
 
     def _on_restore_backup_action(self, event: ActionEvent) -> None:  # noqa #C901
         """Restores a backup to the current cluster."""
-        if not (deployment_desc := self.charm.opensearch_peer_cm.deployment_desc()):
+        if not self.charm.opensearch_peer_cm.deployment_desc():
             event.fail("The action can be run only after the deployment is finished.")
             return
         if self.charm.upgrade_in_progress:
@@ -754,7 +754,7 @@ class OpenSearchBackup(OpenSearchBackupBase):
 
     def _on_create_backup_action(self, event: ActionEvent) -> None:  # noqa: C901
         """Creates a backup from the current cluster."""
-        if not (deployment_desc := self.charm.opensearch_peer_cm.deployment_desc()):
+        if not self.charm.opensearch_peer_cm.deployment_desc():
             event.fail("The action can be run only after the deployment is finished.")
             return
         if self.charm.upgrade_in_progress:

--- a/lib/charms/opensearch/v0/opensearch_backups.py
+++ b/lib/charms/opensearch/v0/opensearch_backups.py
@@ -685,7 +685,7 @@ class OpenSearchBackup(OpenSearchBackupBase):
     def _on_restore_backup_action(self, event: ActionEvent) -> None:  # noqa #C901
         """Restores a backup to the current cluster."""
         if not self.charm.opensearch_peer_cm.deployment_desc():
-            event.fail("The action can be run only after the deployment is finished.")
+            event.fail("The action can only be run once the deployment is complete.")
             return
         if self.charm.upgrade_in_progress:
             event.fail("Restore not supported while upgrade in-progress")
@@ -755,7 +755,7 @@ class OpenSearchBackup(OpenSearchBackupBase):
     def _on_create_backup_action(self, event: ActionEvent) -> None:  # noqa: C901
         """Creates a backup from the current cluster."""
         if not self.charm.opensearch_peer_cm.deployment_desc():
-            event.fail("The action can be run only after the deployment is finished.")
+            event.fail("The action can only be run once the deployment is complete.")
             return
         if self.charm.upgrade_in_progress:
             event.fail("Backup not supported while upgrade in-progress")

--- a/lib/charms/opensearch/v0/opensearch_backups.py
+++ b/lib/charms/opensearch/v0/opensearch_backups.py
@@ -537,7 +537,7 @@ class OpenSearchBackup(OpenSearchBackupBase):
     def _on_list_backups_action(self, event: ActionEvent) -> None:
         """Returns the list of available backups to the user."""
         if not self.charm.opensearch_peer_cm.deployment_desc():
-            event.fail("The action can be run only after the deployment is finished.")
+            event.fail("The action can only be run once the deployment is complete.")
             return
         backups = {}
         try:

--- a/lib/charms/opensearch/v0/opensearch_backups.py
+++ b/lib/charms/opensearch/v0/opensearch_backups.py
@@ -536,6 +536,9 @@ class OpenSearchBackup(OpenSearchBackupBase):
 
     def _on_list_backups_action(self, event: ActionEvent) -> None:
         """Returns the list of available backups to the user."""
+        if not (deployment_desc := self.charm.opensearch_peer_cm.deployment_desc()):
+            event.fail("The action can be run only after the deployment is finished.")
+            return
         backups = {}
         try:
             backups = self._list_backups()
@@ -681,6 +684,9 @@ class OpenSearchBackup(OpenSearchBackupBase):
 
     def _on_restore_backup_action(self, event: ActionEvent) -> None:  # noqa #C901
         """Restores a backup to the current cluster."""
+        if not (deployment_desc := self.charm.opensearch_peer_cm.deployment_desc()):
+            event.fail("The action can be run only after the deployment is finished.")
+            return
         if self.charm.upgrade_in_progress:
             event.fail("Restore not supported while upgrade in-progress")
             return
@@ -748,6 +754,9 @@ class OpenSearchBackup(OpenSearchBackupBase):
 
     def _on_create_backup_action(self, event: ActionEvent) -> None:  # noqa: C901
         """Creates a backup from the current cluster."""
+        if not (deployment_desc := self.charm.opensearch_peer_cm.deployment_desc()):
+            event.fail("The action can be run only after the deployment is finished.")
+            return
         if self.charm.upgrade_in_progress:
             event.fail("Backup not supported while upgrade in-progress")
             return

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -798,7 +798,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
 
     def _on_get_password_action(self, event: ActionEvent):
         """Return the password and cert chain for the admin user of the cluster."""
-        if not (deployment_desc := self.opensearch_peer_cm.deployment_desc()):
+        if not self.opensearch_peer_cm.deployment_desc():
             event.fail("The action can be run only after the deployment is finished.")
             return
 

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -760,7 +760,10 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         if self.upgrade_in_progress:
             event.fail("Setting password not supported while upgrade in-progress")
             return
-        if self.opensearch_peer_cm.deployment_desc().typ != DeploymentType.MAIN_ORCHESTRATOR:
+        if (
+            not self.opensearch_peer_cm.deployment_desc()
+            or self.opensearch_peer_cm.deployment_desc().typ != DeploymentType.MAIN_ORCHESTRATOR
+        ):
             event.fail("The action can be run only on the leader unit of the main cluster.")
             return
 

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -767,7 +767,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             event.fail("The action can only be run on the main cluster.")
             return        
         if not self.unit.is_leader():
-            event.fail("The action can be run only on leader unit.")
+            event.fail("The action can only be run on leader unit.")
             return
 
         user_name = event.params.get("username")

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -764,7 +764,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             event.fail("The action can only be run once the deployment is complete.")
             return
         if self.opensearch_peer_cm.deployment_desc().typ != DeploymentType.MAIN_ORCHESTRATOR:
-            event.fail("The action can be run only on the main cluster.")
+            event.fail("The action can only be run on the main cluster.")
             return        
         if not self.unit.is_leader():
             event.fail("The action can be run only on leader unit.")

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -764,7 +764,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             not self.opensearch_peer_cm.deployment_desc()
             or self.opensearch_peer_cm.deployment_desc().typ != DeploymentType.MAIN_ORCHESTRATOR
         ):
-            event.fail("The action can be run only on the leader unit of the main cluster.")
+            event.fail("The action can only be run once the deployment is complete.")
             return
 
         if not self.unit.is_leader():

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -798,6 +798,10 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
 
     def _on_get_password_action(self, event: ActionEvent):
         """Return the password and cert chain for the admin user of the cluster."""
+        if not (deployment_desc := self.opensearch_peer_cm.deployment_desc()):
+            event.fail("The action can be run only after the deployment is finished.")
+            return
+
         user_name = event.params.get("username")
         if user_name not in OpenSearchUsers:
             event.fail(f"Only the {OpenSearchUsers} username is allowed for this action.")

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -757,9 +757,6 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
 
     def _on_set_password_action(self, event: ActionEvent):
         """Set new admin password from user input or generate if not passed."""
-        if self.upgrade_in_progress:
-            event.fail("Setting password not supported while upgrade in-progress")
-            return
         if not self.opensearch_peer_cm.deployment_desc():
             event.fail("The action can only be run once the deployment is complete.")
             return
@@ -768,6 +765,10 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             return        
         if not self.unit.is_leader():
             event.fail("The action can only be run on leader unit.")
+            return
+
+        if self.upgrade_in_progress:
+            event.fail("Setting password not supported while upgrade in-progress")
             return
 
         user_name = event.params.get("username")

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -762,7 +762,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             return
         if self.opensearch_peer_cm.deployment_desc().typ != DeploymentType.MAIN_ORCHESTRATOR:
             event.fail("The action can only be run on the main orchestrator cluster.")
-            return        
+            return
         if not self.unit.is_leader():
             event.fail("The action can only be run on leader unit.")
             return

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -396,9 +396,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         # configure clients auth
         self.opensearch_config.set_client_auth()
 
-        if not (deployment_desc := self.opensearch_peer_cm.deployment_desc()):
-            event.defer()
-            return
+        deployment_desc = self.opensearch_peer_cm.deployment_desc()
         # only start the main orchestrator if a data node is available
         # this allows for "cluster-manager-only" nodes in large deployments
         # workflow documentation:
@@ -799,7 +797,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
     def _on_get_password_action(self, event: ActionEvent):
         """Return the password and cert chain for the admin user of the cluster."""
         if not self.opensearch_peer_cm.deployment_desc():
-            event.fail("The action can be run only after the deployment is finished.")
+            event.fail("The action can only be run once the deployment is complete.")
             return
 
         user_name = event.params.get("username")

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -396,7 +396,9 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         # configure clients auth
         self.opensearch_config.set_client_auth()
 
-        deployment_desc = self.opensearch_peer_cm.deployment_desc()
+        if not (deployment_desc := self.opensearch_peer_cm.deployment_desc()):
+            event.defer()
+            return
         # only start the main orchestrator if a data node is available
         # this allows for "cluster-manager-only" nodes in large deployments
         # workflow documentation:

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -760,13 +760,12 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         if self.upgrade_in_progress:
             event.fail("Setting password not supported while upgrade in-progress")
             return
-        if (
-            not self.opensearch_peer_cm.deployment_desc()
-            or self.opensearch_peer_cm.deployment_desc().typ != DeploymentType.MAIN_ORCHESTRATOR
-        ):
+        if not self.opensearch_peer_cm.deployment_desc():
             event.fail("The action can only be run once the deployment is complete.")
             return
-
+        if self.opensearch_peer_cm.deployment_desc().typ != DeploymentType.MAIN_ORCHESTRATOR:
+            event.fail("The action can be run only on the main cluster.")
+            return        
         if not self.unit.is_leader():
             event.fail("The action can be run only on leader unit.")
             return

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -764,7 +764,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             event.fail("The action can only be run once the deployment is complete.")
             return
         if self.opensearch_peer_cm.deployment_desc().typ != DeploymentType.MAIN_ORCHESTRATOR:
-            event.fail("The action can only be run on the main cluster.")
+            event.fail("The action can only be run on the main orchestrator cluster.")
             return        
         if not self.unit.is_leader():
             event.fail("The action can only be run on leader unit.")

--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -101,6 +101,9 @@ class OpenSearchTLS(Object):
 
     def _on_set_tls_private_key(self, event: ActionEvent) -> None:
         """Set the TLS private key, which will be used for requesting the certificate."""
+        if not (deployment_desc := self.charm.opensearch_peer_cm.deployment_desc()):
+            event.fail("The action can be run only after the deployment is finished.")
+            return
         if self.charm.upgrade_in_progress:
             event.fail("Setting private key not supported while upgrade in-progress")
             return

--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -101,7 +101,7 @@ class OpenSearchTLS(Object):
 
     def _on_set_tls_private_key(self, event: ActionEvent) -> None:
         """Set the TLS private key, which will be used for requesting the certificate."""
-        if not (deployment_desc := self.charm.opensearch_peer_cm.deployment_desc()):
+        if not self.charm.opensearch_peer_cm.deployment_desc():
             event.fail("The action can be run only after the deployment is finished.")
             return
         if self.charm.upgrade_in_progress:

--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -102,7 +102,7 @@ class OpenSearchTLS(Object):
     def _on_set_tls_private_key(self, event: ActionEvent) -> None:
         """Set the TLS private key, which will be used for requesting the certificate."""
         if not self.charm.opensearch_peer_cm.deployment_desc():
-            event.fail("The action can be run only after the deployment is finished.")
+            event.fail("The action can only be run once the deployment is complete.")
             return
         if self.charm.upgrade_in_progress:
             event.fail("Setting private key not supported while upgrade in-progress")


### PR DESCRIPTION
Currently, if the cluster is not yet ready and the description not yet available, set password action throws an exception. This PR relates to: #547. 

It adds checks for the deployment description on actions and some key-points in the base charm. This PR reviews the base charm calls to the `.deployment_desc()` function and ensures we have appropriate checks each time.

