### PR TITLE
[DPE-6771] Add sniff_timeout

### DIFF
--- a/tests/integration/ha/continuous_writes.py
+++ b/tests/integration/ha/continuous_writes.py
@@ -64,12 +64,13 @@ class ContinuousWrites:
         """Run continuous writes in the background."""
         if not self._is_stopped:
             await self.clear()
-
         # create index if custom conf needed
         if repl_mode == ReplicationMode.WITH_AT_LEAST_1_REPL:
             await self._create_fully_replicated_index()
         elif repl_mode == ReplicationMode.WITH_AT_LEAST_0_REPL:
             await self._create_index_with_0_all_replicas()
+        elif repl_mode == ReplicationMode.DEFAULT:
+            await self._create_default_index()
 
         # create process
         self._create_process(is_bulk=is_bulk)
@@ -138,6 +139,19 @@ class ContinuousWrites:
 
             # max stored document id
             return int(resp["aggregations"]["max_id"]["value"])
+        finally:
+            client.close()
+
+    async def _create_default_index(self):
+        """Create index with 1 p_shard and an r_shard on each node."""
+        client = await self._client()
+        try:
+            # create index with a replica shard on every node
+            client.indices.create(
+                index=ContinuousWrites.INDEX_NAME,
+            )
+        except Exception as e:
+            print(e)
         finally:
             client.close()
 

--- a/tests/integration/ha/continuous_writes.py
+++ b/tests/integration/ha/continuous_writes.py
@@ -64,13 +64,12 @@ class ContinuousWrites:
         """Run continuous writes in the background."""
         if not self._is_stopped:
             await self.clear()
+
         # create index if custom conf needed
         if repl_mode == ReplicationMode.WITH_AT_LEAST_1_REPL:
             await self._create_fully_replicated_index()
         elif repl_mode == ReplicationMode.WITH_AT_LEAST_0_REPL:
             await self._create_index_with_0_all_replicas()
-        elif repl_mode == ReplicationMode.DEFAULT:
-            await self._create_default_index()
 
         # create process
         self._create_process(is_bulk=is_bulk)
@@ -139,19 +138,6 @@ class ContinuousWrites:
 
             # max stored document id
             return int(resp["aggregations"]["max_id"]["value"])
-        finally:
-            client.close()
-
-    async def _create_default_index(self):
-        """Create index with 1 p_shard and an r_shard on each node."""
-        client = await self._client()
-        try:
-            # create index with a replica shard on every node
-            client.indices.create(
-                index=ContinuousWrites.INDEX_NAME,
-            )
-        except Exception as e:
-            print(e)
         finally:
             client.close()
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -114,7 +114,7 @@ async def run_action(
                 continue
 
             ping = subprocess.call(
-                f"nc -zv {unit.ip} 9200".split(),
+                f"nc -zv {unit.ip} 22".split(),
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
             )

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -437,7 +437,7 @@ def opensearch_client(
         sniff_on_start=True,  # sniff before doing anything
         sniff_on_connection_fail=True,  # refresh nodes after a node fails to respond
         sniffer_timeout=60.0,  # and also every 60 seconds
-        sniff_timeout=60.0,  # and also every 60 seconds
+        sniff_timeout=5.0,  # and also every 60 seconds
         use_ssl=True,  # turn on ssl
         verify_certs=True,  # make sure we verify SSL certificates
         ssl_assert_hostname=False,

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -114,7 +114,7 @@ async def run_action(
                 continue
 
             ping = subprocess.call(
-                f"ping -c 1 {unit.ip}".split(),
+                f"nc -zv {unit.ip} 9200".split(),
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
             )
@@ -436,7 +436,8 @@ def opensearch_client(
         http_compress=True,
         sniff_on_start=True,  # sniff before doing anything
         sniff_on_connection_fail=True,  # refresh nodes after a node fails to respond
-        sniffer_timeout=60,  # and also every 60 seconds
+        sniffer_timeout=60.0,  # and also every 60 seconds
+        sniff_timeout=60.0,  # and also every 60 seconds
         use_ssl=True,  # turn on ssl
         verify_certs=True,  # make sure we verify SSL certificates
         ssl_assert_hostname=False,

--- a/tox.ini
+++ b/tox.ini
@@ -69,11 +69,15 @@ allowlist_externals =
     # Set the testing host before starting the lxd cloud
     sudo
     sysctl
+    apt
+    nc
 
 commands_pre =
     poetry install --only main,charm-libs,integration
 
     # Set the testing host before starting the lxd cloud
     sudo sysctl -w vm.max_map_count=262144 vm.swappiness=0 net.ipv4.tcp_retries2=5
+    sudo apt update
+    sudo apt install -y netcat-openbsd
 commands =
     poetry run pytest -v --tb native --log-cli-level=INFO -s --ignore={[vars]tests_path}/unit/ {posargs}


### PR DESCRIPTION
Currently, we are using default sniff_timeout, which is 100ms.

That is not enough for the opensearchpy to a remote cluster.

This PR adds sniff_timeout and extends it to 60s.

Closes #577
