### PR TITLE
[DPE-6858] Add expose support

### DIFF
--- a/terraform/charm/large_deployment/main.tf
+++ b/terraform/charm/large_deployment/main.tf
@@ -41,6 +41,7 @@ module "opensearch_main" {
   constraints       = var.main.constraints
   storage           = var.main.storage
   endpoint_bindings = var.main.endpoint_bindings
+  expose            = var.main.expose
 
   self-signed-certificates = var.self-signed-certificates
 }
@@ -64,6 +65,7 @@ module "opensearch_failover" {
   constraints       = var.failover.constraints
   storage           = var.failover.storage
   endpoint_bindings = var.failover.endpoint_bindings
+  expose            = var.failover.expose
 }
 
 # all non orchestrator apps
@@ -84,6 +86,7 @@ module "opensearch_non_orchestrator_apps" {
   model       = each.value.model
   constraints = each.value.constraints
   storage     = each.value.storage
+  expose      = each.value.expose
 }
 
 #--------------------------------------------------------

--- a/terraform/charm/large_deployment/variables.tf
+++ b/terraform/charm/large_deployment/variables.tf
@@ -21,6 +21,7 @@ variable "main" {
     machines          = optional(list(string), [])
     storage           = optional(map(string), {})
     endpoint_bindings = optional(map(string), {})
+    expose            = optional(bool, false)
   })
 }
 
@@ -38,6 +39,7 @@ variable "failover" {
     machines          = optional(list(string), [])
     storage           = optional(map(string), {})
     endpoint_bindings = optional(map(string), {})
+    expose            = optional(bool, false)
   })
   default = null
 }
@@ -56,6 +58,7 @@ variable "apps" {
     machines          = optional(list(string), [])
     storage           = optional(map(string), {})
     endpoint_bindings = optional(map(string), {})
+    expose            = optional(bool, false)
   }))
   default = null
 }

--- a/terraform/charm/simple_deployment/README.md
+++ b/terraform/charm/simple_deployment/README.md
@@ -22,6 +22,7 @@ The module offers the following configurable inputs:
 | `units`       | number      | Number of units to be deployed                            | False      |
 | `constraints` | string      | Machine constraints for the charm                         | False      |
 | `storage`     | map(string) | Storage description, must follow the juju provider schema | False      |
+| `expose`      | bool        | Expose block, if set to true, opens to anyone's access    | False      |
 
 
 ### Outputs

--- a/terraform/charm/simple_deployment/main.tf
+++ b/terraform/charm/simple_deployment/main.tf
@@ -25,6 +25,11 @@ resource "juju_application" "opensearch" {
   constraints        = var.constraints
   storage_directives = var.storage
 
+  dynamic "expose" {
+    for_each = var.expose ? [1] : []
+    content {}
+  }
+
   # TODO: uncomment once final fixes have been added for:
   # Error: juju/terraform-provider-juju#443, juju/terraform-provider-juju#182
   # placement = join(",", var.machines)

--- a/terraform/charm/simple_deployment/variables.tf
+++ b/terraform/charm/simple_deployment/variables.tf
@@ -79,7 +79,7 @@ variable "endpoint_bindings" {
 }
 
 variable "expose" {
-  description = "Expose the application"
+  description = "Expose the application for external access."
   type        = bool
   default     = false
 }

--- a/terraform/charm/simple_deployment/variables.tf
+++ b/terraform/charm/simple_deployment/variables.tf
@@ -22,7 +22,9 @@ variable "base" {
 variable "config" {
   description = "Map of charm configuration options"
   type        = map(string)
-  default     = {}
+  default = {
+    profile = "testing"
+  }
 }
 
 variable "model" {
@@ -74,6 +76,12 @@ variable "endpoint_bindings" {
   description = "Map of endpoint bindings"
   type        = map(string)
   default     = {}
+}
+
+variable "expose" {
+  description = "Expose the application"
+  type        = bool
+  default     = false
 }
 
 # --------

--- a/terraform/product/large_deployment/variables.tf
+++ b/terraform/product/large_deployment/variables.tf
@@ -21,6 +21,7 @@ variable "main" {
     machines          = optional(list(string), [])
     storage           = optional(map(string), {})
     endpoint_bindings = optional(map(string), {})
+    expose            = optional(bool, false)
   })
 }
 
@@ -38,6 +39,7 @@ variable "failover" {
     machines          = optional(list(string), [])
     storage           = optional(map(string), {})
     endpoint_bindings = optional(map(string), {})
+    expose            = optional(bool, false)
   })
   default = null
 }
@@ -56,6 +58,7 @@ variable "apps" {
     machines          = optional(list(string), [])
     storage           = optional(map(string), {})
     endpoint_bindings = optional(map(string), {})
+    expose            = optional(bool, false)
   }))
   default = null
 }
@@ -73,6 +76,7 @@ variable "opensearch-dashboards" {
     machines          = optional(list(string), [])
     endpoint_bindings = optional(map(string), {})
     tls               = optional(bool, false)
+    expose            = optional(bool, false)
   })
   default = {}
 }

--- a/terraform/product/simple_deployment/main.tf
+++ b/terraform/product/simple_deployment/main.tf
@@ -21,6 +21,7 @@ module "opensearch" {
   storage           = var.opensearch.storage
   endpoint_bindings = var.opensearch.endpoint_bindings
   machines          = var.opensearch.machines
+  expose            = var.opensearch.expose
 
   self-signed-certificates = var.self-signed-certificates
 }
@@ -40,6 +41,7 @@ module "opensearch-dashboards" {
   constraints       = var.opensearch-dashboards.constraints
   endpoint_bindings = var.opensearch-dashboards.endpoint_bindings
   machines          = var.opensearch-dashboards.machines
+  expose            = var.opensearch-dashboards.expose
 }
 
 # Integrator apps and grafana-agent

--- a/terraform/product/simple_deployment/variables.tf
+++ b/terraform/product/simple_deployment/variables.tf
@@ -15,6 +15,7 @@ variable "opensearch" {
     machines          = optional(list(string), [])
     storage           = optional(map(string), {})
     endpoint_bindings = optional(map(string), {})
+    expose            = optional(bool, false)
   })
 }
 
@@ -31,6 +32,7 @@ variable "opensearch-dashboards" {
     machines          = optional(list(string), [])
     endpoint_bindings = optional(map(string), {})
     tls               = optional(bool, false)
+    expose            = optional(bool, false)
   })
   default = {}
 }


### PR DESCRIPTION
This PR adds expose as a variable and subsequent dynamic block. If the expose is set to true, then the dynamic block renders expose {}, which effectively exposes the application to any external access.