### PR TITLE
Decrease low-level `_run_cmd` logging to "DEBUG"

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -391,7 +391,7 @@ class OpenSearchDistribution(ABC):
             logger.debug(f"{command}:\n{output.stdout}")
 
             if output.returncode != 0:
-                logger.error(f"{command}:\n Stderr: {output.stderr}\n Stdout: {output.stdout}")
+                logger.debug(f"{command}:\n Stderr: {output.stderr}\n Stdout: {output.stdout}")
                 raise OpenSearchCmdError(output.stderr)
         except (TimeoutError, subprocess.TimeoutExpired) as e:
             raise OpenSearchCmdError(e)


### PR DESCRIPTION
Currently, if we have a command that fails in `_run_cmd`, we will: (1) get a ERROR level entry; and (2) raise an OpenSearchCmdError exception.

That can be confusing for an user that is following the deployment on juju debug-log, as the ERROR will point to a potential problem, but the upper classes may be handling the exception and taking the appropriate decisions afterwards.

Therefore, logging beyond "DEBUG" level should be part of the upper class source code, not the `_run_cmd` itself.
