### PR TITLE
[DPE-5490] [DPE-6680] [DPE-6694] [DPE-6763] [DPE-6764] Fix edge case failover app removal

### DIFF
--- a/lib/charms/opensearch/v0/constants_charm.py
+++ b/lib/charms/opensearch/v0/constants_charm.py
@@ -64,7 +64,7 @@ PClusterWrongRelation = "Cluster name don't match with related cluster. Remove r
 PClusterWrongRolesProvided = "Cannot start cluster with current set of roles."
 PClusterNoDataNode = "Cannot run cluster with current roles. Waiting for data node..."
 PClusterWrongNodesCountForQuorum = (
-    "Less than 3 cluster-manager-eligible units in this cluster. Add more units."
+    "Even number of members in quorum if current unit started. Add or remove 1 unit."
 )
 PluginConfigError = "Unexpected error during plugin configuration, check the logs"
 BackupSetupFailed = "Backup setup failed, check logs for details"

--- a/lib/charms/opensearch/v0/constants_charm.py
+++ b/lib/charms/opensearch/v0/constants_charm.py
@@ -64,7 +64,7 @@ PClusterWrongRelation = "Cluster name don't match with related cluster. Remove r
 PClusterWrongRolesProvided = "Cannot start cluster with current set of roles."
 PClusterNoDataNode = "Cannot run cluster with current roles. Waiting for data node..."
 PClusterWrongNodesCountForQuorum = (
-    "Even number of members in quorum if current unit started. Add or remove 1 unit."
+    "Less than 3 cluster-manager-eligible units in this cluster. Add more units."
 )
 PluginConfigError = "Unexpected error during plugin configuration, check the logs"
 BackupSetupFailed = "Backup setup failed, check logs for details"

--- a/lib/charms/opensearch/v0/constants_charm.py
+++ b/lib/charms/opensearch/v0/constants_charm.py
@@ -57,11 +57,14 @@ DataRoleRemovalForbidden = (
     "Removal of data role from current deployment not allowed - the data cannot be reallocated."
 )
 PClusterNoRelation = "Cannot start. Waiting for peer cluster relation..."
+PClusterOrchestratorsRemoved = (
+    "Main-cluster-orchestrator removed, and no failover cluster related."
+)
 PClusterWrongRelation = "Cluster name don't match with related cluster. Remove relation."
 PClusterWrongRolesProvided = "Cannot start cluster with current set of roles."
 PClusterNoDataNode = "Cannot run cluster with current roles. Waiting for data node..."
 PClusterWrongNodesCountForQuorum = (
-    "Even number of members in quorum if current unit started. Add or remove 1 unit."
+    "Less than 3 cluster-manager-eligible units in this cluster. Add more units."
 )
 PluginConfigError = "Unexpected error during plugin configuration, check the logs"
 BackupSetupFailed = "Backup setup failed, check logs for details"
@@ -73,6 +76,9 @@ BackupRelUneligible = "Only orchestrator clusters should relate to backup relati
 # Wait status
 RequestUnitServiceOps = "Requesting lock on operation: {}"
 BackupDeferRelBrokenAsInProgress = "Backup service cannot be stopped: backup in progress."
+PClusterWaitingForFailoverPromotion = (
+    "Main-cluster-orchestrator removed, waiting for failover promotion."
+)
 
 
 # Maintenance statuses

--- a/lib/charms/opensearch/v0/helper_charm.py
+++ b/lib/charms/opensearch/v0/helper_charm.py
@@ -106,7 +106,9 @@ class RelDepartureReason(BaseStrEnum):
     REL_BROKEN = "rel-broken"
 
 
-def relation_departure_reason(charm: CharmBase, relation_name: str) -> RelDepartureReason:
+def relation_departure_reason(
+    charm: CharmBase, relation_name: str, departing_app: str
+) -> RelDepartureReason:
     """Compute the reason behind a relation departed event."""
     # fetch relation info
     goal_state = charm.model._backend._run("goal-state", return_output=True, use_json=True)
@@ -116,7 +118,7 @@ def relation_departure_reason(charm: CharmBase, relation_name: str) -> RelDepart
     dying_units = [
         unit_data["status"] == "dying"
         for unit, unit_data in rel_info.items()
-        if unit != relation_name
+        if unit != departing_app and unit.split("/")[0] == departing_app
     ]
 
     # check if app removal

--- a/lib/charms/opensearch/v0/helper_charm.py
+++ b/lib/charms/opensearch/v0/helper_charm.py
@@ -165,6 +165,10 @@ def all_units_names(charm: "OpenSearchBaseCharm") -> List[Unit]:
 
 def all_units(charm: "OpenSearchBaseCharm") -> List[Unit]:
     """Fetch the list of units for the current app."""
+    # if 0 planned units, return empty list
+    if charm.app.planned_units() == 0:
+        return []
+
     return list(charm.model.get_relation(PeerRelationName).units.union({charm.unit}))
 
 

--- a/lib/charms/opensearch/v0/helper_charm.py
+++ b/lib/charms/opensearch/v0/helper_charm.py
@@ -165,7 +165,6 @@ def all_units_names(charm: "OpenSearchBaseCharm") -> List[Unit]:
 
 def all_units(charm: "OpenSearchBaseCharm") -> List[Unit]:
     """Fetch the list of units for the current app."""
-    # if 0 planned units, return empty list
     return list(charm.model.get_relation(PeerRelationName).units.union({charm.unit}))
 
 

--- a/lib/charms/opensearch/v0/helper_charm.py
+++ b/lib/charms/opensearch/v0/helper_charm.py
@@ -166,9 +166,6 @@ def all_units_names(charm: "OpenSearchBaseCharm") -> List[Unit]:
 def all_units(charm: "OpenSearchBaseCharm") -> List[Unit]:
     """Fetch the list of units for the current app."""
     # if 0 planned units, return empty list
-    if charm.app.planned_units() == 0:
-        return []
-
     return list(charm.model.get_relation(PeerRelationName).units.union({charm.unit}))
 
 

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -494,6 +494,11 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         if self.opensearch_peer_cm.is_provider():
             self.peer_cluster_provider.refresh_relation_data(event, can_defer=False)
 
+        # update any orchestrators about planned units
+        if self.opensearch_peer_cm.is_consumer():
+            self.peer_cluster_requirer.refresh_requirer_relation_data()
+            self.peer_cluster_requirer.apply_orchestrator_status()
+
         for relation in self.model.relations.get(ClientRelationName, []):
             self.opensearch_provider.update_endpoints(relation)
 
@@ -506,11 +511,6 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         elif event.relation.data.get(event.app):
             # if app_data + app_data["nodes_config"]: Reconfigure + restart node on the unit
             self._reconfigure_and_restart_unit_if_needed()
-
-        # update any orchestrators about planned units
-        if self.opensearch_peer_cm.is_consumer():
-            self.peer_cluster_requirer.refresh_requirer_relation_data()
-            self.peer_cluster_requirer.apply_orchestrator_status()
 
         if not (unit_data := event.relation.data.get(event.unit)):
             return

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -555,7 +555,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             unit_name=format_unit_name(event.departing_unit.name, deployment_desc.app)
         )
 
-    def _on_opensearch_data_storage_detaching(self, _: StorageDetachingEvent):  # noqa: C901
+    def _on_opensearch_data_storage_detaching(self, event: StorageDetachingEvent):  # noqa: C901
         """Triggered when removing unit, Prior to the storage being detached."""
         if self.upgrade_in_progress:
             logger.warning(
@@ -577,9 +577,14 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
                     if node.name != self.unit_name
                 ]
                 self._compute_and_broadcast_updated_topology(remaining_nodes)
-            elif self.app.planned_units() == 0 and self.model.get_relation(PeerRelationName):
-                self.peers_data.delete(Scope.APP, "bootstrap_contributors_count")
-                self.peers_data.delete(Scope.APP, "nodes_config")
+            elif self.app.planned_units() == 0:
+                if self.model.get_relation(PeerRelationName):
+                    self.peers_data.delete(Scope.APP, "bootstrap_contributors_count")
+                    self.peers_data.delete(Scope.APP, "nodes_config")
+                if self.opensearch_peer_cm.is_provider():
+                    self.peer_cluster_provider.refresh_relation_data(event, can_defer=False)
+                if self.model.relations.get(PeerClusterRelationName):
+                    self.peer_cluster_requirer.refresh_relation_data()
 
         # we attempt to flush the translog to disk
         if self.opensearch.is_node_up():

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -1495,7 +1495,15 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         ):
             return []
 
-        return ClusterTopology.nodes(self.opensearch, use_localhost, self.alt_hosts)
+        nodes = ClusterTopology.nodes(self.opensearch, use_localhost, self.alt_hosts)
+        if cluster_fleet_apps := self.peers_data.get_object(Scope.APP, "cluster_fleet_apps"):
+            has_planned_units = (
+                lambda node: node.app.id in cluster_fleet_apps
+                and cluster_fleet_apps[node.app.id]["planned_units"] != 0
+            )
+            nodes = [node for node in nodes if has_planned_units(node)]
+
+        return nodes
 
     def _set_node_conf(self, nodes: List[Node]) -> None:
         """Set the configuration of the current node / unit."""

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -77,7 +77,6 @@ from charms.opensearch.v0.opensearch_locking import OpenSearchNodeLock
 from charms.opensearch.v0.opensearch_nodes_exclusions import OpenSearchExclusions
 from charms.opensearch.v0.opensearch_peer_clusters import (
     OpenSearchPeerClustersManager,
-    OpenSearchProvidedRolesException,
     StartMode,
 )
 from charms.opensearch.v0.opensearch_performance_profile import OpenSearchPerformance
@@ -444,12 +443,8 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         # check possibility to start
         if self.opensearch_peer_cm.can_start(deployment_desc):
             try:
-                nodes = self._get_nodes(False)
-                self.opensearch_peer_cm.validate_roles(nodes, on_new_unit=True)
+                self._get_nodes(False)
             except OpenSearchHttpError:
-                return False
-            except OpenSearchProvidedRolesException as e:
-                self.unit.status = BlockedStatus(str(e))
                 return False
 
             return True
@@ -508,6 +503,9 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         if self.unit.is_leader():
             # Recompute the node roles in case self-healing didn't trigger leader related event
             self._recompute_roles_if_needed(event)
+            if self.peers_data.get(Scope.APP, "is_expecting_cm_unit"):
+                # indicates we previously scaled down to <3 CM-eligible units in the cluster
+                self.opensearch_peer_cm.validate_recommended_cm_unit_count()
         elif event.relation.data.get(event.app):
             # if app_data + app_data["nodes_config"]: Reconfigure + restart node on the unit
             self._reconfigure_and_restart_unit_if_needed()
@@ -549,16 +547,16 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
 
         self.health.apply(wait_for_green_first=True)
 
-        if (
-            len([node for node in remaining_nodes if node.app.id == current_app.id])
-            == self.app.planned_units()
-        ):
+        n_units = sum(app.planned_units for app in self.opensearch_peer_cm.apps_in_fleet())
+        if len(remaining_nodes) == n_units:
             self._compute_and_broadcast_updated_topology(remaining_nodes)
         else:
             event.defer()
 
         if not self.unit.is_leader():
             return
+
+        self.opensearch_peer_cm.validate_recommended_cm_unit_count(remaining_nodes)
 
         self.opensearch_exclusions.add_to_cleanup_list(
             unit_name=format_unit_name(event.departing_unit.name, deployment_desc.app)
@@ -579,13 +577,14 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         # if the leader is departing, and this hook fails "leader elected" won"t trigger,
         # so we want to re-balance the node roles from here
         if self.unit.is_leader():
-            if self.app.planned_units() > 1 and (self.opensearch.is_node_up() or self.alt_hosts):
+            if self.app.planned_units() >= 1 and (self.opensearch.is_node_up() or self.alt_hosts):
                 remaining_nodes = [
                     node
                     for node in self._get_nodes(self.opensearch.is_node_up())
                     if node.name != self.unit_name
                 ]
                 self._compute_and_broadcast_updated_topology(remaining_nodes)
+                self.opensearch_peer_cm.validate_recommended_cm_unit_count(remaining_nodes)
             elif self.app.planned_units() == 0:
                 if self.model.get_relation(PeerRelationName):
                     self.peers_data.delete(Scope.APP, "bootstrap_contributors_count")
@@ -1049,21 +1048,12 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             # Retrieve the nodes of the cluster, needed to configure this node
             nodes = self._get_nodes(False)
 
-            # validate the roles prior to starting
-            self.opensearch_peer_cm.validate_roles(nodes, on_new_unit=True)
-
             # Set the configuration of the node
             self._set_node_conf(nodes)
         except OpenSearchHttpError as e:
             logger.debug(f"error getting the nodes: {e}")
             self.node_lock.release()
             event.defer()
-            return
-        except OpenSearchProvidedRolesException as e:
-            logger.exception(e)
-            self.node_lock.release()
-            event.defer()
-            self.unit.status = BlockedStatus(str(e))
             return
 
         try:
@@ -1656,13 +1646,6 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
                     unit_number=self.unit_id,
                     temperature=temperature,
                 )
-
-            # TODO: remove this when we get rid of roles recomputing logic
-            try:
-                self.opensearch_peer_cm.validate_roles(current_nodes, on_new_unit=False)
-            except OpenSearchProvidedRolesException as e:
-                logger.exception(e)
-                self.app.status = BlockedStatus(str(e))
 
         if current_reported_nodes == updated_nodes:
             return

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -475,7 +475,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
                 "Adding units during an upgrade is not supported. The charm may be in a broken, unrecoverable state"
             )
 
-    def _on_peer_relation_changed(self, event: RelationChangedEvent):
+    def _on_peer_relation_changed(self, event: RelationChangedEvent):  # noqa C901
         """Handle peer relation changes."""
         if self.unit.is_leader() and self.opensearch.is_node_up():
             health = self.health.apply()
@@ -507,6 +507,11 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             # if app_data + app_data["nodes_config"]: Reconfigure + restart node on the unit
             self._reconfigure_and_restart_unit_if_needed()
 
+        # update any orchestrators about planned units
+        if self.opensearch_peer_cm.is_consumer():
+            self.peer_cluster_requirer.refresh_requirer_relation_data()
+            self.peer_cluster_requirer.apply_orchestrator_status()
+
         if not (unit_data := event.relation.data.get(event.unit)):
             return
 
@@ -525,23 +530,6 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         if not (self.unit.is_leader() and self.opensearch.is_node_up()):
             return
 
-        current_app = self.opensearch_peer_cm.deployment_desc().app
-        remaining_nodes = [
-            node
-            for node in self._get_nodes(True)
-            if node.name != format_unit_name(event.departing_unit, app=current_app)
-        ]
-
-        self.health.apply(wait_for_green_first=True)
-
-        if len(remaining_nodes) == self.app.planned_units():
-            self._compute_and_broadcast_updated_topology(remaining_nodes)
-        else:
-            event.defer()
-
-        if not self.unit.is_leader():
-            return
-
         # Now, we register in the leader application the presence of departing unit's name
         # We need to save them as we have a count limit
         if (
@@ -551,6 +539,27 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             # No deployment description present
             # that happens in the very last stages of the application removal
             return
+
+        current_app = self.opensearch_peer_cm.deployment_desc().app
+        remaining_nodes = [
+            node
+            for node in self._get_nodes(True)
+            if node.name != format_unit_name(event.departing_unit, app=current_app)
+        ]
+
+        self.health.apply(wait_for_green_first=True)
+
+        if (
+            len([node for node in remaining_nodes if node.app.id == current_app.id])
+            == self.app.planned_units()
+        ):
+            self._compute_and_broadcast_updated_topology(remaining_nodes)
+        else:
+            event.defer()
+
+        if not self.unit.is_leader():
+            return
+
         self.opensearch_exclusions.add_to_cleanup_list(
             unit_name=format_unit_name(event.departing_unit.name, deployment_desc.app)
         )
@@ -583,8 +592,8 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
                     self.peers_data.delete(Scope.APP, "nodes_config")
                 if self.opensearch_peer_cm.is_provider():
                     self.peer_cluster_provider.refresh_relation_data(event, can_defer=False)
-                if self.model.relations.get(PeerClusterRelationName):
-                    self.peer_cluster_requirer.refresh_relation_data()
+                if self.opensearch_peer_cm.is_consumer():
+                    self.peer_cluster_requirer.refresh_requirer_relation_data()
 
         # we attempt to flush the translog to disk
         if self.opensearch.is_node_up():
@@ -1495,15 +1504,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         ):
             return []
 
-        nodes = ClusterTopology.nodes(self.opensearch, use_localhost, self.alt_hosts)
-        if cluster_fleet_apps := self.peers_data.get_object(Scope.APP, "cluster_fleet_apps"):
-            has_planned_units = (
-                lambda node: node.app.id in cluster_fleet_apps
-                and cluster_fleet_apps[node.app.id]["planned_units"] != 0
-            )
-            nodes = [node for node in nodes if has_planned_units(node)]
-
-        return nodes
+        return ClusterTopology.nodes(self.opensearch, use_localhost, self.alt_hosts)
 
     def _set_node_conf(self, nodes: List[Node]) -> None:
         """Set the configuration of the current node / unit."""

--- a/lib/charms/opensearch/v0/opensearch_peer_clusters.py
+++ b/lib/charms/opensearch/v0/opensearch_peer_clusters.py
@@ -407,15 +407,15 @@ class OpenSearchPeerClustersManager:
 
         # validate the full-cluster wide count of cm+voting_only nodes to keep the quorum
         full_cluster_planned_units = self._charm.app.planned_units()
-        apps_in_fleet = self._charm.peers_data.get_object(Scope.APP, "cluster_fleet_apps") or {}
-        apps_in_fleet = [PeerClusterApp.from_dict(app) for app in apps_in_fleet.values()]
-        full_cluster_planned_units += sum(
-            [
-                p_cluster_app.planned_units
-                for p_cluster_app in apps_in_fleet
-                if p_cluster_app.app.id != deployment_desc.app.id
-            ]
-        )
+        if apps_in_fleet := self._charm.peers_data.get_object(Scope.APP, "cluster_fleet_apps"):
+            apps_in_fleet = [PeerClusterApp.from_dict(app) for app in apps_in_fleet.values()]
+            full_cluster_planned_units += sum(
+                [
+                    p_cluster_app.planned_units
+                    for p_cluster_app in apps_in_fleet
+                    if p_cluster_app.app.id != deployment_desc.app.id
+                ]
+            )
 
         current_cluster_online_nodes = [
             node for node in nodes if node.app.id == deployment_desc.app.id
@@ -425,11 +425,11 @@ class OpenSearchPeerClustersManager:
             # this is not the latest unit to be brought online, we can continue
             return
 
-        is_large_deployment = len(apps_in_fleet) > 1
-        cms = sum(1 for node in nodes if node.is_cm_eligible())
-        if on_new_unit or not is_large_deployment or (is_large_deployment and cms >= 3):
-            # if validation called on large deployment,
-            # start if there are at least 3 cm eligible nodes
+        voters = sum(1 for node in nodes if node.is_cm_eligible() or node.is_voting_only())
+        if voters % 2 == (0 if on_new_unit else 1):
+            # if validation called on new unit: it means it will start and maintain the quorum
+            #    (called on the latest unit to be configured and brought online)
+            # if validation called on existing cluster we should expect an odd number in the sum
             return
 
         raise OpenSearchProvidedRolesException(PClusterWrongNodesCountForQuorum)

--- a/lib/charms/opensearch/v0/opensearch_peer_clusters.py
+++ b/lib/charms/opensearch/v0/opensearch_peer_clusters.py
@@ -332,7 +332,6 @@ class OpenSearchPeerClustersManager:
             CmVoRolesProvidedInvalid,
             DataRoleRemovalForbidden,
             PClusterNoRelation,
-            PClusterWrongNodesCountForQuorum,
             PClusterWrongRelation,
             PClusterWrongRolesProvided,
         ]
@@ -394,45 +393,51 @@ class OpenSearchPeerClustersManager:
             Scope.APP, "deployment-description", deployment_desc.to_dict()
         )
 
-    def validate_roles(self, nodes: List[Node], on_new_unit: bool = False) -> None:
-        """Validate full-cluster wide the quorum for CM/voting_only nodes on services start."""
+    def has_recommended_cm_count(self, nodes: List[Node]) -> bool:
+        """Validate cluster-wide count for CM-eligible nodes is at least 3"""
         deployment_desc = self.deployment_desc()
-        if not set(deployment_desc.config.roles) & {"cluster_manager", "voting_only"}:
-            # the user is not adding any cm nor voting_only roles to the nodes
-            return
+        if (
+            not set(deployment_desc.config.roles) & {"cluster_manager", "voting_only"}
+            and deployment_desc.start != StartMode.WITH_GENERATED_ROLES
+        ):
+            # only CM-eligible nodes run the validations
+            return True
 
-        if deployment_desc.start == StartMode.WITH_GENERATED_ROLES:
-            # the roles are automatically generated, we trust the correctness
-            return
+        is_large_deployment = self.is_provider() or self.is_consumer()
+        cms = sum(1 for node in nodes if node.is_cm_eligible())
+        if not is_large_deployment or (is_large_deployment and cms >= 3):
+            # validation is only needed in large deployments
+            # we can start with any number of cms but set a blocked status
+            # if CMS < 3 when a CM-eligible application is scaled down or removed
+            return True
 
-        # validate the full-cluster wide count of cm+voting_only nodes to keep the quorum
-        full_cluster_planned_units = self._charm.app.planned_units()
-        if apps_in_fleet := self._charm.peers_data.get_object(Scope.APP, "cluster_fleet_apps"):
-            apps_in_fleet = [PeerClusterApp.from_dict(app) for app in apps_in_fleet.values()]
-            full_cluster_planned_units += sum(
-                [
-                    p_cluster_app.planned_units
-                    for p_cluster_app in apps_in_fleet
-                    if p_cluster_app.app.id != deployment_desc.app.id
-                ]
+        logger.info("Less than 3 CM-eligible units in this cluster")
+        return False
+
+    def validate_recommended_cm_unit_count(self, nodes: Optional[List[Node]] = None) -> None:
+        """Validates that the cluster has at least 3 CM-eligible units.
+
+        If validation fails, sets the application status to Blocked.
+        """
+        if nodes is None:
+            nodes = ClusterTopology.nodes(
+                self._charm.opensearch, self._opensearch.is_node_up(), self._charm.alt_hosts
             )
 
-        current_cluster_online_nodes = [
-            node for node in nodes if node.app.id == deployment_desc.app.id
-        ]
-
-        if len(current_cluster_online_nodes) < full_cluster_planned_units - 1:
-            # this is not the latest unit to be brought online, we can continue
+        if self.has_recommended_cm_count(nodes):
+            self._charm.peers_data.delete(Scope.APP, "is_expecting_cm_unit")
+            self._charm.status.clear(PClusterWrongNodesCountForQuorum, app=True)
             return
 
-        voters = sum(1 for node in nodes if node.is_cm_eligible() or node.is_voting_only())
-        if voters % 2 == (0 if on_new_unit else 1):
-            # if validation called on new unit: it means it will start and maintain the quorum
-            #    (called on the latest unit to be configured and brought online)
-            # if validation called on existing cluster we should expect an odd number in the sum
-            return
+        self._charm.peers_data.put(Scope.APP, "is_expecting_cm_unit", True)
+        self._charm.status.set(BlockedStatus(PClusterWrongNodesCountForQuorum), app=True)
 
-        raise OpenSearchProvidedRolesException(PClusterWrongNodesCountForQuorum)
+    def apps_in_fleet(self) -> List[PeerClusterApp]:
+        """Returns list of apps in cluster fleet"""
+        cluster_fleet_apps = (
+            self._charm.peers_data.get_object(Scope.APP, "cluster_fleet_apps") or {}
+        )
+        return [PeerClusterApp.from_dict(app) for app in cluster_fleet_apps.values()]
 
     def is_provider(self, typ: Optional[Literal["main", "failover"]] = None) -> bool:
         """Return whether the current app is a related to provider / orchestrator."""

--- a/lib/charms/opensearch/v0/opensearch_peer_clusters.py
+++ b/lib/charms/opensearch/v0/opensearch_peer_clusters.py
@@ -425,11 +425,11 @@ class OpenSearchPeerClustersManager:
             # this is not the latest unit to be brought online, we can continue
             return
 
-        voters = sum(1 for node in nodes if node.is_cm_eligible() or node.is_voting_only())
-        if voters % 2 == (0 if on_new_unit else 1):
-            # if validation called on new unit: it means it will start and maintain the quorum
-            #    (called on the latest unit to be configured and brought online)
-            # if validation called on existing cluster we should expect an odd number in the sum
+        is_large_deployment = len(apps_in_fleet) > 1
+        cms = sum(1 for node in nodes if node.is_cm_eligible())
+        if on_new_unit or not is_large_deployment or (is_large_deployment and cms >= 3):
+            # if validation called on large deployment,
+            # start if there are at least 3 cm eligible nodes
             return
 
         raise OpenSearchProvidedRolesException(PClusterWrongNodesCountForQuorum)

--- a/lib/charms/opensearch/v0/opensearch_peer_clusters.py
+++ b/lib/charms/opensearch/v0/opensearch_peer_clusters.py
@@ -407,15 +407,15 @@ class OpenSearchPeerClustersManager:
 
         # validate the full-cluster wide count of cm+voting_only nodes to keep the quorum
         full_cluster_planned_units = self._charm.app.planned_units()
-        if apps_in_fleet := self._charm.peers_data.get_object(Scope.APP, "cluster_fleet_apps"):
-            apps_in_fleet = [PeerClusterApp.from_dict(app) for app in apps_in_fleet.values()]
-            full_cluster_planned_units += sum(
-                [
-                    p_cluster_app.planned_units
-                    for p_cluster_app in apps_in_fleet
-                    if p_cluster_app.app.id != deployment_desc.app.id
-                ]
-            )
+        apps_in_fleet = self._charm.peers_data.get_object(Scope.APP, "cluster_fleet_apps") or {}
+        apps_in_fleet = [PeerClusterApp.from_dict(app) for app in apps_in_fleet.values()]
+        full_cluster_planned_units += sum(
+            [
+                p_cluster_app.planned_units
+                for p_cluster_app in apps_in_fleet
+                if p_cluster_app.app.id != deployment_desc.app.id
+            ]
+        )
 
         current_cluster_online_nodes = [
             node for node in nodes if node.app.id == deployment_desc.app.id

--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -258,6 +258,10 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
         ):
             return
 
+        cluster_fleet_apps = self.charm.peers_data.get_object(Scope.APP, "cluster_fleet_apps")
+        cluster_fleet_apps.pop(trigger_app.app.id, None)
+        self.charm.peers_data.put_object(Scope.APP, "cluster_fleet_apps", cluster_fleet_apps)
+
         orchestrators = PeerClusterOrchestrators.from_dict(
             self.charm.peers_data.get_object(Scope.APP, "orchestrators")
         )
@@ -1022,8 +1026,12 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
         self.put_in_rel(data={"app": current_app.to_str()}, rel_id=rel_id)
 
         # update content of fleet in the current app's peer databag
-        cluster_fleet_apps = self.get_obj_from_rel("cluster_fleet_apps", rel_id=rel_id)
-        cluster_fleet_apps.update({deployment_desc.app.id: current_app.to_dict()})
+        cluster_fleet_apps = (
+            self.charm.peers_data.get_object(Scope.APP, "cluster_fleet_apps") or {}
+        )
+        rel_cluster_fleet_apps = self.get_obj_from_rel("cluster_fleet_apps", rel_id=rel_id)
+        rel_cluster_fleet_apps.update({deployment_desc.app.id: current_app.to_dict()})
+        cluster_fleet_apps.update(rel_cluster_fleet_apps)
         self.charm.peers_data.put_object(Scope.APP, "cluster_fleet_apps", cluster_fleet_apps)
 
     def _on_peer_cluster_relation_departed(self, event: RelationDepartedEvent):

--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -274,6 +274,9 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
             self.charm.peers_data.get_object(Scope.APP, "orchestrators")
         )
 
+        # store the main/failover-cm planned units count
+        self._put_fleet_apps(deployment_desc, all_relation_ids)
+
         # compute the data that needs to be broadcast to all related clusters (success or error)
         # if rel_data is an error, prepare to broadcast it to all related clusters
         rel_data = self._rel_data(deployment_desc, orchestrators)
@@ -291,14 +294,9 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
             self.delete_from_rel("trigger", rel_id=event_rel_id)
             return
 
-        # store the main/failover-cm planned units count
-        self._put_fleet_apps(deployment_desc, all_relation_ids)
-
         cluster_type = (
             "main" if deployment_desc.typ == DeploymentType.MAIN_ORCHESTRATOR else "failover"
         )
-        orchestrator_app_key = f"{cluster_type}_app"
-        orchestrator_rel_key = f"{cluster_type}_rel_id"
 
         # flag the trigger of the rel changed update on the consumer side
         if event_rel_id:
@@ -306,9 +304,11 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
 
         # update reported orchestrators on local orchestrator
         orchestrators = orchestrators.to_dict()
+        orchestrator_app_key = f"{cluster_type}_app"
+        orchestrator_rel_key = f"{cluster_type}_rel_id"
         planned_units = self.charm.app.planned_units()
         if planned_units == 0:
-            # remove orchestrator if 0 planned units
+            # remove orchestrator if units scaled down to 0
             orchestrators[orchestrator_app_key] = None
             orchestrators[orchestrator_rel_key] = -1
         else:
@@ -322,14 +322,15 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
         # save the orchestrators of this fleet
         for rel_id in all_relation_ids:
             orchestrators = self.get_obj_from_rel("orchestrators", rel_id=rel_id)
-            # remove orchestrator if 0 planned units
-            updated_orchestrator = {
-                orchestrator_app_key: (
-                    None if planned_units == 0 else deployment_desc.app.to_dict()
-                ),
-                orchestrator_rel_key: -1 if planned_units == 0 else rel_id,
-            }
-            orchestrators.update(updated_orchestrator)
+            # remove orchestrator if units scaled down to 0
+            orchestrators.update(
+                {
+                    orchestrator_app_key: (
+                        None if planned_units == 0 else deployment_desc.app.to_dict()
+                    ),
+                    orchestrator_rel_key: -1 if planned_units == 0 else rel_id,
+                }
+            )
             self.put_in_rel(data={"orchestrators": json.dumps(orchestrators)}, rel_id=rel_id)
 
             # there is no error to broadcast - we clear any previously broadcasted error
@@ -348,9 +349,16 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
                 )
             else:
                 self.put_in_rel(data={"error_data": rel_data.to_str()}, rel_id=rel_id)
+                self._delete_rel_data_on_error(rel_id)
 
         if can_defer and should_defer:
             event.defer()
+
+    def _delete_rel_data_on_error(self, rel_id: int) -> None:
+        """Deletes relation data when an error is about to be broadcasted"""
+        self.delete_from_rel("cluster_fleet_apps", rel_id=rel_id)
+        self.delete_from_rel("data", rel_id=rel_id)
+        self.delete_from_rel("rel_data_hash", rel_id=rel_id)
 
     def _notify_if_wrong_integration(
         self,
@@ -368,18 +376,6 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
             self.put_in_rel(data={"error_data": rel_data.to_str()}, rel_id=rel_id)
 
         return True
-
-    def _update_fleet_dict(
-        self, fleet_dict: dict, app: PeerClusterApp, update_key: Optional[str] = None
-    ) -> None:
-        """Updates or removes app in the provided fleet dictionary."""
-        if not update_key:
-            update_key = app.app.id
-
-        if app.planned_units == 0:  # if 0 planned units, remove entry
-            fleet_dict.pop(update_key, None)
-        else:
-            fleet_dict.update({update_key: app.to_dict()})
 
     def _put_fleet_apps(
         self,
@@ -400,9 +396,9 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
             roles=deployment_desc.config.roles,
         )
 
-        self._update_fleet_dict(cluster_fleet_apps, current_app)
+        cluster_fleet_apps.update({current_app.app.id: current_app.to_dict()})
         if p_cluster_app:
-            self._update_fleet_dict(cluster_fleet_apps, p_cluster_app)
+            cluster_fleet_apps.update({p_cluster_app.app.id: p_cluster_app.to_dict()})
 
         for rel_id in target_relation_ids:
             self.put_in_rel(
@@ -417,7 +413,7 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
             cluster_fleet_apps_rels = (
                 self.charm.peers_data.get_object(Scope.APP, "cluster_fleet_apps_rels") or {}
             )
-            self._update_fleet_dict(cluster_fleet_apps_rels, p_cluster_app, str(trigger_rel_id))
+            cluster_fleet_apps_rels.update({str(trigger_rel_id): p_cluster_app.to_dict()})
             self.charm.peers_data.put_object(
                 Scope.APP, "cluster_fleet_apps_rels", cluster_fleet_apps_rels
             )
@@ -601,17 +597,13 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
 
     def _fetch_local_cm_nodes(self, deployment_desc: DeploymentDescription) -> List[Node]:
         """Fetch the cluster_manager eligible node IPs in the current cluster."""
-        # if 0 planned_units, return empty list
-        if self.charm.app.planned_units() == 0:
-            return []
-
         nodes = ClusterTopology.nodes(
             self._opensearch,
             use_localhost=self._opensearch.is_node_up(),
             hosts=self.charm.alt_hosts,
         )
 
-        if not nodes:
+        if not nodes and self.charm.app.planned_units() != 0:
             # create a node from the deployment desc or generated roles and unit data only
             if deployment_desc.start == StartMode.WITH_PROVIDED_ROLES:
                 computed_roles = deployment_desc.config.roles
@@ -627,6 +619,13 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
                     unit_number=self.charm.unit_id,
                 )
             ]
+
+        if cluster_fleet_apps := self.charm.peers_data.get_object(Scope.APP, "cluster_fleet_apps"):
+            has_planned_units = (
+                lambda node: node.app.id in cluster_fleet_apps
+                and cluster_fleet_apps[node.app.id]["planned_units"] != 0
+            )
+            nodes = [node for node in nodes if has_planned_units(node)]
 
         return [
             node
@@ -769,8 +768,10 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
             event.defer()
             return
 
-        if event.relation.app:
-            # register in the 'main/failover'-CMs the number of planned units of the current app
+        # register in the 'main/failover'-CMs the number of planned units of the current app
+        if (
+            event.relation.active
+        ):  # guard against updating a relation with an already departed orchestrator
             self._put_current_app(event.relation.id, deployment_desc)
 
         if not (data := event.relation.data.get(event.app)):

--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -253,9 +253,7 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
 
         # if the trigger app is the failover orchestrator and there are no planned units, delete it
         if (
-            relation_departure_reason(
-                self.charm, self.relation_name, event.app.name if event.app else ""
-            )
+            relation_departure_reason(self.charm, self.relation_name, event.app.name)
             == RelDepartureReason.SCALE_DOWN
         ):
             return
@@ -266,16 +264,6 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
         if event.relation.id == orchestrators.failover_rel_id:
             orchestrators.delete("failover")
             self.charm.peers_data.put_object(Scope.APP, "orchestrators", orchestrators.to_dict())
-            # update orchestrators in rel data
-            all_relation_ids = [
-                rel.id for rel in self.charm.model.relations[self.relation_name] if rel.units
-            ]
-            for rel_id in all_relation_ids:
-                orchestrators = PeerClusterOrchestrators.from_dict(
-                    self.get_obj_from_rel("orchestrators", rel_id=rel_id)
-                )
-                orchestrators.delete("failover")
-                self.put_in_rel(data={"orchestrators": orchestrators.to_str()}, rel_id=rel_id)
 
     def refresh_relation_data(  # noqa: C901
         self, event: EventBase, event_rel_id: int | None = None, can_defer: bool = True
@@ -1062,9 +1050,7 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
 
         # handle scale-down at the charm level storage detaching, or??
         if (
-            relation_departure_reason(
-                self.charm, self.relation_name, event.app.name if event.app else ""
-            )
+            relation_departure_reason(self.charm, self.relation_name, event.app.name)
             == RelDepartureReason.SCALE_DOWN
         ):
             return

--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -243,10 +243,7 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
         if not (trigger_app := cluster_fleet_apps_rels.get(str(event.relation.id))):
             return
 
-        # set the planned units to 0 given we're losing visibility over it from here on
         trigger_app = PeerClusterApp.from_dict(trigger_app)
-        trigger_app.planned_units = 0
-
         self._put_fleet_apps(
             deployment_desc=self.charm.opensearch_peer_cm.deployment_desc(),
             target_relation_ids=target_relation_ids,
@@ -254,7 +251,33 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
             trigger_rel_id=event.relation.id,
         )
 
-    def refresh_relation_data(
+        # if the trigger app is the failover orchestrator and there are no planned units, delete it
+        if (
+            relation_departure_reason(
+                self.charm, self.relation_name, event.app.name if event.app else ""
+            )
+            == RelDepartureReason.SCALE_DOWN
+        ):
+            return
+
+        orchestrators = PeerClusterOrchestrators.from_dict(
+            self.charm.peers_data.get_object(Scope.APP, "orchestrators")
+        )
+        if event.relation.id == orchestrators.failover_rel_id:
+            orchestrators.delete("failover")
+            self.charm.peers_data.put_object(Scope.APP, "orchestrators", orchestrators.to_dict())
+            # update orchestrators in rel data
+            all_relation_ids = [
+                rel.id for rel in self.charm.model.relations[self.relation_name] if rel.units
+            ]
+            for rel_id in all_relation_ids:
+                orchestrators = PeerClusterOrchestrators.from_dict(
+                    self.get_obj_from_rel("orchestrators", rel_id=rel_id)
+                )
+                orchestrators.delete("failover")
+                self.put_in_rel(data={"orchestrators": orchestrators.to_str()}, rel_id=rel_id)
+
+    def refresh_relation_data(  # noqa: C901
         self, event: EventBase, event_rel_id: int | None = None, can_defer: bool = True
     ) -> None:
         """Refresh the peer cluster rel data (new cm node, admin password change etc.)."""
@@ -274,9 +297,6 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
             self.charm.peers_data.get_object(Scope.APP, "orchestrators")
         )
 
-        # store the main/failover-cm planned units count
-        self._put_fleet_apps(deployment_desc, all_relation_ids)
-
         # compute the data that needs to be broadcast to all related clusters (success or error)
         # if rel_data is an error, prepare to broadcast it to all related clusters
         rel_data = self._rel_data(deployment_desc, orchestrators)
@@ -294,6 +314,9 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
             self.delete_from_rel("trigger", rel_id=event_rel_id)
             return
 
+        # store the main/failover-cm planned units count
+        self._put_fleet_apps(deployment_desc, all_relation_ids)
+
         cluster_type = (
             "main" if deployment_desc.typ == DeploymentType.MAIN_ORCHESTRATOR else "failover"
         )
@@ -303,13 +326,8 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
             self.put_in_rel({"trigger": cluster_type}, rel_id=event_rel_id)
 
         # update reported orchestrators on local orchestrator
-        has_units = self.charm.app.planned_units() > 0
         orchestrators = orchestrators.to_dict()
-        if has_units:
-            orchestrators[f"{cluster_type}_app"] = deployment_desc.app.to_dict()
-        else:
-            orchestrators[f"{cluster_type}_app"] = None
-            orchestrators[f"{cluster_type}_rel_id"] = -1
+        orchestrators[f"{cluster_type}_app"] = deployment_desc.app.to_dict()
         self.charm.peers_data.put_object(Scope.APP, "orchestrators", orchestrators)
 
         should_defer = False
@@ -317,9 +335,9 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
             should_defer = rel_data.should_wait
 
         # save the orchestrators of this fleet
+        has_units = self.charm.app.planned_units() > 0
         for rel_id in all_relation_ids:
             orchestrators = self.get_obj_from_rel("orchestrators", rel_id=rel_id)
-            # remove orchestrator if units scaled down to 0
             orchestrators.update(
                 {
                     f"{cluster_type}_app": deployment_desc.app.to_dict() if has_units else None,
@@ -344,16 +362,13 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
                 )
             else:
                 self.put_in_rel(data={"error_data": rel_data.to_str()}, rel_id=rel_id)
-                self._delete_rel_data_on_error(rel_id)
+
+            # if no planned units, delete relation data as it won't get updated
+            if not has_units:
+                self._delete_rel_data(rel_id)
 
         if can_defer and should_defer:
             event.defer()
-
-    def _delete_rel_data_on_error(self, rel_id: int) -> None:
-        """Deletes relation data when an error is broadcasted"""
-        self.delete_from_rel("cluster_fleet_apps", rel_id=rel_id)
-        self.delete_from_rel("data", rel_id=rel_id)
-        self.delete_from_rel("rel_data_hash", rel_id=rel_id)
 
     def _notify_if_wrong_integration(
         self,
@@ -372,6 +387,25 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
 
         return True
 
+    def _delete_rel_data(self, rel_id: int) -> None:
+        """Deletes relation data"""
+        self.delete_from_rel("cluster_fleet_apps", rel_id=rel_id)
+        self.delete_from_rel("data", rel_id=rel_id)
+        self.delete_from_rel("rel_data_hash", rel_id=rel_id)
+
+    def _update_or_pop_from_fleet_dict(
+        self, fleet_dict: dict, app: PeerClusterApp, key: Optional[str] = None
+    ) -> None:
+        """Update fleet dictionary with the app, or remove the entry if no planned units."""
+        if not key:
+            key = app.app.id
+
+        if app.planned_units == 0:
+            fleet_dict.pop(key, None)
+            return
+
+        fleet_dict.update({key: app.to_dict()})
+
     def _put_fleet_apps(
         self,
         deployment_desc: DeploymentDescription,
@@ -384,21 +418,16 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
             self.charm.peers_data.get_object(Scope.APP, "cluster_fleet_apps") or {}
         )
 
-        planned_units = self.charm.app.planned_units()
         current_app = PeerClusterApp(
             app=deployment_desc.app,
-            planned_units=planned_units,
-            units=(
-                [format_unit_name(u, app=deployment_desc.app) for u in all_units(self.charm)]
-                if planned_units > 0
-                else []
-            ),
+            planned_units=self.charm.app.planned_units(),
+            units=[format_unit_name(u, app=deployment_desc.app) for u in all_units(self.charm)],
             roles=deployment_desc.config.roles,
         )
-        cluster_fleet_apps.update({current_app.app.id: current_app.to_dict()})
+        self._update_or_pop_from_fleet_dict(cluster_fleet_apps, current_app)
 
         if p_cluster_app:
-            cluster_fleet_apps.update({p_cluster_app.app.id: p_cluster_app.to_dict()})
+            self._update_or_pop_from_fleet_dict(cluster_fleet_apps, p_cluster_app)
 
         for rel_id in target_relation_ids:
             self.put_in_rel(
@@ -413,7 +442,9 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
             cluster_fleet_apps_rels = (
                 self.charm.peers_data.get_object(Scope.APP, "cluster_fleet_apps_rels") or {}
             )
-            cluster_fleet_apps_rels.update({str(trigger_rel_id): p_cluster_app.to_dict()})
+            self._update_or_pop_from_fleet_dict(
+                cluster_fleet_apps_rels, p_cluster_app, key=str(trigger_rel_id)
+            )
 
             self.charm.peers_data.put_object(
                 Scope.APP, "cluster_fleet_apps_rels", cluster_fleet_apps_rels
@@ -622,11 +653,12 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
             ]
 
         if cluster_fleet_apps := self.charm.peers_data.get_object(Scope.APP, "cluster_fleet_apps"):
+            # only report nodes from apps with planned units
             has_planned_units = (
-                lambda node: node.app.id in cluster_fleet_apps
-                and cluster_fleet_apps[node.app.id]["planned_units"] != 0
+                lambda app_id: app_id in cluster_fleet_apps
+                and cluster_fleet_apps[app_id]["planned_units"] > 0
             )
-            nodes = [node for node in nodes if has_planned_units(node)]
+            nodes = [node for node in nodes if has_planned_units(node.app.id)]
 
         return [
             node
@@ -764,14 +796,16 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
         if not self.charm.unit.is_leader():
             return
 
+        if not event.relation.units:  # ensure not a deferred event from a departed orchestrator
+            return
+
         # check if current cluster ready
         if not (deployment_desc := self.charm.opensearch_peer_cm.deployment_desc()):
             event.defer()
             return
 
         # register in the 'main/failover'-CMs the number of planned units of the current app
-        if event.relation.active:  # ensure not deferred event from departed orchestrator
-            self._put_current_app(event.relation.id, deployment_desc)
+        self._put_current_app(event.relation.id, deployment_desc)
 
         if not (data := event.relation.data.get(event.app)):
             return
@@ -816,6 +850,9 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
         # register main and failover cm app names if any
         self.charm.peers_data.put_object(Scope.APP, "orchestrators", orchestrators.to_dict())
 
+        # clear or set missing orchestrator status
+        self.apply_orchestrator_status()
+
         if data.security_index_initialised:
             self.charm.peers_data.put(Scope.APP, "security_index_initialised", True)
 
@@ -836,6 +873,23 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
 
         # recompute the deployment desc
         self.charm.opensearch_peer_cm.run_with_relation_data(data)
+
+    def apply_orchestrator_status(self) -> None:
+        """Sets or clears status based on presence of local orchestrators."""
+        deployment_desc = self.charm.opensearch_peer_cm.deployment_desc()
+        orchestrators = PeerClusterOrchestrators.from_dict(
+            self.charm.peers_data.get_object(Scope.APP, "orchestrators") or {}
+        )
+        if orchestrators.failover_app and orchestrators.failover_app.id == deployment_desc.app.id:
+            return
+
+        if orchestrators.main_app:
+            self.charm.status.clear(PClusterOrchestratorsRemoved, app=True)
+            self.charm.status.clear(PClusterWaitingForFailoverPromotion, app=True)
+        elif orchestrators.failover_app:
+            self.charm.status.set(WaitingStatus(PClusterWaitingForFailoverPromotion), app=True)
+        else:
+            self.charm.status.set(BlockedStatus(PClusterOrchestratorsRemoved), app=True)
 
     def _set_security_conf(self, data: PeerClusterRelData) -> None:
         """Store security related config."""
@@ -919,13 +973,13 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
         cm_relations = [
             rel.id
             for rel in self.model.relations[self.relation_name]
-            if rel.id != event.relation.id
+            if rel.id != event.relation.id and rel.units
         ]
         for rel_id in cm_relations:
             remote_orchestrators.update(self.get_obj_from_rel(key="orchestrators", rel_id=rel_id))
 
         local_orchestrators = self.charm.peers_data.get_object(Scope.APP, "orchestrators") or {}
-        if trigger in {"main", "failover"}:
+        if trigger in {"main", "failover"} and event.relation.units:
             local_orchestrators.update(
                 {
                     f"{trigger}_rel_id": event.relation.id,
@@ -951,20 +1005,27 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
             rel_id=orchestrators.main_rel_id,
         )
 
-    def refresh_relation_data(self) -> None:
+    def refresh_requirer_relation_data(self) -> None:
         """Refresh the peer cluster rel data (planned units)."""
+        if not self.charm.unit.is_leader():
+            return
+
         deployment_desc = self.charm.opensearch_peer_cm.deployment_desc()
-        for rel in self.model.relations[self.relation_name]:
+        all_relations = [rel for rel in self.model.relations[self.relation_name] if rel.units]
+        for rel in all_relations:
             self._put_current_app(rel.id, deployment_desc)
 
     def _put_current_app(self, rel_id: int, deployment_desc: DeploymentDescription) -> None:
         """Report the current app on the peer cluster rel data to be broadcast to all apps."""
+        planned_units = self.charm.app.planned_units()
         current_app = PeerClusterApp(
             app=deployment_desc.app,
-            planned_units=self.charm.app.planned_units(),
-            units=[
-                format_unit_name(unit, app=deployment_desc.app) for unit in all_units(self.charm)
-            ],
+            planned_units=planned_units,
+            units=(
+                [format_unit_name(u, app=deployment_desc.app) for u in all_units(self.charm)]
+                if planned_units > 0
+                else []
+            ),
             roles=deployment_desc.config.roles,
         )
         self.put_in_rel(data={"app": current_app.to_str()}, rel_id=rel_id)
@@ -972,7 +1033,6 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
         # update content of fleet in the current app's peer databag
         cluster_fleet_apps = self.get_obj_from_rel("cluster_fleet_apps", rel_id=rel_id)
         cluster_fleet_apps.update({deployment_desc.app.id: current_app.to_dict()})
-
         self.charm.peers_data.put_object(Scope.APP, "cluster_fleet_apps", cluster_fleet_apps)
 
     def _on_peer_cluster_relation_departed(self, event: RelationDepartedEvent):
@@ -1011,36 +1071,25 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
             "main" if event.relation.id == orchestrators.main_rel_id else "failover"
         )
 
-        # delete the orchestrator from cluster fleet apps
-        orchestrator_id = (
+        # delete the orchestrator that triggered this event
+        orchestrator_app_id = (
             orchestrators.main_app.id
             if event_src_cluster_type == "main"
             else orchestrators.failover_app.id
         )
         cluster_fleet_apps = self.charm.peers_data.get_object(Scope.APP, "cluster_fleet_apps")
-        cluster_fleet_apps.pop(orchestrator_id, None)
+        cluster_fleet_apps.pop(orchestrator_app_id, None)
         self.charm.peers_data.put_object(Scope.APP, "cluster_fleet_apps", cluster_fleet_apps)
 
-        # delete the orchestrator that triggered this event
         orchestrators.delete(event_src_cluster_type)
         self.charm.peers_data.put_object(Scope.APP, "orchestrators", orchestrators.to_dict())
-
-        # the 'main' cluster orchestrator is the one being removed
-        if (
-            event_src_cluster_type == "main"
-            and deployment_desc.typ != DeploymentType.FAILOVER_ORCHESTRATOR
-        ):
-            if not orchestrators.failover_app:
-                self.charm.status.set(BlockedStatus(PClusterOrchestratorsRemoved))
-            else:
-                # wait for failover promotion
-                self.charm.status.set(WaitingStatus(PClusterWaitingForFailoverPromotion))
-        elif event_src_cluster_type == "failover" and not orchestrators.main_app:
-            self.charm.status.set(BlockedStatus(PClusterOrchestratorsRemoved))
 
         # clear previously set errors due to this relation
         self._clear_errors(f"error_from_provider-{event.relation.id}")
         self._clear_errors(f"error_from_requirer-{event.relation.id}")
+
+        # clear or set missing orchestrator status
+        self.apply_orchestrator_status()
 
         # we leave in case not an orchestrator
         if (
@@ -1060,27 +1109,10 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
 
             rel_orchestrators.delete(event_src_cluster_type)
             self.put_in_rel(data={"orchestrators": rel_orchestrators.to_str()}, rel_id=rel_id)
-
-    def _promote_failover(self, orchestrators: PeerClusterOrchestrators, cms: List[Node]) -> None:
-        """Handle the departure of the main orchestrator."""
-        # current cluster is failover
-        self.charm.opensearch_peer_cm.promote_to_main_orchestrator()
-
-        # ensuring quorum
-        main_cms = [cm for cm in cms if cm.app.id == orchestrators.main_app.id]
-        non_main_cms = [cm for cm in cms if cm not in main_cms]
-        if len(non_main_cms) % 2 == 0:
-            departure_reason = relation_departure_reason(self.charm, self.relation_name)
-            message = "Scale-up this application by an odd number of units{} to ensure quorum."
-            if len(main_cms) % 2 == 1 and departure_reason == RelDepartureReason.REL_BROKEN:
-                message = message.format(
-                    f" and scale-'down/up' {orchestrators.main_app.name} by 1 unit"
-                )
-
-            self.charm.status.set(message)
-
-        # remove old main and promote new failover
-        orchestrators.promote_failover()
+            self.put_in_rel(
+                data={"cluster_fleet_apps": json.dumps(cluster_fleet_apps)},
+                rel_id=rel_id,
+            )
 
     def _cm_nodes(self, orchestrators: PeerClusterOrchestrators) -> List[Node]:
         """Fetch the cm nodes passed from the peer cluster relation not api call."""

--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -389,10 +389,11 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
             self.charm.peers_data.get_object(Scope.APP, "cluster_fleet_apps") or {}
         )
 
+        planned_units = self.charm.app.planned_units()
         current_app = PeerClusterApp(
             app=deployment_desc.app,
-            planned_units=self.charm.app.planned_units(),
-            units=[format_unit_name(u, app=deployment_desc.app) for u in all_units(self.charm)],
+            planned_units=planned_units,
+            units=[format_unit_name(u, app=deployment_desc.app) for u in all_units(self.charm)] if planned_units > 0 else [],
             roles=deployment_desc.config.roles,
         )
         cluster_fleet_apps.update({current_app.app.id: current_app.to_dict()})

--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -297,6 +297,8 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
         cluster_type = (
             "main" if deployment_desc.typ == DeploymentType.MAIN_ORCHESTRATOR else "failover"
         )
+        orchestrator_app_key = f"{cluster_type}_app"
+        orchestrator_rel_key = f"{cluster_type}_rel_id"
 
         # flag the trigger of the rel changed update on the consumer side
         if event_rel_id:
@@ -304,7 +306,13 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
 
         # update reported orchestrators on local orchestrator
         orchestrators = orchestrators.to_dict()
-        orchestrators[f"{cluster_type}_app"] = deployment_desc.app.to_dict()
+        planned_units = self.charm.app.planned_units()
+        if planned_units == 0:
+            # remove orchestrator if 0 planned units
+            orchestrators[orchestrator_app_key] = None
+            orchestrators[orchestrator_rel_key] = -1
+        else:
+            orchestrators[orchestrator_app_key] = deployment_desc.app.to_dict()
         self.charm.peers_data.put_object(Scope.APP, "orchestrators", orchestrators)
 
         should_defer = False
@@ -314,12 +322,14 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
         # save the orchestrators of this fleet
         for rel_id in all_relation_ids:
             orchestrators = self.get_obj_from_rel("orchestrators", rel_id=rel_id)
-            orchestrators.update(
-                {
-                    f"{cluster_type}_app": deployment_desc.app.to_dict(),
-                    f"{cluster_type}_rel_id": rel_id,
-                }
-            )
+            # remove orchestrator if 0 planned units
+            updated_orchestrator = {
+                orchestrator_app_key: (
+                    None if planned_units == 0 else deployment_desc.app.to_dict()
+                ),
+                orchestrator_rel_key: -1 if planned_units == 0 else rel_id,
+            }
+            orchestrators.update(updated_orchestrator)
             self.put_in_rel(data={"orchestrators": json.dumps(orchestrators)}, rel_id=rel_id)
 
             # there is no error to broadcast - we clear any previously broadcasted error
@@ -366,7 +376,7 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
         if not update_key:
             update_key = app.app.id
 
-        if app.planned_units == 0:  # app removal
+        if app.planned_units == 0:  # if 0 planned units, remove entry
             fleet_dict.pop(update_key, None)
         else:
             fleet_dict.update({update_key: app.to_dict()})
@@ -591,6 +601,10 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
 
     def _fetch_local_cm_nodes(self, deployment_desc: DeploymentDescription) -> List[Node]:
         """Fetch the cluster_manager eligible node IPs in the current cluster."""
+        # if 0 planned_units, return empty list
+        if self.charm.app.planned_units() == 0:
+            return []
+
         nodes = ClusterTopology.nodes(
             self._opensearch,
             use_localhost=self._opensearch.is_node_up(),

--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -395,8 +395,8 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
             units=[format_unit_name(u, app=deployment_desc.app) for u in all_units(self.charm)],
             roles=deployment_desc.config.roles,
         )
-
         cluster_fleet_apps.update({current_app.app.id: current_app.to_dict()})
+
         if p_cluster_app:
             cluster_fleet_apps.update({p_cluster_app.app.id: p_cluster_app.to_dict()})
 
@@ -769,9 +769,7 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
             return
 
         # register in the 'main/failover'-CMs the number of planned units of the current app
-        if (
-            event.relation.active
-        ):  # guard against updating a relation with an already departed orchestrator
+        if event.relation.active:  # ensure not deferred event from departed orchestrator
             self._put_current_app(event.relation.id, deployment_desc)
 
         if not (data := event.relation.data.get(event.app)):
@@ -1000,7 +998,9 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
 
         # handle scale-down at the charm level storage detaching, or??
         if (
-            relation_departure_reason(self.charm, self.relation_name, event.app.name)
+            relation_departure_reason(
+                self.charm, self.relation_name, event.app.name if event.app else ""
+            )
             == RelDepartureReason.SCALE_DOWN
         ):
             return

--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -786,7 +786,9 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
         if not self.charm.unit.is_leader():
             return
 
-        if not event.relation.units:  # ensure not a deferred event from a departed orchestrator
+        if (
+            len(event.relation.units) == 0
+        ):  # ensure not a deferred event from a departed orchestrator
             return
 
         # check if current cluster ready
@@ -966,13 +968,13 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
         cm_relations = [
             rel.id
             for rel in self.model.relations[self.relation_name]
-            if rel.id != event.relation.id and rel.units
+            if rel.id != event.relation.id and len(rel.units) > 0
         ]
         for rel_id in cm_relations:
             remote_orchestrators.update(self.get_obj_from_rel(key="orchestrators", rel_id=rel_id))
 
         local_orchestrators = self.charm.peers_data.get_object(Scope.APP, "orchestrators") or {}
-        if trigger in {"main", "failover"} and event.relation.units:
+        if trigger in {"main", "failover"} and len(event.relation.units) > 0:
             local_orchestrators.update(
                 {
                     f"{trigger}_rel_id": event.relation.id,
@@ -1004,7 +1006,9 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
             return
 
         deployment_desc = self.charm.opensearch_peer_cm.deployment_desc()
-        all_relations = [rel for rel in self.model.relations[self.relation_name] if rel.units]
+        all_relations = [
+            rel for rel in self.model.relations[self.relation_name] if len(rel.units) > 0
+        ]
         for rel in all_relations:
             self._put_current_app(rel.id, deployment_desc)
 

--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -355,7 +355,7 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
             event.defer()
 
     def _delete_rel_data_on_error(self, rel_id: int) -> None:
-        """Deletes relation data when an error is about to be broadcasted"""
+        """Deletes relation data when an error is broadcasted"""
         self.delete_from_rel("cluster_fleet_apps", rel_id=rel_id)
         self.delete_from_rel("data", rel_id=rel_id)
         self.delete_from_rel("rel_data_hash", rel_id=rel_id)

--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -14,6 +14,8 @@ from charms.opensearch.v0.constants_charm import (
     AdminUser,
     COSUser,
     KibanaserverUser,
+    PClusterOrchestratorsRemoved,
+    PClusterWaitingForFailoverPromotion,
     PeerClusterOrchestratorRelationName,
     PeerClusterRelationName,
 )
@@ -357,6 +359,18 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
 
         return True
 
+    def _update_fleet_dict(
+        self, fleet_dict: dict, app: PeerClusterApp, update_key: Optional[str] = None
+    ) -> None:
+        """Updates or removes app in the provided fleet dictionary."""
+        if not update_key:
+            update_key = app.app.id
+
+        if app.planned_units == 0:  # app removal
+            fleet_dict.pop(update_key, None)
+        else:
+            fleet_dict.update({update_key: app.to_dict()})
+
     def _put_fleet_apps(
         self,
         deployment_desc: DeploymentDescription,
@@ -375,10 +389,10 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
             units=[format_unit_name(u, app=deployment_desc.app) for u in all_units(self.charm)],
             roles=deployment_desc.config.roles,
         )
-        cluster_fleet_apps.update({current_app.app.id: current_app.to_dict()})
 
+        self._update_fleet_dict(cluster_fleet_apps, current_app)
         if p_cluster_app:
-            cluster_fleet_apps.update({p_cluster_app.app.id: p_cluster_app.to_dict()})
+            self._update_fleet_dict(cluster_fleet_apps, p_cluster_app)
 
         for rel_id in target_relation_ids:
             self.put_in_rel(
@@ -393,8 +407,7 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
             cluster_fleet_apps_rels = (
                 self.charm.peers_data.get_object(Scope.APP, "cluster_fleet_apps_rels") or {}
             )
-            cluster_fleet_apps_rels.update({str(trigger_rel_id): p_cluster_app.to_dict()})
-
+            self._update_fleet_dict(cluster_fleet_apps_rels, p_cluster_app, str(trigger_rel_id))
             self.charm.peers_data.put_object(
                 Scope.APP, "cluster_fleet_apps_rels", cluster_fleet_apps_rels
             )
@@ -927,6 +940,10 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
         self, event: RelationEvent, deployment_desc: DeploymentDescription
     ) -> None:
         """Report the current app on the peer cluster rel data to be broadcast to all apps."""
+        # this guards against a deferred event from an already departed orchestrator
+        if not event.relation.app:
+            return
+
         current_app = PeerClusterApp(
             app=deployment_desc.app,
             planned_units=self.charm.app.planned_units(),
@@ -967,36 +984,42 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
 
         # handle scale-down at the charm level storage detaching, or??
         if (
-            relation_departure_reason(self.charm, self.relation_name)
+            relation_departure_reason(self.charm, self.relation_name, event.app.name)
             == RelDepartureReason.SCALE_DOWN
         ):
             return
-
-        # fetch cluster manager nodes from API + across all peer clusters
-        cms = self._cm_nodes(orchestrators)
 
         # check the departed cluster which triggered this hook
         event_src_cluster_type = (
             "main" if event.relation.id == orchestrators.main_rel_id else "failover"
         )
 
+        # delete the orchestrator from cluster fleet apps
+        orchestrator_id = (
+            orchestrators.main_app.id
+            if event_src_cluster_type == "main"
+            else orchestrators.failover_app.id
+        )
+        cluster_fleet_apps = self.charm.peers_data.get_object(Scope.APP, "cluster_fleet_apps")
+        cluster_fleet_apps.pop(orchestrator_id, None)
+        self.charm.peers_data.put_object(Scope.APP, "cluster_fleet_apps", cluster_fleet_apps)
+
         # delete the orchestrator that triggered this event
         orchestrators.delete(event_src_cluster_type)
+        self.charm.peers_data.put_object(Scope.APP, "orchestrators", orchestrators.to_dict())
 
         # the 'main' cluster orchestrator is the one being removed
-        failover_promoted = False
-        if event_src_cluster_type == "main":
+        if (
+            event_src_cluster_type == "main"
+            and deployment_desc.typ != DeploymentType.FAILOVER_ORCHESTRATOR
+        ):
             if not orchestrators.failover_app:
-                self.charm.status.set(
-                    BlockedStatus(
-                        "Main-cluster-orchestrator removed, and no failover cluster related."
-                    )
-                )
-            elif orchestrators.failover_app.id == deployment_desc.app.id:
-                self._promote_failover(orchestrators, cms)
-                failover_promoted = True
-
-        self.charm.peers_data.put_object(Scope.APP, "orchestrators", orchestrators.to_dict())
+                self.charm.status.set(BlockedStatus(PClusterOrchestratorsRemoved))
+            else:
+                # wait for failover promotion
+                self.charm.status.set(WaitingStatus(PClusterWaitingForFailoverPromotion))
+        elif event_src_cluster_type == "failover" and not orchestrators.main_app:
+            self.charm.status.set(BlockedStatus(PClusterOrchestratorsRemoved))
 
         # clear previously set errors due to this relation
         self._clear_errors(f"error_from_provider-{event.relation.id}")
@@ -1006,7 +1029,7 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
         if (
             self.charm.opensearch_peer_cm.deployment_desc().typ == DeploymentType.OTHER
             or deployment_desc.app.id
-            not in [orchestrators.main_app.id, orchestrators.failover_app.id]
+            not in [app.id for app in (orchestrators.main_app, orchestrators.failover_app) if app]
         ):
             return
 
@@ -1019,9 +1042,6 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
             )
 
             rel_orchestrators.delete(event_src_cluster_type)
-            if failover_promoted:
-                rel_orchestrators.promote_failover()
-
             self.put_in_rel(data={"orchestrators": rel_orchestrators.to_str()}, rel_id=rel_id)
 
     def _promote_failover(self, orchestrators: PeerClusterOrchestrators, cms: List[Node]) -> None:

--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -304,15 +304,7 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
 
         # update reported orchestrators on local orchestrator
         orchestrators = orchestrators.to_dict()
-        orchestrator_app_key = f"{cluster_type}_app"
-        orchestrator_rel_key = f"{cluster_type}_rel_id"
-        planned_units = self.charm.app.planned_units()
-        if planned_units == 0:
-            # remove orchestrator if units scaled down to 0
-            orchestrators[orchestrator_app_key] = None
-            orchestrators[orchestrator_rel_key] = -1
-        else:
-            orchestrators[orchestrator_app_key] = deployment_desc.app.to_dict()
+        orchestrators[f"{cluster_type}_app"] = deployment_desc.app.to_dict()
         self.charm.peers_data.put_object(Scope.APP, "orchestrators", orchestrators)
 
         should_defer = False
@@ -325,10 +317,8 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
             # remove orchestrator if units scaled down to 0
             orchestrators.update(
                 {
-                    orchestrator_app_key: (
-                        None if planned_units == 0 else deployment_desc.app.to_dict()
-                    ),
-                    orchestrator_rel_key: -1 if planned_units == 0 else rel_id,
+                    f"{cluster_type}_app": deployment_desc.app.to_dict(),
+                    f"{cluster_type}_rel_id": rel_id,
                 }
             )
             self.put_in_rel(data={"orchestrators": json.dumps(orchestrators)}, rel_id=rel_id)

--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -755,8 +755,9 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
             event.defer()
             return
 
-        # register in the 'main/failover'-CMs / save the number of planned units of the current app
-        self._put_current_app(event, deployment_desc)
+        if event.relation.app:
+            # register in the 'main/failover'-CMs the number of planned units of the current app
+            self._put_current_app(event.relation.id, deployment_desc)
 
         if not (data := event.relation.data.get(event.app)):
             return
@@ -936,14 +937,14 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
             rel_id=orchestrators.main_rel_id,
         )
 
-    def _put_current_app(
-        self, event: RelationEvent, deployment_desc: DeploymentDescription
-    ) -> None:
-        """Report the current app on the peer cluster rel data to be broadcast to all apps."""
-        # this guards against a deferred event from an already departed orchestrator
-        if not event.relation.app:
-            return
+    def refresh_relation_data(self) -> None:
+        """Refresh the peer cluster rel data (planned units)."""
+        deployment_desc = self.charm.opensearch_peer_cm.deployment_desc()
+        for rel in self.model.relations[self.relation_name]:
+            self._put_current_app(rel.id, deployment_desc)
 
+    def _put_current_app(self, rel_id: int, deployment_desc: DeploymentDescription) -> None:
+        """Report the current app on the peer cluster rel data to be broadcast to all apps."""
         current_app = PeerClusterApp(
             app=deployment_desc.app,
             planned_units=self.charm.app.planned_units(),
@@ -952,10 +953,10 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
             ],
             roles=deployment_desc.config.roles,
         )
-        self.put_in_rel(data={"app": current_app.to_str()}, rel_id=event.relation.id)
+        self.put_in_rel(data={"app": current_app.to_str()}, rel_id=rel_id)
 
         # update content of fleet in the current app's peer databag
-        cluster_fleet_apps = self.get_obj_from_rel("cluster_fleet_apps", rel_id=event.relation.id)
+        cluster_fleet_apps = self.get_obj_from_rel("cluster_fleet_apps", rel_id=rel_id)
         cluster_fleet_apps.update({deployment_desc.app.id: current_app.to_dict()})
 
         self.charm.peers_data.put_object(Scope.APP, "cluster_fleet_apps", cluster_fleet_apps)

--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -314,7 +314,6 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
         # save the orchestrators of this fleet
         for rel_id in all_relation_ids:
             orchestrators = self.get_obj_from_rel("orchestrators", rel_id=rel_id)
-            # remove orchestrator if units scaled down to 0
             orchestrators.update(
                 {
                     f"{cluster_type}_app": deployment_desc.app.to_dict(),
@@ -409,6 +408,7 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
                 self.charm.peers_data.get_object(Scope.APP, "cluster_fleet_apps_rels") or {}
             )
             cluster_fleet_apps_rels.update({str(trigger_rel_id): p_cluster_app.to_dict()})
+
             self.charm.peers_data.put_object(
                 Scope.APP, "cluster_fleet_apps_rels", cluster_fleet_apps_rels
             )

--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -876,6 +876,9 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
 
     def apply_orchestrator_status(self) -> None:
         """Sets or clears status based on presence of local orchestrators."""
+        if not self.charm.unit.is_leader():
+            return
+
         deployment_desc = self.charm.opensearch_peer_cm.deployment_desc()
         orchestrators = PeerClusterOrchestrators.from_dict(
             self.charm.peers_data.get_object(Scope.APP, "orchestrators") or {}

--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -393,7 +393,11 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
         current_app = PeerClusterApp(
             app=deployment_desc.app,
             planned_units=planned_units,
-            units=[format_unit_name(u, app=deployment_desc.app) for u in all_units(self.charm)] if planned_units > 0 else [],
+            units=(
+                [format_unit_name(u, app=deployment_desc.app) for u in all_units(self.charm)]
+                if planned_units > 0
+                else []
+            ),
             roles=deployment_desc.config.roles,
         )
         cluster_fleet_apps.update({current_app.app.id: current_app.to_dict()})

--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -385,8 +385,8 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
         self.delete_from_rel("data", rel_id=rel_id)
         self.delete_from_rel("rel_data_hash", rel_id=rel_id)
 
-    def _update_or_pop_from_fleet_dict(
-        self, fleet_dict: dict, app: PeerClusterApp, key: Optional[str] = None
+    def _update_fleet(
+        self, fleet_dict: dict[str, dict[str, Any]], app: PeerClusterApp, key: Optional[str] = None
     ) -> None:
         """Update fleet dictionary with the app, or remove the entry if no planned units."""
         if not key:
@@ -416,10 +416,10 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
             units=[format_unit_name(u, app=deployment_desc.app) for u in all_units(self.charm)],
             roles=deployment_desc.config.roles,
         )
-        self._update_or_pop_from_fleet_dict(cluster_fleet_apps, current_app)
+        self._update_fleet(cluster_fleet_apps, current_app)
 
         if p_cluster_app:
-            self._update_or_pop_from_fleet_dict(cluster_fleet_apps, p_cluster_app)
+            self._update_fleet(cluster_fleet_apps, p_cluster_app)
 
         for rel_id in target_relation_ids:
             self.put_in_rel(
@@ -434,9 +434,7 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
             cluster_fleet_apps_rels = (
                 self.charm.peers_data.get_object(Scope.APP, "cluster_fleet_apps_rels") or {}
             )
-            self._update_or_pop_from_fleet_dict(
-                cluster_fleet_apps_rels, p_cluster_app, key=str(trigger_rel_id)
-            )
+            self._update_fleet(cluster_fleet_apps_rels, p_cluster_app, key=str(trigger_rel_id))
 
             self.charm.peers_data.put_object(
                 Scope.APP, "cluster_fleet_apps_rels", cluster_fleet_apps_rels

--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -303,8 +303,13 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
             self.put_in_rel({"trigger": cluster_type}, rel_id=event_rel_id)
 
         # update reported orchestrators on local orchestrator
+        has_units = self.charm.app.planned_units() > 0
         orchestrators = orchestrators.to_dict()
-        orchestrators[f"{cluster_type}_app"] = deployment_desc.app.to_dict()
+        if has_units:
+            orchestrators[f"{cluster_type}_app"] = deployment_desc.app.to_dict()
+        else:
+            orchestrators[f"{cluster_type}_app"] = None
+            orchestrators[f"{cluster_type}_rel_id"] = -1
         self.charm.peers_data.put_object(Scope.APP, "orchestrators", orchestrators)
 
         should_defer = False
@@ -314,10 +319,11 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
         # save the orchestrators of this fleet
         for rel_id in all_relation_ids:
             orchestrators = self.get_obj_from_rel("orchestrators", rel_id=rel_id)
+            # remove orchestrator if units scaled down to 0
             orchestrators.update(
                 {
-                    f"{cluster_type}_app": deployment_desc.app.to_dict(),
-                    f"{cluster_type}_rel_id": rel_id,
+                    f"{cluster_type}_app": deployment_desc.app.to_dict() if has_units else None,
+                    f"{cluster_type}_rel_id": rel_id if has_units else -1,
                 }
             )
             self.put_in_rel(data={"orchestrators": json.dumps(orchestrators)}, rel_id=rel_id)

--- a/tests/integration/ha/test_large_deployments_relations.py
+++ b/tests/integration/ha/test_large_deployments_relations.py
@@ -7,7 +7,12 @@ import logging
 import time
 
 import pytest
-from charms.opensearch.v0.constants_charm import PClusterNoRelation, TLSRelationMissing
+from charms.opensearch.v0.constants_charm import (
+    PClusterNoRelation,
+    PClusterOrchestratorsRemoved,
+    PClusterWaitingForFailoverPromotion,
+    TLSRelationMissing,
+)
 from pytest_operator.plugin import OpsTest
 
 from ..helpers import CONFIG_OPTS, MODEL_CONFIG, SERIES, get_leader_unit_ip
@@ -246,3 +251,102 @@ async def test_large_deployment_fully_formed(
             assert (
                 temperature == "hot"
             ), f"Wrong temperature for {app}:{temperature} - expected:hot"
+
+
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "xlarge"])
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_large_deployment_sever_main_failover_relation(ops_test: OpsTest) -> None:
+    """Test that the main-failover relation can be removed and re-added."""
+    await ops_test.model.applications[MAIN_APP].remove_relation(
+        f"{FAILOVER_APP}:{REL_PEER}", f"{MAIN_APP}:{REL_ORCHESTRATOR}"
+    )
+
+    await wait_until(
+        ops_test,
+        apps=[MAIN_APP, FAILOVER_APP, DATA_APP],
+        apps_statuses=["active"],
+        units_statuses=["active"],
+        wait_for_exact_units={
+            app: units for app, units in APP_UNITS.items() if app != INVALID_APP
+        },
+        idle_period=IDLE_PERIOD,
+        timeout=1800,
+    )
+    # re-relate main and failover
+    await ops_test.model.integrate(f"{FAILOVER_APP}:{REL_PEER}", f"{MAIN_APP}:{REL_ORCHESTRATOR}")
+
+    await wait_until(
+        ops_test,
+        apps=[MAIN_APP, FAILOVER_APP, DATA_APP],
+        apps_statuses=["active"],
+        units_statuses=["active"],
+        wait_for_exact_units={
+            app: units for app, units in APP_UNITS.items() if app != INVALID_APP
+        },
+        idle_period=IDLE_PERIOD,
+        timeout=1800,
+    )
+
+
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "xlarge"])
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_large_deployment_remove_app(ops_test: OpsTest) -> None:
+    """Test that the orchestrator apps can be deleted."""
+    # delete the main orchestrator
+    await ops_test.model.remove_application(
+        MAIN_APP,
+        block_until_done=True,
+        destroy_storage=True,
+    )
+
+    await wait_until(
+        ops_test,
+        apps=[FAILOVER_APP, DATA_APP],
+        units_full_statuses={
+            DATA_APP: {
+                "units": {
+                    "waiting": [PClusterWaitingForFailoverPromotion],
+                    "active": [],
+                },
+            },
+            FAILOVER_APP: {
+                "units": {
+                    "active": [],
+                },
+            },
+        },
+        apps_statuses=["active"],
+        wait_for_exact_units={
+            DATA_APP: APP_UNITS[DATA_APP],
+            FAILOVER_APP: APP_UNITS[FAILOVER_APP],
+        },
+        idle_period=IDLE_PERIOD,
+        timeout=1800,
+    )
+
+    # delete the failover orchestrator
+    await ops_test.model.remove_application(
+        FAILOVER_APP,
+        block_until_done=True,
+        destroy_storage=True,
+    )
+    await wait_until(
+        ops_test,
+        apps=[DATA_APP],
+        units_full_statuses={
+            DATA_APP: {
+                "units": {
+                    "blocked": [PClusterOrchestratorsRemoved],
+                    "active": [],
+                },
+            },
+        },
+        apps_statuses=["active"],
+        wait_for_exact_units={
+            DATA_APP: APP_UNITS[DATA_APP],
+        },
+        idle_period=IDLE_PERIOD,
+        timeout=1800,
+    )

--- a/tests/integration/ha/test_large_deployments_relations.py
+++ b/tests/integration/ha/test_large_deployments_relations.py
@@ -7,12 +7,7 @@ import logging
 import time
 
 import pytest
-from charms.opensearch.v0.constants_charm import (
-    PClusterNoRelation,
-    PClusterOrchestratorsRemoved,
-    PClusterWaitingForFailoverPromotion,
-    TLSRelationMissing,
-)
+from charms.opensearch.v0.constants_charm import PClusterNoRelation, TLSRelationMissing
 from pytest_operator.plugin import OpsTest
 
 from ..helpers import CONFIG_OPTS, MODEL_CONFIG, SERIES, get_leader_unit_ip
@@ -251,102 +246,3 @@ async def test_large_deployment_fully_formed(
             assert (
                 temperature == "hot"
             ), f"Wrong temperature for {app}:{temperature} - expected:hot"
-
-
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "xlarge"])
-@pytest.mark.group(1)
-@pytest.mark.abort_on_fail
-async def test_large_deployment_sever_main_failover_relation(ops_test: OpsTest) -> None:
-    """Test that the main-failover relation can be removed and re-added."""
-    await ops_test.model.applications[MAIN_APP].remove_relation(
-        f"{FAILOVER_APP}:{REL_PEER}", f"{MAIN_APP}:{REL_ORCHESTRATOR}"
-    )
-
-    await wait_until(
-        ops_test,
-        apps=[MAIN_APP, FAILOVER_APP, DATA_APP],
-        apps_statuses=["active"],
-        units_statuses=["active"],
-        wait_for_exact_units={
-            app: units for app, units in APP_UNITS.items() if app != INVALID_APP
-        },
-        idle_period=IDLE_PERIOD,
-        timeout=1800,
-    )
-    # re-relate main and failover
-    await ops_test.model.integrate(f"{FAILOVER_APP}:{REL_PEER}", f"{MAIN_APP}:{REL_ORCHESTRATOR}")
-
-    await wait_until(
-        ops_test,
-        apps=[MAIN_APP, FAILOVER_APP, DATA_APP],
-        apps_statuses=["active"],
-        units_statuses=["active"],
-        wait_for_exact_units={
-            app: units for app, units in APP_UNITS.items() if app != INVALID_APP
-        },
-        idle_period=IDLE_PERIOD,
-        timeout=1800,
-    )
-
-
-@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "xlarge"])
-@pytest.mark.group(1)
-@pytest.mark.abort_on_fail
-async def test_large_deployment_remove_app(ops_test: OpsTest) -> None:
-    """Test that the orchestrator apps can be deleted."""
-    # delete the main orchestrator
-    await ops_test.model.remove_application(
-        MAIN_APP,
-        block_until_done=True,
-        destroy_storage=True,
-    )
-
-    await wait_until(
-        ops_test,
-        apps=[FAILOVER_APP, DATA_APP],
-        units_full_statuses={
-            DATA_APP: {
-                "units": {
-                    "waiting": [PClusterWaitingForFailoverPromotion],
-                    "active": [],
-                },
-            },
-            FAILOVER_APP: {
-                "units": {
-                    "active": [],
-                },
-            },
-        },
-        apps_statuses=["active"],
-        wait_for_exact_units={
-            DATA_APP: APP_UNITS[DATA_APP],
-            FAILOVER_APP: APP_UNITS[FAILOVER_APP],
-        },
-        idle_period=IDLE_PERIOD,
-        timeout=1800,
-    )
-
-    # delete the failover orchestrator
-    await ops_test.model.remove_application(
-        FAILOVER_APP,
-        block_until_done=True,
-        destroy_storage=True,
-    )
-    await wait_until(
-        ops_test,
-        apps=[DATA_APP],
-        units_full_statuses={
-            DATA_APP: {
-                "units": {
-                    "blocked": [PClusterOrchestratorsRemoved],
-                    "active": [],
-                },
-            },
-        },
-        apps_statuses=["active"],
-        wait_for_exact_units={
-            DATA_APP: APP_UNITS[DATA_APP],
-        },
-        idle_period=IDLE_PERIOD,
-        timeout=1800,
-    )

--- a/tests/integration/ha/test_large_deployments_remove_orchestrators.py
+++ b/tests/integration/ha/test_large_deployments_remove_orchestrators.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+
+import pytest
+from charms.opensearch.v0.constants_charm import (
+    PClusterOrchestratorsRemoved,
+    PClusterWaitingForFailoverPromotion,
+)
+from pytest_operator.plugin import OpsTest
+
+from ..helpers import CONFIG_OPTS, MODEL_CONFIG, SERIES
+from ..helpers_deployments import wait_until
+from ..tls.test_tls import TLS_CERTIFICATES_APP_NAME, TLS_STABLE_CHANNEL
+from .test_horizontal_scaling import IDLE_PERIOD
+
+logger = logging.getLogger(__name__)
+
+REL_ORCHESTRATOR = "peer-cluster-orchestrator"
+REL_PEER = "peer-cluster"
+
+MAIN_APP = "opensearch-main"
+FAILOVER_APP = "opensearch-failover"
+DATA_APP = "opensearch-data"
+
+CLUSTER_NAME = "app"
+
+APP_UNITS = {MAIN_APP: 1, FAILOVER_APP: 2, DATA_APP: 1}
+
+
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "xlarge"])
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+@pytest.mark.skip_if_deployed
+async def test_build_and_deploy(ops_test: OpsTest) -> None:
+    """Build and deploy one unit of OpenSearch."""
+    my_charm = await ops_test.build_charm(".")
+    await ops_test.model.set_config(MODEL_CONFIG)
+
+    # Deploy TLS Certificates operator.
+    config = {"ca-common-name": "CN_CA"}
+    await asyncio.gather(
+        ops_test.model.deploy(
+            TLS_CERTIFICATES_APP_NAME, channel=TLS_STABLE_CHANNEL, config=config
+        ),
+        ops_test.model.deploy(
+            my_charm,
+            application_name=MAIN_APP,
+            num_units=APP_UNITS[MAIN_APP],
+            series=SERIES,
+            config={"cluster_name": CLUSTER_NAME} | CONFIG_OPTS,
+        ),
+        ops_test.model.deploy(
+            my_charm,
+            application_name=FAILOVER_APP,
+            num_units=APP_UNITS[FAILOVER_APP],
+            series=SERIES,
+            config={"cluster_name": CLUSTER_NAME, "init_hold": True} | CONFIG_OPTS,
+        ),
+        ops_test.model.deploy(
+            my_charm,
+            application_name=DATA_APP,
+            num_units=APP_UNITS[DATA_APP],
+            series=SERIES,
+            config={"cluster_name": CLUSTER_NAME, "init_hold": True, "roles": "data.hot,ml"}
+            | CONFIG_OPTS,
+        ),
+    )
+    await wait_until(
+        ops_test,
+        apps=[TLS_CERTIFICATES_APP_NAME],
+        apps_statuses=["active"],
+        units_statuses=["active"],
+        wait_for_exact_units={TLS_CERTIFICATES_APP_NAME: 1},
+        idle_period=IDLE_PERIOD,
+    )
+
+    # integrate TLS to all applications
+    for app in [MAIN_APP, FAILOVER_APP, DATA_APP]:
+        await ops_test.model.integrate(app, TLS_CERTIFICATES_APP_NAME)
+
+    await ops_test.model.integrate(f"{FAILOVER_APP}:{REL_PEER}", f"{MAIN_APP}:{REL_ORCHESTRATOR}")
+    await ops_test.model.integrate(f"{DATA_APP}:{REL_PEER}", f"{MAIN_APP}:{REL_ORCHESTRATOR}")
+    await ops_test.model.integrate(f"{DATA_APP}:{REL_PEER}", f"{FAILOVER_APP}:{REL_ORCHESTRATOR}")
+    await wait_until(
+        ops_test,
+        apps=[MAIN_APP, FAILOVER_APP, DATA_APP],
+        apps_statuses=["active"],
+        units_statuses=["active"],
+        wait_for_exact_units={app: units for app, units in APP_UNITS.items()},
+        idle_period=IDLE_PERIOD,
+        timeout=1800,
+    )
+
+
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "xlarge"])
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_large_deployment_sever_main_failover_relation(ops_test: OpsTest) -> None:
+    """Test that the main-failover relation can be removed and re-added."""
+    await ops_test.model.applications[MAIN_APP].remove_relation(
+        f"{FAILOVER_APP}:{REL_PEER}", f"{MAIN_APP}:{REL_ORCHESTRATOR}"
+    )
+    await wait_until(
+        ops_test,
+        apps=[MAIN_APP, FAILOVER_APP, DATA_APP],
+        apps_statuses=["active"],
+        units_statuses=["active"],
+        wait_for_exact_units={app: units for app, units in APP_UNITS.items()},
+        idle_period=IDLE_PERIOD,
+        timeout=1800,
+    )
+    # re-relate main and failover
+    await ops_test.model.integrate(f"{FAILOVER_APP}:{REL_PEER}", f"{MAIN_APP}:{REL_ORCHESTRATOR}")
+    await wait_until(
+        ops_test,
+        apps=[MAIN_APP, FAILOVER_APP, DATA_APP],
+        apps_statuses=["active"],
+        units_statuses=["active"],
+        wait_for_exact_units={app: units for app, units in APP_UNITS.items()},
+        idle_period=IDLE_PERIOD,
+        timeout=1800,
+    )
+
+
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "xlarge"])
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_large_deployment_remove_app(ops_test: OpsTest) -> None:
+    """Test that the orchestrator apps can be deleted."""
+    # delete the main orchestrator
+    await ops_test.model.remove_application(
+        MAIN_APP,
+        block_until_done=True,
+        destroy_storage=True,
+    )
+    await wait_until(
+        ops_test,
+        apps=[FAILOVER_APP, DATA_APP],
+        apps_full_statuses={
+            FAILOVER_APP: {"active": []},
+            DATA_APP: {"waiting": [PClusterWaitingForFailoverPromotion]},
+        },
+        units_statuses=["active"],
+        wait_for_exact_units={
+            DATA_APP: APP_UNITS[DATA_APP],
+            FAILOVER_APP: APP_UNITS[FAILOVER_APP],
+        },
+        idle_period=IDLE_PERIOD,
+        timeout=1800,
+    )
+
+    # delete the failover orchestrator
+    await ops_test.model.remove_application(
+        FAILOVER_APP,
+    )
+    await wait_until(
+        ops_test,
+        apps=[DATA_APP],
+        apps_full_statuses={
+            DATA_APP: {"blocked": [PClusterOrchestratorsRemoved]},
+        },
+        units_statuses=["active"],
+        wait_for_exact_units={
+            DATA_APP: APP_UNITS[DATA_APP],
+        },
+        idle_period=IDLE_PERIOD,
+        timeout=1800,
+    )

--- a/tests/integration/ha/test_large_deployments_remove_orchestrators.py
+++ b/tests/integration/ha/test_large_deployments_remove_orchestrators.py
@@ -129,7 +129,7 @@ async def test_large_deployment_sever_main_failover_relation(ops_test: OpsTest) 
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "xlarge"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
-async def test_large_deployment_remove_app(ops_test: OpsTest) -> None:
+async def test_large_deployment_remove_orchestrators(ops_test: OpsTest) -> None:
     """Test that the orchestrator apps can be deleted."""
     # delete the main orchestrator
     await ops_test.model.remove_application(

--- a/tests/integration/ha/test_large_deployments_validate_cm_count.py
+++ b/tests/integration/ha/test_large_deployments_validate_cm_count.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+
+import pytest
+from charms.opensearch.v0.constants_charm import PClusterWrongNodesCountForQuorum
+from pytest_operator.plugin import OpsTest
+
+from ..helpers import CONFIG_OPTS, MODEL_CONFIG, SERIES
+from ..helpers_deployments import wait_until
+from ..tls.test_tls import TLS_CERTIFICATES_APP_NAME, TLS_STABLE_CHANNEL
+from .test_horizontal_scaling import IDLE_PERIOD
+
+logger = logging.getLogger(__name__)
+
+REL_ORCHESTRATOR = "peer-cluster-orchestrator"
+REL_PEER = "peer-cluster"
+
+MAIN_APP = "opensearch-main"
+DATA_APP = "opensearch-data"
+
+CLUSTER_NAME = "log-app"
+
+APP_UNITS = {MAIN_APP: 2, DATA_APP: 1}
+
+
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "xlarge"])
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+@pytest.mark.skip_if_deployed
+async def test_build_and_deploy(ops_test: OpsTest) -> None:
+    """Build and deploy one unit of OpenSearch."""
+    # it is possible for users to provide their own cluster for HA testing.
+    # Hence, check if there is a pre-existing cluster.
+    my_charm = await ops_test.build_charm(".")
+    await ops_test.model.set_config(MODEL_CONFIG)
+
+    # Deploy TLS Certificates operator.
+    config = {"ca-common-name": "CN_CA"}
+    await asyncio.gather(
+        ops_test.model.deploy(
+            TLS_CERTIFICATES_APP_NAME, channel=TLS_STABLE_CHANNEL, config=config
+        ),
+        ops_test.model.deploy(
+            my_charm,
+            application_name=MAIN_APP,
+            num_units=APP_UNITS[MAIN_APP],
+            series=SERIES,
+            config={"cluster_name": CLUSTER_NAME} | CONFIG_OPTS,
+        ),
+        ops_test.model.deploy(
+            my_charm,
+            application_name=DATA_APP,
+            num_units=APP_UNITS[DATA_APP],
+            series=SERIES,
+            config={"cluster_name": CLUSTER_NAME, "init_hold": True, "roles": "data.hot,ml"}
+            | CONFIG_OPTS,
+        ),
+    )
+
+    # wait until the TLS operator is ready
+    await wait_until(
+        ops_test,
+        apps=[TLS_CERTIFICATES_APP_NAME],
+        apps_statuses=["active"],
+        units_statuses=["active"],
+        wait_for_exact_units={TLS_CERTIFICATES_APP_NAME: 1},
+        idle_period=IDLE_PERIOD,
+    )
+
+    # integrate TLS to all applications
+    for app in [MAIN_APP, DATA_APP]:
+        await ops_test.model.integrate(app, TLS_CERTIFICATES_APP_NAME)
+
+    await ops_test.model.integrate(f"{DATA_APP}:{REL_PEER}", f"{MAIN_APP}:{REL_ORCHESTRATOR}")
+
+    await wait_until(
+        ops_test,
+        apps=[MAIN_APP, DATA_APP],
+        apps_full_statuses={
+            MAIN_APP: {"active": []},
+            DATA_APP: {"active": []},
+        },
+        units_statuses=["active"],
+        wait_for_exact_units={app: units for app, units in APP_UNITS.items()},
+        idle_period=IDLE_PERIOD,
+        timeout=1800,
+    )
+
+
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "xlarge"])
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_large_deployment_validate_cm_count(ops_test: OpsTest) -> None:
+    """Test that scaling down to less than 3 cms triggers a status change"""
+    # scale main down to 1 units
+    main_app = ops_test.model.applications[MAIN_APP]
+    await main_app.destroy_units(main_app.units[-1].name)
+
+    await wait_until(
+        ops_test,
+        apps=[MAIN_APP, DATA_APP],
+        apps_full_statuses={
+            DATA_APP: {"active": []},
+            MAIN_APP: {"blocked": [PClusterWrongNodesCountForQuorum]},
+        },
+        units_statuses=["active"],
+        wait_for_exact_units={
+            MAIN_APP: 1,
+            DATA_APP: APP_UNITS[DATA_APP],
+        },
+        idle_period=IDLE_PERIOD,
+        timeout=1800,
+    )
+
+    # check that the status is cleared on scale up to >= 3 cms
+    await ops_test.model.applications[MAIN_APP].add_units(2)
+    await wait_until(
+        ops_test,
+        apps=[MAIN_APP, DATA_APP],
+        apps_statuses=["active"],
+        units_statuses=["active"],
+        wait_for_exact_units={
+            MAIN_APP: 3,
+            DATA_APP: APP_UNITS[DATA_APP],
+        },
+        idle_period=IDLE_PERIOD,
+        timeout=1800,
+    )

--- a/tests/integration/ha/test_roles_managements.py
+++ b/tests/integration/ha/test_roles_managements.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 
 import pytest
+from charms.opensearch.v0.constants_charm import PClusterWrongNodesCountForQuorum
 from pytest_operator.plugin import OpsTest
 
 from ..helpers import (
@@ -15,6 +16,7 @@ from ..helpers import (
     SERIES,
     check_cluster_formation_successful,
     cluster_health,
+    get_application_unit_ids,
     get_application_unit_names,
     get_leader_unit_ip,
 )
@@ -110,6 +112,30 @@ async def test_set_roles_manually(
     for node in nodes:
         assert sorted(node.roles) == ["cluster_manager", "data"], "roles unchanged"
         assert node.temperature == "cold", "Temperature unchanged."
+
+    # scale up cluster by 1 unit, this should give the new node the same roles
+    await ops_test.model.applications[app].add_unit(count=1)
+    # TODO: this should have to go once we full trust that quorum is automatically established
+    await wait_until(
+        ops_test,
+        apps=[app],
+        units_full_statuses={
+            app: {
+                "units": {
+                    "blocked": [PClusterWrongNodesCountForQuorum],
+                    "active": [],
+                },
+            },
+        },
+        wait_for_exact_units=len(nodes) + 1,
+        idle_period=IDLE_PERIOD,
+    )
+    new_nodes = await all_nodes(ops_test, leader_unit_ip)
+    assert len(new_nodes) == len(nodes)
+
+    # remove new unit
+    last_unit_id = sorted(get_application_unit_ids(ops_test, app))[-1]
+    await ops_test.model.applications[app].destroy_unit(f"{app}/{last_unit_id}")
 
 
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])

--- a/tests/integration/ha/test_roles_managements.py
+++ b/tests/integration/ha/test_roles_managements.py
@@ -6,7 +6,6 @@ import asyncio
 import logging
 
 import pytest
-from charms.opensearch.v0.constants_charm import PClusterWrongNodesCountForQuorum
 from pytest_operator.plugin import OpsTest
 
 from ..helpers import (
@@ -16,7 +15,6 @@ from ..helpers import (
     SERIES,
     check_cluster_formation_successful,
     cluster_health,
-    get_application_unit_ids,
     get_application_unit_names,
     get_leader_unit_ip,
 )
@@ -112,30 +110,6 @@ async def test_set_roles_manually(
     for node in nodes:
         assert sorted(node.roles) == ["cluster_manager", "data"], "roles unchanged"
         assert node.temperature == "cold", "Temperature unchanged."
-
-    # scale up cluster by 1 unit, this should give the new node the same roles
-    await ops_test.model.applications[app].add_unit(count=1)
-    # TODO: this should have to go once we full trust that quorum is automatically established
-    await wait_until(
-        ops_test,
-        apps=[app],
-        units_full_statuses={
-            app: {
-                "units": {
-                    "blocked": [PClusterWrongNodesCountForQuorum],
-                    "active": [],
-                },
-            },
-        },
-        wait_for_exact_units=len(nodes) + 1,
-        idle_period=IDLE_PERIOD,
-    )
-    new_nodes = await all_nodes(ops_test, leader_unit_ip)
-    assert len(new_nodes) == len(nodes)
-
-    # remove new unit
-    last_unit_id = sorted(get_application_unit_ids(ops_test, app))[-1]
-    await ops_test.model.applications[app].destroy_unit(f"{app}/{last_unit_id}")
 
 
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])

--- a/tests/unit/lib/test_opensearch_base_charm.py
+++ b/tests/unit/lib/test_opensearch_base_charm.py
@@ -273,7 +273,6 @@ class TestOpenSearchBaseCharm(unittest.TestCase):
             self.charm._start_opensearch_event.emit.assert_called_once()
 
     @patch(f"{BASE_LIB_PATH}.opensearch_locking.OpenSearchNodeLock.acquired")
-    @patch(f"{PEER_CLUSTERS_MANAGER}.validate_roles")
     @patch(f"{PEER_CLUSTERS_MANAGER}.deployment_desc")
     @patch(f"{PEER_CLUSTERS_MANAGER}.can_start")
     @patch(f"{BASE_CHARM_CLASS}.is_admin_user_configured")
@@ -302,7 +301,6 @@ class TestOpenSearchBaseCharm(unittest.TestCase):
         is_admin_user_configured,
         can_start,
         deployment_desc,
-        validate_roles,
         lock_acquired,
     ):
         """Test on start event."""
@@ -381,8 +379,6 @@ class TestOpenSearchBaseCharm(unittest.TestCase):
 
             _get_nodes.side_effect = None
             _get_nodes.assert_called()
-            validate_roles.side_effect = None
-            validate_roles.assert_called()
             _set_node_conf.assert_called()
             start.assert_called_once()
             _post_start_init.assert_called_once()

--- a/tests/unit/lib/test_opensearch_peer_clusters.py
+++ b/tests/unit/lib/test_opensearch_peer_clusters.py
@@ -115,16 +115,19 @@ class TestOpenSearchPeerClustersManager(unittest.TestCase):
             can_start = self.peer_cm.can_start(deployment_desc)
             self.assertEqual(can_start, expected)
 
-    @patch(f"{BASE_LIB_PATH}.models.PeerClusterApp.from_dict")
+    @patch(f"{PEER_CLUSTERS_MANAGER}.is_peer_cluster_orchestrator_relation_set")
+    @patch("ops.model.Model.get_relation")
     @patch(f"{PEER_CLUSTERS_MANAGER}.deployment_desc")
-    def test_validate_roles(self, deployment_desc, peer_cluster_app_from_dict):
+    def test_validate_roles(
+        self, deployment_desc, get_relation, is_peer_cluster_orchestrator_relation_set
+    ):
         """Test the roles' validation."""
+        is_peer_cluster_orchestrator_relation_set.return_value = False
+        get_relation.return_value.units = set(self.p_units)
+
         app = App(name="logs", model_uuid=self.charm.model.uuid)
 
         self.peers_data.get_object = MagicMock()
-        peer_cluster_app_from_dict.side_effect = lambda app: MagicMock(
-            planned_units=app["planned_units"]
-        )
 
         deployment_desc.return_value = DeploymentDescription(
             config=self.user_configs["roles_ok"],
@@ -135,63 +138,45 @@ class TestOpenSearchPeerClustersManager(unittest.TestCase):
             state=DeploymentState(value=State.ACTIVE),
             profile="production",
         )
-        # mock unit count=0 to only account for nodes in nodes list for full_cluster_planned_units
-        self.charm.app.planned_units = MagicMock(return_value=0)
-        # large deployment with 3 cms, should not raise an exception
-        nodes = [
-            Node(
-                name=node.name.replace("/", "-"),
-                roles=["cluster_manager"],
-                ip="1.1.1.1",
-                app=App(model_uuid=self.charm.model.uuid, name=app.name),
-                unit_number=int(node.name.split("/")[-1]),
-            )
-            for node in self.p_units[0:3]
-        ] + [
-            Node(
-                name="node",
-                roles=["data"],
-                ip="1.1.1.1",
-                app=App(model_uuid=self.charm.model.uuid, name=app.name),
-                unit_number=3,
-            )
-        ]
+        with self.assertRaises(OpenSearchProvidedRolesException):
+            # on scale up
+            self.charm.app.planned_units = MagicMock(return_value=4)
+            nodes = [
+                Node(
+                    name=node.name.replace("/", "-"),
+                    roles=["cluster_manager", "data"],
+                    ip="1.1.1.1",
+                    app=App(model_uuid=self.charm.model.uuid, name=app.name),
+                    unit_number=int(node.name.split("/")[-1]),
+                )
+                for node in self.p_units[0:3]
+            ]
 
-        self.peers_data.get_object.return_value = {
-            "main": {"planned_units": 3},
-            "data": {"planned_units": 1},
-        }
-        # test no exception is raised when sufficient cms in deployment
-        self.peer_cm.validate_roles(nodes=nodes, on_new_unit=False)
-
-        # large deployment with < 3 cms, should raise an exception on final unit
-        nodes = [
-            Node(
-                name=node.name.replace("/", "-"),
-                roles=["cluster_manager"],
-                ip="1.1.1.1",
-                app=App(model_uuid=self.charm.model.uuid, name=app.name),
-                unit_number=int(node.name.split("/")[-1]),
-            )
-            for node in self.p_units[0:2]
-        ] + [
-            Node(
-                name="node",
-                roles=["data"],
-                ip="0.0.0.0",
-                app=App(model_uuid=self.charm.model.uuid, name="logs"),
-                unit_number=2,
-            )
-        ]
-        self.peers_data.get_object.return_value = {
-            "main": {"planned_units": 2},
-            "data": {"planned_units": 1},
-        }
-
-        # test no exception is raised on new unit
-        self.peer_cm.validate_roles(nodes=nodes, on_new_unit=True)
+            self.peers_data.get_object.return_value = None
+            self.peer_cm.validate_roles(nodes=nodes, on_new_unit=True)
 
         with self.assertRaises(OpenSearchProvidedRolesException):
+            # on rebalance
+            self.charm.app.planned_units = MagicMock(return_value=5)
+            nodes = [
+                Node(
+                    name=node.name.replace("/", "-"),
+                    roles=["cluster_manager", "data"],
+                    ip="1.1.1.1",
+                    app=App(model_uuid=self.charm.model.uuid, name=app.name),
+                    unit_number=int(node.name.split("/")[-1]),
+                )
+                for node in self.p_units[0:4]
+            ] + [
+                Node(
+                    name="node",
+                    roles=["ml"],
+                    ip="0.0.0.0",
+                    app=App(model_uuid=self.charm.model.uuid, name="logs"),
+                    unit_number=7,
+                )
+            ]
+            self.peers_data.get_object.return_value = None
             self.peer_cm.validate_roles(nodes=nodes, on_new_unit=False)
 
     @patch("ops.model.Model.get_relation")

--- a/tests/unit/lib/test_opensearch_peer_clusters.py
+++ b/tests/unit/lib/test_opensearch_peer_clusters.py
@@ -115,19 +115,16 @@ class TestOpenSearchPeerClustersManager(unittest.TestCase):
             can_start = self.peer_cm.can_start(deployment_desc)
             self.assertEqual(can_start, expected)
 
-    @patch(f"{PEER_CLUSTERS_MANAGER}.is_peer_cluster_orchestrator_relation_set")
-    @patch("ops.model.Model.get_relation")
+    @patch(f"{BASE_LIB_PATH}.models.PeerClusterApp.from_dict")
     @patch(f"{PEER_CLUSTERS_MANAGER}.deployment_desc")
-    def test_validate_roles(
-        self, deployment_desc, get_relation, is_peer_cluster_orchestrator_relation_set
-    ):
+    def test_validate_roles(self, deployment_desc, peer_cluster_app_from_dict):
         """Test the roles' validation."""
-        is_peer_cluster_orchestrator_relation_set.return_value = False
-        get_relation.return_value.units = set(self.p_units)
-
         app = App(name="logs", model_uuid=self.charm.model.uuid)
 
         self.peers_data.get_object = MagicMock()
+        peer_cluster_app_from_dict.side_effect = lambda app: MagicMock(
+            planned_units=app["planned_units"]
+        )
 
         deployment_desc.return_value = DeploymentDescription(
             config=self.user_configs["roles_ok"],
@@ -138,45 +135,63 @@ class TestOpenSearchPeerClustersManager(unittest.TestCase):
             state=DeploymentState(value=State.ACTIVE),
             profile="production",
         )
-        with self.assertRaises(OpenSearchProvidedRolesException):
-            # on scale up
-            self.charm.app.planned_units = MagicMock(return_value=4)
-            nodes = [
-                Node(
-                    name=node.name.replace("/", "-"),
-                    roles=["cluster_manager", "data"],
-                    ip="1.1.1.1",
-                    app=App(model_uuid=self.charm.model.uuid, name=app.name),
-                    unit_number=int(node.name.split("/")[-1]),
-                )
-                for node in self.p_units[0:3]
-            ]
+        # mock unit count=0 to only account for nodes in nodes list for full_cluster_planned_units
+        self.charm.app.planned_units = MagicMock(return_value=0)
+        # large deployment with 3 cms, should not raise an exception
+        nodes = [
+            Node(
+                name=node.name.replace("/", "-"),
+                roles=["cluster_manager"],
+                ip="1.1.1.1",
+                app=App(model_uuid=self.charm.model.uuid, name=app.name),
+                unit_number=int(node.name.split("/")[-1]),
+            )
+            for node in self.p_units[0:3]
+        ] + [
+            Node(
+                name="node",
+                roles=["data"],
+                ip="1.1.1.1",
+                app=App(model_uuid=self.charm.model.uuid, name=app.name),
+                unit_number=3,
+            )
+        ]
 
-            self.peers_data.get_object.return_value = None
-            self.peer_cm.validate_roles(nodes=nodes, on_new_unit=True)
+        self.peers_data.get_object.return_value = {
+            "main": {"planned_units": 3},
+            "data": {"planned_units": 1},
+        }
+        # test no exception is raised when sufficient cms in deployment
+        self.peer_cm.validate_roles(nodes=nodes, on_new_unit=False)
+
+        # large deployment with < 3 cms, should raise an exception on final unit
+        nodes = [
+            Node(
+                name=node.name.replace("/", "-"),
+                roles=["cluster_manager"],
+                ip="1.1.1.1",
+                app=App(model_uuid=self.charm.model.uuid, name=app.name),
+                unit_number=int(node.name.split("/")[-1]),
+            )
+            for node in self.p_units[0:2]
+        ] + [
+            Node(
+                name="node",
+                roles=["data"],
+                ip="0.0.0.0",
+                app=App(model_uuid=self.charm.model.uuid, name="logs"),
+                unit_number=2,
+            )
+        ]
+        self.peers_data.get_object.return_value = {
+            "main": {"planned_units": 2},
+            "data": {"planned_units": 1},
+        }
+
+        # test no exception is raised on new unit
+        self.peer_cm.validate_roles(nodes=nodes, on_new_unit=True)
 
         with self.assertRaises(OpenSearchProvidedRolesException):
-            # on rebalance
-            self.charm.app.planned_units = MagicMock(return_value=5)
-            nodes = [
-                Node(
-                    name=node.name.replace("/", "-"),
-                    roles=["cluster_manager", "data"],
-                    ip="1.1.1.1",
-                    app=App(model_uuid=self.charm.model.uuid, name=app.name),
-                    unit_number=int(node.name.split("/")[-1]),
-                )
-                for node in self.p_units[0:4]
-            ] + [
-                Node(
-                    name="node",
-                    roles=["ml"],
-                    ip="0.0.0.0",
-                    app=App(model_uuid=self.charm.model.uuid, name="logs"),
-                    unit_number=7,
-                )
-            ]
-            self.peers_data.get_object.return_value = None
             self.peer_cm.validate_roles(nodes=nodes, on_new_unit=False)
 
     @patch("ops.model.Model.get_relation")


### PR DESCRIPTION
## Issue

When removing or scaling down an orchestrator in a large deployment or when removing the relations with an orchestrator, several parts of the code access properties of NoneType objects. Additionally, the failover promotes itself in cases where it shouldn't.

## Solution
- guard against accessing properties of NoneTypes
- stop the failover from promoting itself when it shouldn't
- treat scaling an orchestrator down to 0 units as deleting the orchestrator
- put peer-cluster requirer in a `Waiting` state if the main orchestrator is removed and a failover is related
- put peer-cluster requirer in a `Blocked` state if both the main and failover orchestrators are removed

This PR fixes #555 #564 #568 #569

Supersedes #440 
