### PR TITLE
WIP peer cluster relation hooks fail - promote failover

### DIFF
--- a/lib/charms/opensearch/v0/helper_charm.py
+++ b/lib/charms/opensearch/v0/helper_charm.py
@@ -106,7 +106,9 @@ class RelDepartureReason(BaseStrEnum):
     REL_BROKEN = "rel-broken"
 
 
-def relation_departure_reason(charm: CharmBase, relation_name: str) -> RelDepartureReason:
+def relation_departure_reason(
+    charm: CharmBase, relation_name: str, trigger_app: str
+) -> RelDepartureReason:
     """Compute the reason behind a relation departed event."""
     # fetch relation info
     goal_state = charm.model._backend._run("goal-state", return_output=True, use_json=True)
@@ -116,7 +118,7 @@ def relation_departure_reason(charm: CharmBase, relation_name: str) -> RelDepart
     dying_units = [
         unit_data["status"] == "dying"
         for unit, unit_data in rel_info.items()
-        if unit != relation_name
+        if unit == trigger_app
     ]
 
     # check if app removal

--- a/lib/charms/opensearch/v0/opensearch_peer_clusters.py
+++ b/lib/charms/opensearch/v0/opensearch_peer_clusters.py
@@ -361,7 +361,7 @@ class OpenSearchPeerClustersManager:
 
         return DeploymentDescription.from_dict(current_deployment_desc)
 
-    def promote_to_main_orchestrator(self) -> None:
+    def promote_deployment_desc_type(self) -> None:
         """Update the deployment type of the current deployment desc."""
         if not (deployment_desc := self.deployment_desc()):
             return

--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -2,7 +2,6 @@
 # See LICENSE file for licensing details.
 
 """Peer clusters relation related classes for OpenSearch."""
-import copy
 import json
 import logging
 from hashlib import sha1
@@ -164,11 +163,16 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
             event.defer()
             return
 
-        # only the main-orchestrator is able to designate a failover
-        if deployment_desc.typ != DeploymentType.MAIN_ORCHESTRATOR:
+        if not (data := event.relation.data.get(event.app)):
             return
 
-        if not (data := event.relation.data.get(event.app)):
+        if deployment_desc.typ == DeploymentType.FAILOVER_ORCHESTRATOR:
+            if self._should_promote_failover():
+                self._promote_failover()
+            return
+
+        # only the main-orchestrator is able to designate a failover
+        if deployment_desc.typ != DeploymentType.MAIN_ORCHESTRATOR:
             return
 
         if self._get_security_index_initialised():
@@ -205,6 +209,7 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
         orchestrators = PeerClusterOrchestrators.from_dict(
             self.charm.peers_data.get_object(Scope.APP, "orchestrators")
         )
+
         if orchestrators.failover_app and orchestrators.failover_rel_id in target_relation_ids:
             logger.info("A failover cluster orchestrator is already registered.")
             self.refresh_relation_data(event)
@@ -222,6 +227,60 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
             )
             orchestrators.failover_app = candidate_failover_app
             self.put_in_rel(data={"orchestrators": orchestrators.to_str()}, rel_id=rel_id)
+
+    def _should_promote_failover(self) -> bool:
+        requirers = self.charm.model.relations[self.relation_name]
+        if len(requirers) > 0:
+            total = 0
+            for rel in requirers:
+                if self.get_from_rel("is_disconnected_from_main", rel_id=rel.id) == "true":
+                    total += 1
+
+            if total >= len(requirers) // 2:
+                return True
+        return False
+
+    def _promote_failover(self) -> None:
+        """Handle the departure of the main orchestrator."""
+        orchestrators = PeerClusterOrchestrators.from_dict(
+            self.charm.peers_data.get_object(Scope.APP, "orchestrators")
+        )
+        # remove old main and promote new failover
+        orchestrators.promote_failover()
+
+        self.charm.peers_data.put_object(Scope.APP, "orchestrators", orchestrators.to_dict())
+
+        # broadcast the new conf to all related apps
+        for rel_id in [
+            rel.id for rel in self.charm.model.relations[PeerClusterOrchestratorRelationName]
+        ]:
+            rel_orchestrators = PeerClusterOrchestrators.from_dict(
+                self.get_obj_from_rel("orchestrators", rel_id, remote_app=False)
+            )
+
+            rel_orchestrators.delete("main")
+            rel_orchestrators.promote_failover()
+
+            self.put_in_rel(data={"orchestrators": rel_orchestrators.to_str()}, rel_id=rel_id)
+
+        # current cluster is failover, update deployment type
+        self.charm.opensearch_peer_cm.promote_deployment_desc_type()
+
+        # get deployment descriptor of current app
+        deployment_desc = self.charm.opensearch_peer_cm.deployment_desc()
+        message = None
+        try:
+            cms = self._fetch_local_cm_nodes(deployment_desc)
+            # ensuring quorum, need at least 3 cms
+            n_cms_less_than_3 = 3 - len(cms)
+            if n_cms_less_than_3 > 0:
+                message = f"Scale up this application by {n_cms_less_than_3} unit{'' if n_cms_less_than_3 == 1 else 's'} to ensure quorum."
+        except OpenSearchHttpError as e:
+            logger.error(e)
+            message = "Could not fetch cm nodes"
+
+        if message:
+            self.charm.status.set(BlockedStatus(message))
 
     def _on_peer_cluster_relation_departed(self, event: RelationDepartedEvent) -> None:
         """Event received by all units in sub-cluster when a sub-cluster leaves the relation."""
@@ -899,13 +958,20 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
             remote_orchestrators.update(self.get_obj_from_rel(key="orchestrators", rel_id=rel_id))
 
         local_orchestrators = self.charm.peers_data.get_object(Scope.APP, "orchestrators") or {}
-        if trigger in {"main", "failover"} and f"{trigger}_app" in remote_orchestrators:
-            local_orchestrators.update(
-                {
-                    f"{trigger}_rel_id": event.relation.id,
-                    f"{trigger}_app": remote_orchestrators[f"{trigger}_app"],
-                }
-            )
+        if trigger in {"main", "failover"}:
+            local_orchestrators = {
+                orchestrator: rel_info
+                for orchestrator, rel_info in local_orchestrators.items()
+                if orchestrator in remote_orchestrators
+            }
+            trigger_app = f"{trigger}_app"
+            if trigger_app in remote_orchestrators:
+                local_orchestrators.update(
+                    {
+                        f"{trigger}_rel_id": event.relation.id,
+                        trigger_app: remote_orchestrators[trigger_app],
+                    }
+                )
 
         return PeerClusterOrchestrators.from_dict(local_orchestrators)
 
@@ -952,9 +1018,9 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
         cluster_fleet_apps = (
             self.charm.peers_data.get_object(Scope.APP, "cluster_fleet_apps") or {}
         )
-        if departing_orchestrator == "main":
+        if departing_orchestrator == "main" and orchestrators.main_app:
             cluster_fleet_apps.pop(orchestrators.main_app.id, None)
-        else:
+        elif departing_orchestrator == "failover" and orchestrators.failover_app:
             cluster_fleet_apps.pop(orchestrators.failover_app.id, None)
         self.charm.peers_data.put_object(Scope.APP, "cluster_fleet_apps", cluster_fleet_apps)
 
@@ -971,6 +1037,14 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
             self.charm.peers_data.get_object(Scope.APP, "orchestrators")
         )
 
+        # fetch cluster manager nodes from API + across all peer clusters
+        # cms = self._cm_nodes(orchestrators)
+
+        # check the departed cluster which triggered this hook
+        event_src_cluster_type = (
+            "main" if event.relation.id == orchestrators.main_rel_id else "failover"
+        )
+
         # a cluster of type "other" is departing (wrong relation), or, the current is a main
         # orchestrator and a failover is departing, we can safely ignore.
         if event.relation.id not in [
@@ -982,85 +1056,57 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
 
         # handle scale-down at the charm level storage detaching, or??
         if (
-            relation_departure_reason(self.charm, self.relation_name)
+            relation_departure_reason(self.charm, self.relation_name, event_src_cluster_type)
             == RelDepartureReason.SCALE_DOWN
         ):
             return
 
-        # fetch cluster manager nodes from API + across all peer clusters
-        cms = self._cm_nodes(orchestrators)
-
-        # check the departed cluster which triggered this hook
-        event_src_cluster_type = (
-            "main" if event.relation.id == orchestrators.main_rel_id else "failover"
-        )
-
         # remove the departing app from the peer_cluster_apps
         self._update_fleet_apps_on_departure(orchestrators, event_src_cluster_type)
 
-        new_orchestrators = copy.deepcopy(orchestrators)
-        new_orchestrators.delete(event_src_cluster_type)
+        orchestrators.delete(event_src_cluster_type)
 
         # the 'main' cluster orchestrator is the one being removed
-        failover_promoted = False
-        if event_src_cluster_type == "main":
+        if (
+            event_src_cluster_type == "main"
+            and deployment_desc.typ != DeploymentType.FAILOVER_ORCHESTRATOR
+        ):
+            message = "Main-cluster-orchestrator removed"
             if not orchestrators.failover_app:
-                self.charm.status.set(
-                    BlockedStatus(
-                        "Main-cluster-orchestrator removed, and no failover cluster related."
-                    )
+                message += ", and no failover cluster related."
+            else:  # let failover know that main has been disconnected
+                message += ", waiting for failover promotion."
+                self.put_in_rel(
+                    data={"is_disconnected_from_main": "true"},
+                    rel_id=orchestrators.failover_rel_id,
                 )
-            elif orchestrators.failover_app.id == deployment_desc.app.id:
-                self._promote_failover(new_orchestrators, cms)
-                failover_promoted = True
 
-        self.charm.peers_data.put_object(Scope.APP, "orchestrators", new_orchestrators.to_dict())
+        self.charm.peers_data.put_object(Scope.APP, "orchestrators", orchestrators.to_dict())
         # clear previously set errors due to this relation
         self._clear_errors(f"error_from_provider-{event.relation.id}")
         self._clear_errors(f"error_from_requirer-{event.relation.id}")
 
         # we leave in case not an orchestrator
-        if (
-            self.charm.opensearch_peer_cm.deployment_desc().typ == DeploymentType.OTHER
-            or deployment_desc.app.id
-            not in [app.id for app in (orchestrators.main_app, orchestrators.failover_app) if app]
-        ):
-            return
+        # if (
+        #     self.charm.opensearch_peer_cm.deployment_desc().typ == DeploymentType.OTHER
+        #     or deployment_desc.app.id
+        #     not in [app.id for app in (orchestrators.main_app, orchestrators.failover_app) if app]
+        # ):
+        #     return
 
-        # the current is an orchestrator, let's broadcast the new conf to all related apps
-        for rel_id in [
-            rel.id for rel in self.charm.model.relations[PeerClusterOrchestratorRelationName]
-        ]:
-            rel_orchestrators = PeerClusterOrchestrators.from_dict(
-                self.get_obj_from_rel("orchestrators", rel_id, remote_app=False)
-            )
-
-            rel_orchestrators.delete(event_src_cluster_type)
-            if failover_promoted:
-                rel_orchestrators.promote_failover()
-
-            self.put_in_rel(data={"orchestrators": rel_orchestrators.to_str()}, rel_id=rel_id)
-
-    def _promote_failover(self, orchestrators: PeerClusterOrchestrators, cms: List[Node]) -> None:
-        """Handle the departure of the main orchestrator."""
-        # remove old main and promote new failover
-        orchestrators.promote_failover()
-
-        # current cluster is failover, update deployment type
-        self.charm.opensearch_peer_cm.promote_to_main_orchestrator()
-
-        # ensuring quorum
-        main_cms = [cm for cm in cms if cm.app.id == orchestrators.main_app.id]
-        non_main_cms = [cm for cm in cms if cm not in main_cms]
-        if len(non_main_cms) % 2 == 0:
-            departure_reason = relation_departure_reason(self.charm, self.relation_name)
-            message = "Scale-up this application by an odd number of units{} to ensure quorum."
-            if len(main_cms) % 2 == 1 and departure_reason == RelDepartureReason.REL_BROKEN:
-                message = message.format(
-                    f" and scale-'down/up' {orchestrators.main_app.name} by 1 unit"
-                )
-
-            self.charm.status.set(BlockedStatus(message))
+        # # the current is an orchestrator, let's broadcast the new conf to all related apps
+        # for rel_id in [
+        #     rel.id for rel in self.charm.model.relations[PeerClusterOrchestratorRelationName]
+        # ]:
+        #     rel_orchestrators = PeerClusterOrchestrators.from_dict(
+        #         self.get_obj_from_rel("orchestrators", rel_id, remote_app=False)
+        #     )
+        #
+        #     rel_orchestrators.delete(event_src_cluster_type)
+        #     if failover_promoted:
+        #         rel_orchestrators.promote_failover()
+        #
+        #     self.put_in_rel(data={"orchestrators": rel_orchestrators.to_str()}, rel_id=rel_id)
 
     def _cm_nodes(self, orchestrators: PeerClusterOrchestrators) -> List[Node]:
         """Fetch the cm nodes passed from the peer cluster relation not api call."""

--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 
 """Peer clusters relation related classes for OpenSearch."""
-
+import copy
 import json
 import logging
 from hashlib import sha1
@@ -377,7 +377,10 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
         cluster_fleet_apps.update({current_app.app.id: current_app.to_dict()})
 
         if p_cluster_app:
-            cluster_fleet_apps.update({p_cluster_app.app.id: p_cluster_app.to_dict()})
+            if p_cluster_app.planned_units == 0:  # app removal
+                cluster_fleet_apps.pop(p_cluster_app.app.id, None)
+            else:
+                cluster_fleet_apps.update({p_cluster_app.app.id: p_cluster_app.to_dict()})
 
         for rel_id in target_relation_ids:
             self.put_in_rel(
@@ -896,7 +899,7 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
             remote_orchestrators.update(self.get_obj_from_rel(key="orchestrators", rel_id=rel_id))
 
         local_orchestrators = self.charm.peers_data.get_object(Scope.APP, "orchestrators") or {}
-        if trigger in {"main", "failover"}:
+        if trigger in {"main", "failover"} and f"{trigger}_app" in remote_orchestrators:
             local_orchestrators.update(
                 {
                     f"{trigger}_rel_id": event.relation.id,
@@ -942,6 +945,19 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
 
         self.charm.peers_data.put_object(Scope.APP, "cluster_fleet_apps", cluster_fleet_apps)
 
+    def _update_fleet_apps_on_departure(
+        self, orchestrators: PeerClusterOrchestrators, departing_orchestrator: str
+    ):
+        """Delete the current departing orchestrator from the cluster fleet apps."""
+        cluster_fleet_apps = (
+            self.charm.peers_data.get_object(Scope.APP, "cluster_fleet_apps") or {}
+        )
+        if departing_orchestrator == "main":
+            cluster_fleet_apps.pop(orchestrators.main_app.id, None)
+        else:
+            cluster_fleet_apps.pop(orchestrators.failover_app.id, None)
+        self.charm.peers_data.put_object(Scope.APP, "cluster_fleet_apps", cluster_fleet_apps)
+
     def _on_peer_cluster_relation_departed(self, event: RelationDepartedEvent):
         """Handle when 'main/failover'-CMs leave the relation (app or relation removal)."""
         if not self.charm.unit.is_leader():
@@ -979,8 +995,11 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
             "main" if event.relation.id == orchestrators.main_rel_id else "failover"
         )
 
-        # delete the orchestrator that triggered this event
-        orchestrators.delete(event_src_cluster_type)
+        # remove the departing app from the peer_cluster_apps
+        self._update_fleet_apps_on_departure(orchestrators, event_src_cluster_type)
+
+        new_orchestrators = copy.deepcopy(orchestrators)
+        new_orchestrators.delete(event_src_cluster_type)
 
         # the 'main' cluster orchestrator is the one being removed
         failover_promoted = False
@@ -992,11 +1011,10 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
                     )
                 )
             elif orchestrators.failover_app.id == deployment_desc.app.id:
-                self._promote_failover(orchestrators, cms)
+                self._promote_failover(new_orchestrators, cms)
                 failover_promoted = True
 
-        self.charm.peers_data.put_object(Scope.APP, "orchestrators", orchestrators.to_dict())
-
+        self.charm.peers_data.put_object(Scope.APP, "orchestrators", new_orchestrators.to_dict())
         # clear previously set errors due to this relation
         self._clear_errors(f"error_from_provider-{event.relation.id}")
         self._clear_errors(f"error_from_requirer-{event.relation.id}")
@@ -1025,7 +1043,10 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
 
     def _promote_failover(self, orchestrators: PeerClusterOrchestrators, cms: List[Node]) -> None:
         """Handle the departure of the main orchestrator."""
-        # current cluster is failover
+        # remove old main and promote new failover
+        orchestrators.promote_failover()
+
+        # current cluster is failover, update deployment type
         self.charm.opensearch_peer_cm.promote_to_main_orchestrator()
 
         # ensuring quorum
@@ -1039,10 +1060,7 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
                     f" and scale-'down/up' {orchestrators.main_app.name} by 1 unit"
                 )
 
-            self.charm.status.set(message)
-
-        # remove old main and promote new failover
-        orchestrators.promote_failover()
+            self.charm.status.set(BlockedStatus(message))
 
     def _cm_nodes(self, orchestrators: PeerClusterOrchestrators) -> List[Node]:
         """Fetch the cm nodes passed from the peer cluster relation not api call."""

--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -1005,7 +1005,7 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
         if (
             self.charm.opensearch_peer_cm.deployment_desc().typ == DeploymentType.OTHER
             or deployment_desc.app.id
-            not in [orchestrators.main_app.id, orchestrators.failover_app.id]
+            not in [app.id for app in (orchestrators.main_app, orchestrators.failover_app) if app]
         ):
             return
 

--- a/tests/integration/ha/test_large_deployments_cluster_manager_only_nodes.py
+++ b/tests/integration/ha/test_large_deployments_cluster_manager_only_nodes.py
@@ -177,7 +177,9 @@ async def test_remove_relation(ops_test: OpsTest) -> None:
         apps_full_statuses={
             MAIN_APP: {"active": []},
             DATA_APP: {"active": []},
-            FAILOVER_APP: {"blocked": ["Main-cluster-orchestrator removed, and no failover cluster related."]},
+            FAILOVER_APP: {
+                "blocked": ["Main-cluster-orchestrator removed, and no failover cluster related."]
+            },
         },
         units_statuses=["active"],
         wait_for_exact_units={app: units for app, units in APP_UNITS.items()},

--- a/tests/integration/ha/test_large_deployments_cluster_manager_only_nodes.py
+++ b/tests/integration/ha/test_large_deployments_cluster_manager_only_nodes.py
@@ -171,18 +171,12 @@ async def test_remove_relation(ops_test: OpsTest) -> None:
         f"{DATA_APP}:{REL_PEER}", f"{FAILOVER_APP}:{REL_ORCHESTRATOR}"
     )
 
-    await ops_test.model.applications[DATA_APP].destroy_relation(
-        f"{DATA_APP}:{REL_PEER}", f"{MAIN_APP}:{REL_ORCHESTRATOR}"
-    )
-
     await wait_until(
         ops_test,
         apps=[MAIN_APP, DATA_APP, FAILOVER_APP],
         apps_full_statuses={
             MAIN_APP: {"active": []},
-            DATA_APP: {
-                "blocked": ["Main-cluster-orchestrator removed, and no failover cluster related."]
-            },
+            DATA_APP: {"active": []},
             FAILOVER_APP: {"active": []},
         },
         units_statuses=["active"],

--- a/tests/integration/ha/test_large_deployments_cluster_manager_only_nodes.py
+++ b/tests/integration/ha/test_large_deployments_cluster_manager_only_nodes.py
@@ -168,7 +168,7 @@ async def test_integrate_failover(ops_test: OpsTest) -> None:
 async def test_remove_relation(ops_test: OpsTest) -> None:
     """Successfully remove relation"""
     await ops_test.model.applications[DATA_APP].destroy_relation(
-        f"{DATA_APP}:{REL_PEER}", f"{FAILOVER_APP}:{REL_ORCHESTRATOR}"
+        f"{FAILOVER_APP}:{REL_PEER}", f"{MAIN_APP}:{REL_ORCHESTRATOR}"
     )
 
     await wait_until(
@@ -177,7 +177,7 @@ async def test_remove_relation(ops_test: OpsTest) -> None:
         apps_full_statuses={
             MAIN_APP: {"active": []},
             DATA_APP: {"active": []},
-            FAILOVER_APP: {"active": []},
+            FAILOVER_APP: {"blocked": ["Main-cluster-orchestrator removed, and no failover cluster related."]},
         },
         units_statuses=["active"],
         wait_for_exact_units={app: units for app, units in APP_UNITS.items()},

--- a/tests/integration/ha/test_large_deployments_cluster_manager_only_nodes.py
+++ b/tests/integration/ha/test_large_deployments_cluster_manager_only_nodes.py
@@ -168,7 +168,7 @@ async def test_integrate_failover(ops_test: OpsTest) -> None:
 async def test_remove_relation(ops_test: OpsTest) -> None:
     """Successfully remove relation"""
     await ops_test.model.applications[DATA_APP].destroy_relation(
-        f"{FAILOVER_APP}:{REL_PEER}", f"{MAIN_APP}:{REL_ORCHESTRATOR}"
+        f"{DATA_APP}:{REL_PEER}", f"{FAILOVER_APP}:{REL_ORCHESTRATOR}"
     )
 
     await wait_until(
@@ -177,9 +177,7 @@ async def test_remove_relation(ops_test: OpsTest) -> None:
         apps_full_statuses={
             MAIN_APP: {"active": []},
             DATA_APP: {"active": []},
-            FAILOVER_APP: {
-                "blocked": ["Main-cluster-orchestrator removed, and no failover cluster related."]
-            },
+            FAILOVER_APP: {"active": []},
         },
         units_statuses=["active"],
         wait_for_exact_units={app: units for app, units in APP_UNITS.items()},

--- a/tests/integration/ha/test_large_deployments_cluster_manager_only_nodes.py
+++ b/tests/integration/ha/test_large_deployments_cluster_manager_only_nodes.py
@@ -160,3 +160,32 @@ async def test_integrate_failover(ops_test: OpsTest) -> None:
     leader_unit_ip = await get_leader_unit_ip(ops_test, app=MAIN_APP)
     nodes = await all_nodes(ops_test, leader_unit_ip, app=MAIN_APP)
     assert len(nodes) == 4, f"Wrong node count. Expecting 4 online nodes, found: {len(nodes)}."
+
+
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "xlarge"])
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_remove_relation(ops_test: OpsTest) -> None:
+    """Successfully remove relation"""
+    await ops_test.model.applications[DATA_APP].destroy_relation(
+        f"{DATA_APP}:{REL_PEER}", f"{FAILOVER_APP}:{REL_ORCHESTRATOR}"
+    )
+
+    await ops_test.model.applications[DATA_APP].destroy_relation(
+        f"{DATA_APP}:{REL_PEER}", f"{MAIN_APP}:{REL_ORCHESTRATOR}"
+    )
+
+    await wait_until(
+        ops_test,
+        apps=[MAIN_APP, DATA_APP, FAILOVER_APP],
+        apps_full_statuses={
+            MAIN_APP: {"active": []},
+            DATA_APP: {
+                "blocked": ["Main-cluster-orchestrator removed, and no failover cluster related."]
+            },
+            FAILOVER_APP: {"active": []},
+        },
+        units_statuses=["active"],
+        wait_for_exact_units={app: units for app, units in APP_UNITS.items()},
+        idle_period=IDLE_PERIOD,
+    )


### PR DESCRIPTION
## Issue
#555 
The `id` of each app in the orchestrators list is accessed in `_on_peer_cluster_relation_departed` but they can be None types

## Solution
Filter out None types from the list of orchestrators before trying to access their ids