### PR TITLE
[DPE-6422] Fix upgrade path with snap rev. 65

### DIFF
--- a/lib/charms/opensearch/v0/constants_charm.py
+++ b/lib/charms/opensearch/v0/constants_charm.py
@@ -114,7 +114,7 @@ ClientUsersDict = "client_relation_users"
 
 
 # Opensearch Snap revision
-OPENSEARCH_SNAP_REVISION = 63  # Keep in sync with `workload_version` file
+OPENSEARCH_SNAP_REVISION = 65  # Keep in sync with `workload_version` file
 
 # User-face Backup ID format
 OPENSEARCH_BACKUP_ID_FORMAT = "%Y-%m-%dT%H:%M:%SZ"

--- a/tests/integration/upgrades/test_small_deployment_upgrades.py
+++ b/tests/integration/upgrades/test_small_deployment_upgrades.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 
 OPENSEARCH_ORIGINAL_CHARM_NAME = "opensearch"
 OPENSEARCH_CHANNEL = "2/edge"
+OPENSEARCH_STABLE_CHANNEL = "2/stable"
 
 
 STARTING_VERSION = "2.15.0"
@@ -245,11 +246,13 @@ async def test_upgrade_rollback_from_local(
         )
 
         logger.info(f"Rolling back to {version}")
+        # TODO: return to 2/edge channel instead once this channel's latest 2.17 charm
+        # revision points to snap rev. 65 instead of snap rev. 62.
         await refresh(
             ops_test,
             app,
             switch=OPENSEARCH_ORIGINAL_CHARM_NAME,
-            channel=OPENSEARCH_CHANNEL,
+            channel=OPENSEARCH_STABLE_CHANNEL,
         )
         # Wait until we are set in an idle state and can rollback the revision.
         # app status blocked: that will happen if we are jumping N-2 versions in our test


### PR DESCRIPTION
The upgrade path tests have two issues: (1) the snap mismatch between core22 and core24: that is resolved by using the newest snap rev 65; and (2) the rollback that demands to first switch from locally built charm (this is a particular issue in our tests as we are using these built charms), then a refresh to the target version.

For the point (1), this PR bumps the 2.17 to use snap rev. 65, which enables a smooth rollback during upgrades.

For the point (2), when we rollback from locally built to the upstream charm using `--switch`, then we cannot select a revision:
```
$ juju refresh opensearch --model=test --revision=144 --switch=opensearch --channel=2/edge
ERROR --switch and --revision are mutually exclusive
```

The only way we can refresh is the following:
```
# Get back to upstream, abandoning local charm
$ juju refresh opensearch --model=test --switch=opensearch --channel=2/edge

# Returns to the right version
$ juju refresh opensearch --model=test --revision=144 --channel=2/edge
```

However, that first refresh (switch) will rollback to charm revision 204 (snap rev. 62), which still has core24 but does not have the fix that is coming on snap rev. 65. To avoid this issue, we will instead:
```
# Get back to upstream, abandoning local charm but use the rev. in stable, as it does not contain snap with core24
$ juju refresh opensearch --model=test --switch=opensearch --channel=2/stable

# Returns to the right version
$ juju refresh opensearch --model=test --revision=144 --channel=2/edge
```