### PR TITLE
[DPE-6793] Check deployment desc. before plugin manager is called

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -719,6 +719,11 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             event.defer()
             return
 
+        if not self.opensearch_peer_cm.deployment_desc():
+            logger.info("Deployment description not ready yet, deferring and trying later.")
+            event.defer()
+            return
+
         perf_profile_needs_restart = False
         plugin_needs_restart = False
 
@@ -752,13 +757,9 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             if original_status:
                 self.status.set(original_status)
 
-        if self.opensearch_peer_cm.deployment_desc():
-            perf_profile_needs_restart = self.performance_profile.apply(
-                self.config.get(PERFORMANCE_PROFILE)
-            )
-        else:
-            event.defer()
-            return
+        perf_profile_needs_restart = self.performance_profile.apply(
+            self.config.get(PERFORMANCE_PROFILE)
+        )
 
         if self.opensearch.is_service_started() and (
             plugin_needs_restart or perf_profile_needs_restart


### PR DESCRIPTION
This PR fixes #589 by checking if the deployment description is available before the plugin manager is called.

This PR moves the check done later in `_on_config_changed` to right after the `upgrade_in_progress` check.

Closes #589
