### PR TITLE
[2.18] Temp. skip relation provider tests

### DIFF
--- a/tests/integration/relations/test_opensearch_provider.py
+++ b/tests/integration/relations/test_opensearch_provider.py
@@ -55,6 +55,7 @@ PROTECTED_INDICES = [
 ]
 
 
+@pytest.mark.skip(reason="Merge 2.18 change")
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
@@ -110,6 +111,7 @@ async def test_create_relation(ops_test: OpsTest, application_charm, opensearch_
     )
 
 
+@pytest.mark.skip(reason="Merge 2.18 change")
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
@@ -149,6 +151,7 @@ async def test_index_usage(ops_test: OpsTest):
     )
 
 
+@pytest.mark.skip(reason="Merge 2.18 change")
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
@@ -191,6 +194,7 @@ async def test_bulk_index_usage(ops_test: OpsTest):
     assert set(artists) == {"Herbie Hancock", "Lydian Collective", "Vulfpeck"}
 
 
+@pytest.mark.skip(reason="Merge 2.18 change")
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
@@ -220,6 +224,7 @@ async def get_secret_data(ops_test, secret_uri):
     return json.loads(stdout)[secret_unique_id]["content"]["Data"]
 
 
+@pytest.mark.skip(reason="Merge 2.18 change")
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
@@ -253,6 +258,7 @@ async def test_dashboard_relation(ops_test: OpsTest):
     assert relation_user_pwd == result.response.get("password")
 
 
+@pytest.mark.skip(reason="Merge 2.18 change")
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
@@ -283,6 +289,7 @@ async def test_dashboard_relation_password_change(ops_test: OpsTest):
     assert relation_user_pwd == result.response.get("password")
 
 
+@pytest.mark.skip(reason="Merge 2.18 change")
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
@@ -348,6 +355,7 @@ async def test_scaling(ops_test: OpsTest):
     ), await rel_endpoints(CLIENT_APP_NAME, FIRST_RELATION_NAME)
 
 
+@pytest.mark.skip(reason="Merge 2.18 change")
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
@@ -414,6 +422,7 @@ async def test_multiple_relations(ops_test: OpsTest, application_charm):
     assert "403 Client Error: Forbidden for url:" in results[0], results
 
 
+@pytest.mark.skip(reason="Merge 2.18 change")
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
@@ -452,6 +461,7 @@ async def test_multiple_relations_accessing_same_index(ops_test: OpsTest):
     assert set(artists) == {"Herbie Hancock", "Lydian Collective", "Vulfpeck"}
 
 
+@pytest.mark.skip(reason="Merge 2.18 change")
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
@@ -490,6 +500,7 @@ async def test_admin_relation(ops_test: OpsTest):
     assert set(artists) == {"Herbie Hancock", "Lydian Collective", "Vulfpeck"}
 
 
+@pytest.mark.skip(reason="Merge 2.18 change")
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
@@ -559,6 +570,7 @@ async def test_admin_permissions(ops_test: OpsTest):
         assert "Error:" in results[0], results
 
 
+@pytest.mark.skip(reason="Merge 2.18 change")
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
@@ -621,6 +633,7 @@ async def test_normal_user_permissions(ops_test: OpsTest):
         assert "Error:" in results[0], results
 
 
+@pytest.mark.skip(reason="Merge 2.18 change")
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
@@ -677,6 +690,7 @@ async def test_relation_broken(ops_test: OpsTest):
     assert relation_user not in users.keys()
 
 
+@pytest.mark.skip(reason="Merge 2.18 change")
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail


### PR DESCRIPTION
This PR skips the relation provider checks as we will not have the OSD on v2.18 yet.

