### PR TITLE
[DPE-6601] Return changes for upgrade test

### DIFF
--- a/tests/integration/upgrades/test_small_deployment_upgrades.py
+++ b/tests/integration/upgrades/test_small_deployment_upgrades.py
@@ -26,7 +26,6 @@ logger = logging.getLogger(__name__)
 
 OPENSEARCH_ORIGINAL_CHARM_NAME = "opensearch"
 OPENSEARCH_CHANNEL = "2/edge"
-OPENSEARCH_STABLE_CHANNEL = "2/stable"
 
 
 STARTING_VERSION = "2.15.0"
@@ -246,13 +245,11 @@ async def test_upgrade_rollback_from_local(
         )
 
         logger.info(f"Rolling back to {version}")
-        # TODO: return to 2/edge channel instead once this channel's latest 2.17 charm
-        # revision points to snap rev. 65 instead of snap rev. 62.
         await refresh(
             ops_test,
             app,
             switch=OPENSEARCH_ORIGINAL_CHARM_NAME,
-            channel=OPENSEARCH_STABLE_CHANNEL,
+            channel=OPENSEARCH_CHANNEL,
         )
         # Wait until we are set in an idle state and can rollback the revision.
         # app status blocked: that will happen if we are jumping N-2 versions in our test


### PR DESCRIPTION
This PR is a follow-up of #553: remove the work-around of rolling back to stable as we now have a charm released in `2/edge` that points to snap rev. 65.