### PR TITLE
[DPE-6772] Add http.publish_host

### DIFF
--- a/lib/charms/opensearch/v0/helper_networking.py
+++ b/lib/charms/opensearch/v0/helper_networking.py
@@ -31,12 +31,6 @@ def get_host_ip(charm: CharmBase, peer_relation_name: str) -> str:
     return str(address)
 
 
-def get_host_public_ip(charm: CharmBase, peer_relation_name: str) -> str:
-    """Fetches the IP address of the current unit."""
-    address = charm.model.get_binding(peer_relation_name).network.ingress_address
-    return str(address)
-
-
 def get_host_public_ip() -> Optional[str]:
     """Fetches the Public IP address of the current unit."""
     cmd = "dig +short myip.opendns.com @resolver1.opendns.com"

--- a/lib/charms/opensearch/v0/helper_networking.py
+++ b/lib/charms/opensearch/v0/helper_networking.py
@@ -6,7 +6,6 @@ import logging
 import os
 import socket
 import subprocess
-from enum import Enum
 from typing import Dict, List, Optional
 
 from ops.charm import CharmBase

--- a/lib/charms/opensearch/v0/helper_networking.py
+++ b/lib/charms/opensearch/v0/helper_networking.py
@@ -6,6 +6,7 @@ import logging
 import os
 import socket
 import subprocess
+from enum import Enum
 from typing import Dict, List, Optional
 
 from ops.charm import CharmBase
@@ -25,9 +26,22 @@ LIBPATCH = 1
 logger = logging.getLogger(__name__)
 
 
-def get_host_ip(charm: CharmBase, peer_relation_name: str) -> str:
+class NetworkType(str, Enum):
+    """NetworkType Enum."""
+
+    PUBLIC = "public"
+    PRIVATE = "private"
+    BIND = "bind"
+
+
+def get_host_ip(charm: CharmBase, relation_name: str, type: NetworkType = NetworkType.BIND) -> str:
     """Fetches the IP address of the current unit."""
-    address = charm.model.get_binding(peer_relation_name).network.bind_address
+    if type == NetworkType.PRIVATE:
+        address = charm.model.get_binding(relation_name).network.private_address
+    elif type == NetworkType.PUBLIC:
+        address = charm.model.get_binding(relation_name).network.ingress_address
+    else:
+        address = charm.model.get_binding(relation_name).network.bind_address
     return str(address)
 
 

--- a/lib/charms/opensearch/v0/helper_networking.py
+++ b/lib/charms/opensearch/v0/helper_networking.py
@@ -30,14 +30,11 @@ class NetworkType(str, Enum):
     """NetworkType Enum."""
 
     PUBLIC = "public"
-    PRIVATE = "private"
     BIND = "bind"
 
 
 def get_host_ip(charm: CharmBase, relation_name: str, type: NetworkType = NetworkType.BIND) -> str:
     """Fetches the IP address of the current unit."""
-    if type == NetworkType.PRIVATE:
-        address = charm.model.get_binding(relation_name).network.private_address
     elif type == NetworkType.PUBLIC:
         address = charm.model.get_binding(relation_name).network.ingress_address
     else:

--- a/lib/charms/opensearch/v0/helper_networking.py
+++ b/lib/charms/opensearch/v0/helper_networking.py
@@ -26,19 +26,15 @@ LIBPATCH = 1
 logger = logging.getLogger(__name__)
 
 
-class NetworkType(str, Enum):
-    """NetworkType Enum."""
-
-    PUBLIC = "public"
-    BIND = "bind"
-
-
-def get_host_ip(charm: CharmBase, relation_name: str, type: NetworkType = NetworkType.BIND) -> str:
+def get_host_ip(charm: CharmBase, peer_relation_name: str) -> str:
     """Fetches the IP address of the current unit."""
-    elif type == NetworkType.PUBLIC:
-        address = charm.model.get_binding(relation_name).network.ingress_address
-    else:
-        address = charm.model.get_binding(relation_name).network.bind_address
+    address = charm.model.get_binding(peer_relation_name).network.bind_address
+    return str(address)
+
+
+def get_host_public_ip(charm: CharmBase, peer_relation_name: str) -> str:
+    """Fetches the IP address of the current unit."""
+    address = charm.model.get_binding(peer_relation_name).network.ingress_address
     return str(address)
 
 

--- a/lib/charms/opensearch/v0/opensearch_config.py
+++ b/lib/charms/opensearch/v0/opensearch_config.py
@@ -170,11 +170,9 @@ class OpenSearchConfig:
             self._opensearch.config.put(
                 self.CONFIG_YML, "network.publish_host", self._opensearch.host
             )
-
-        if self._opensearch.public_address:
-            self._opensearch.config.put(
-                self.CONFIG_YML, "http.publish_host", self._opensearch.public_address
-            )
+        self._opensearch.config.put(
+            self.CONFIG_YML, "http.publish_host", self._opensearch.public_address
+        )
 
         self._opensearch.config.put(
             self.CONFIG_YML, "node.roles", roles, inline_array=len(roles) == 0

--- a/lib/charms/opensearch/v0/opensearch_config.py
+++ b/lib/charms/opensearch/v0/opensearch_config.py
@@ -171,6 +171,11 @@ class OpenSearchConfig:
                 self.CONFIG_YML, "network.publish_host", self._opensearch.host
             )
 
+        if self._opensearch.public_address:
+            self._opensearch.config.put(
+                self.CONFIG_YML, "http.publish_host", self._opensearch.public_address
+            )
+
         self._opensearch.config.put(
             self.CONFIG_YML, "node.roles", roles, inline_array=len(roles) == 0
         )
@@ -285,6 +290,11 @@ class OpenSearchConfig:
                 "network.publish_host",
                 node.get("network.publish_host"),
                 self._opensearch.host,
+            ),
+            NetworkHost(
+                "http.publish_host",
+                node.get("http.publish_host"),
+                self._opensearch.public_address,
             ),
         ]:
             if not host.old:

--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -444,7 +444,7 @@ class OpenSearchDistribution(ABC):
         """Get the client bind address."""
         return (
             get_host_public_ip()
-            or or self._charm.model.get_binding(self._peer_relation_name).network.ingress_address
+            or self._charm.model.get_binding(self._peer_relation_name).network.ingress_address
         )
 
     @property

--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -444,9 +444,7 @@ class OpenSearchDistribution(ABC):
         """Get the client bind address."""
         return (
             get_host_public_ip()
-            or self._charm.model.get_binding(
-                self._peer_relation_name
-            ).network.ingress_address
+            or or self._charm.model.get_binding(self._peer_relation_name).network.ingress_address
         )
 
     @property

--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -444,7 +444,7 @@ class OpenSearchDistribution(ABC):
         """Get the client bind address."""
         return (
             get_host_public_ip()
-            or self._charm.model.get_binding(self._peer_relation_name).network.ingress_address
+            or str(self._charm.model.get_binding(self._peer_relation_name).network.ingress_address)
         )
 
     @property

--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -443,8 +443,9 @@ class OpenSearchDistribution(ABC):
     def public_address(self) -> str:
         """Get the client bind address."""
         return (
-            get_host_public_ip()
-            or str(self._charm.model.get_binding(self._peer_relation_name).network.ingress_address)
+            get_host_public_ip() or str(
+                self._charm.model.get_binding(self._peer_relation_name).network.ingress_address
+            )
         )
 
     @property

--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -442,10 +442,8 @@ class OpenSearchDistribution(ABC):
     @property
     def public_address(self) -> str:
         """Get the client bind address."""
-        return (
-            get_host_public_ip() or str(
-                self._charm.model.get_binding(self._peer_relation_name).network.ingress_address
-            )
+        return get_host_public_ip() or str(
+            self._charm.model.get_binding(self._peer_relation_name).network.ingress_address
         )
 
     @property

--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -442,7 +442,12 @@ class OpenSearchDistribution(ABC):
     @property
     def public_address(self) -> str:
         """Get the client bind address."""
-        return get_host_public_ip()
+        return (
+            get_host_public_ip()
+            or self._charm.model.get_binding(
+                self._peer_relation_name
+            ).network.ingress_address
+        )
 
     @property
     def port(self) -> int:

--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -441,7 +441,7 @@ class OpenSearchDistribution(ABC):
 
     @property
     def public_address(self) -> str:
-        """Get the client bind address."""
+        """Get the public bind address of this unit."""
         return get_host_public_ip() or str(
             self._charm.model.get_binding(self._peer_relation_name).network.ingress_address
         )

--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -26,7 +26,11 @@ from charms.opensearch.v0.helper_charm import (
 from charms.opensearch.v0.helper_cluster import Node
 from charms.opensearch.v0.helper_conf_setter import YamlConfigSetter
 from charms.opensearch.v0.helper_http import error_http_retry_log
-from charms.opensearch.v0.helper_networking import get_host_ip, is_reachable
+from charms.opensearch.v0.helper_networking import (
+    get_host_ip,
+    get_host_public_ip,
+    is_reachable,
+)
 from charms.opensearch.v0.models import App, StartMode
 from charms.opensearch.v0.opensearch_exceptions import (
     OpenSearchCmdError,
@@ -434,6 +438,11 @@ class OpenSearchDistribution(ABC):
     def network_hosts(self) -> List[str]:
         """All HTTP/Transport hosts for the current node."""
         return [socket.getfqdn(), self.host]
+
+    @property
+    def public_address(self) -> str:
+        """Get the client bind address."""
+        return get_host_public_ip()
 
     @property
     def port(self) -> int:

--- a/tests/integration/ha/test_scale_to_one_and_back.py
+++ b/tests/integration/ha/test_scale_to_one_and_back.py
@@ -33,6 +33,7 @@ from .test_horizontal_scaling import IDLE_PERIOD
 logger = logging.getLogger(__name__)
 
 
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 @pytest.mark.skip_if_deployed
@@ -71,6 +72,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     await set_watermark(ops_test, app=APP_NAME)
 
 
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_scale_down(
@@ -132,6 +134,7 @@ async def test_scale_down(
     await assert_continuous_writes_consistency(ops_test, c_writes, [app])
 
 
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_scale_back_up(
@@ -183,6 +186,7 @@ async def test_scale_back_up(
     await assert_continuous_writes_consistency(ops_test, c_writes, [app])
 
 
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_gracefully_cluster_remove(ops_test: OpsTest) -> None:

--- a/tests/unit/lib/test_opensearch_config.py
+++ b/tests/unit/lib/test_opensearch_config.py
@@ -187,6 +187,7 @@ class TestOpenSearchConfig(unittest.TestCase):
             typ=DeploymentType.MAIN_ORCHESTRATOR,
             state=DeploymentState(value=State.ACTIVE),
         )
+        self.charm.opensearch.public_address = "30.30.30.30"
 
         self.opensearch_config.set_node(
             app=app,
@@ -205,6 +206,7 @@ class TestOpenSearchConfig(unittest.TestCase):
         self.assertEqual(opensearch_conf["node.attr.app_id"], app.id)
         self.assertEqual(opensearch_conf["network.host"], ["_site_", "10.10.10.10"])
         self.assertEqual(opensearch_conf["network.publish_host"], "20.20.20.20")
+        self.assertEqual(opensearch_conf["http.publish_host"], "30.30.30.30")
         self.assertEqual(opensearch_conf["node.roles"], ["cluster_manager", "data"])
         self.assertEqual(opensearch_conf["discovery.seed_providers"], "file")
         self.assertEqual(opensearch_conf["cluster.initial_cluster_manager_nodes"], ["cm1"])


### PR DESCRIPTION
Adds the http.publish_host so we can separate the IPs that are shared when sniffed.

Closes #579