### PR TITLE
pop random key if exists

### DIFF
--- a/lib/charms/opensearch/v0/helper_conf_setter.py
+++ b/lib/charms/opensearch/v0/helper_conf_setter.py
@@ -195,7 +195,8 @@ class YamlConfigSetter(ConfigSetter):
             lines.append(f"{random_id}: {random_id}")
 
             data = self.yaml.load(StringIO("\n".join(lines)))
-            del data[random_id]
+            if random_id in data:
+                del data[random_id]
 
             return data
 


### PR DESCRIPTION
## Issue
When loading a yaml file in the conf-setter, we're adding a random entry and immediately deleting it. If this line isn't correctly parsed for whatever reason, it will cause a crash.

## Solution
Add a guard to check that the random entry exists before deleting it
