### PR TITLE
[DPE-6882] Add support for plugin-folder s3 relation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -32,11 +32,6 @@ options:
         cluster_manager, data, data.hot, data.warm, data.cold, ingest, coordinating, voting_only, ml.
       Other dynamic roles are not validated.
 
-  plugin_opensearch_knn:
-    default: true
-    type: boolean
-    description: Enable opensearch-knn
-
   profile:
     type: string
     default: "production"
@@ -46,3 +41,32 @@ options:
       Production will tune opensearch for maximum performance while default will tune for
       minimal running performance.
       Performance tuning is described on: https://opensearch.org/docs/latest/tuning-your-cluster/performance/
+
+  plugin_opensearch_knn:
+    default: true
+    type: boolean
+    description: Enable opensearch-knn
+
+  plugin_ml_commons_override_trust_url_regex:
+    default: "^(https?|file)://(/var/snap/common/opensearch/var/lib/opensearch/ml_commons/|https://artifacts.opensearch.org/models/ml-models/)*"
+    type: string
+    description: |
+      URL regex to trust for ML commons plugin. By default, this option is left empty and only `opensearch.org`
+      and the path /var/snap/common/opensearch/var/lib/opensearch/ml_commons/ are trusted.
+
+      This is a security risk, and should only be used in trusted environments and trusted URLs.
+      See https://opensearch.org/docs/latest/ml-commons-plugin/cluster-settings/#add-trusted-url
+
+  plugin_ml_commons_enable_inhouse_python_model:
+    default: false
+    type: boolean
+    description: |
+      Enable in-house python model for ML commons plugin. By default, this option is disabled.
+      See https://opensearch.org/docs/latest/ml-commons-plugin/cluster-settings/#run-python-based-models
+
+  plugin_ml_commons_s3_path:
+    default: ""
+    type: string
+    description: |
+      S3 path to store ML commons plugin data.
+      If set, the charm will download the data from the S3 bucket and store it in the local path.

--- a/lib/charms/opensearch/v0/constants_charm.py
+++ b/lib/charms/opensearch/v0/constants_charm.py
@@ -124,4 +124,6 @@ S3_RELATION = "s3-credentials"
 AZURE_REPO_BASE_PATH = "/"
 AZURE_RELATION = "azure-credentials"
 
+PLUGIN_FOLDER_RELATION = "plugin-folder"
+
 PERFORMANCE_PROFILE = "profile"

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -309,8 +309,13 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
 
         # Restore purged system users in local `internal_users.yml`
         # with corresponding credentials
-        for user in OpenSearchSystemUsers:
-            self._put_or_update_internal_user_leader(user)
+        try:
+            for user in OpenSearchSystemUsers:
+                self._put_or_update_internal_user_leader(user)
+        except OpenSearchHttpError as e:
+            logger.warning(f"Failed to update internal users: {e}")
+            event.defer()
+            return
 
         self.status.clear(AdminUserInitProgress)
 

--- a/lib/charms/opensearch/v0/opensearch_plugin_manager.py
+++ b/lib/charms/opensearch/v0/opensearch_plugin_manager.py
@@ -13,9 +13,16 @@ config-changed, upgrade, s3-credentials-changed, etc.
 import copy
 import functools
 import logging
+import os
 from typing import Dict, List, Tuple, Type
 
+import boto3
+
+from ops import Object
+
+from charms.opensearch.v0.constants_charm import PLUGIN_FOLDER_RELATION
 from charms.opensearch.v0.helper_cluster import ClusterTopology
+from charms.opensearch.v0.models import S3RelData
 from charms.opensearch.v0.opensearch_exceptions import (
     OpenSearchCmdError,
     OpenSearchHttpError,
@@ -28,6 +35,7 @@ from charms.opensearch.v0.opensearch_keystore import (
 from charms.opensearch.v0.opensearch_plugins import (
     OpenSearchAzurePlugin,
     OpenSearchKnn,
+    OpenSearchMlCommons,
     OpenSearchPlugin,
     OpenSearchPluginConfig,
     OpenSearchPluginError,
@@ -54,6 +62,10 @@ logger = logging.getLogger(__name__)
 
 
 ConfigExposedPlugins = {
+    "ml-commons": {
+        "class": OpenSearchMlCommons,
+        "config": None,
+    },
     "opensearch-knn": {
         "class": OpenSearchKnn,
         "config": "plugin_opensearch_knn",
@@ -74,7 +86,18 @@ class OpenSearchPluginManagerNotReadyYetError(OpenSearchPluginError):
 
 
 class OpenSearchPluginManager:
-    """Manages plugins."""
+    """Manages plugins.
+
+    This class is in charge of handling:
+    * cluster settings for plugins
+    * keystore management using the OpenSearchKeystore class for plugin secrets
+    * /_plugins API
+    * Interact with `opensearch-plugin` CLI
+    * s3 repository to download plugin artifacts and install on the right folders
+
+    If another component needs to interact with either of these components of OpenSearch,
+    they can use the `apply_config` API in this class to enforce a given configuration.
+    """
 
     def __init__(self, charm):
         """Creates the plugin manager object based on the charm and home_path.
@@ -87,6 +110,7 @@ class OpenSearchPluginManager:
         self._opensearch_config = charm.opensearch_config
         self._charm_config = self._charm.model.config
         self._keystore = OpenSearchKeystore(self._charm)
+        self._repository = PluginRepositoryHandler(self._charm)
 
     @functools.cached_property
     def cluster_config(self):
@@ -459,3 +483,89 @@ class OpenSearchPluginManager:
             return self._opensearch.run_bin("plugin", "list").split("\n")
         except OpenSearchCmdError as e:
             raise OpenSearchPluginError("Failed to list plugins: " + str(e))
+
+
+class PluginRepositoryHandler(Object):
+    """Manages the repositories for the plugins."""
+
+    def __init__(self, charm):
+        """Creates the plugin repository manager object based on the charm."""
+        super().__init__(charm, PLUGIN_FOLDER_RELATION)
+        self._charm = charm
+
+        self.framework.observe(
+            self._charm.on[PLUGIN_FOLDER_RELATION].relation_changed,
+            self._on_plugin_folder_relation_changed,
+        )
+
+    @property
+    def _model(self) -> S3RelData | None:
+        if relation := self._charm.model.get_relation(PLUGIN_FOLDER_RELATION):
+            if data := S3RelData.from_relation(dict(relation.data[relation.app])):
+                return data
+        return None
+
+    def download(self, plugin: OpenSearchPlugin):
+        if not self._model:
+            logger.warning("S3 relation data is not available.")
+            return
+
+        if not self._model.credentials.access_key or not self._model.credentials.secret_key:
+            logger.debug("S3 credentials are not available.")
+            return
+
+        if not plugin.local_path:
+            logger.debug(f"{plugin.name} plugin does not have a local path set.")
+            return
+
+        try:
+            s3_client = boto3.client(
+                "s3",
+                region_name=self._model.region,
+                verify=False,
+                endpoint_url=self._model.endpoint,
+                aws_access_key_id=self._model.credentials.access_key,
+                aws_secret_access_key=self._model.credentials.secret_key,
+            )
+        except Exception as e:
+            logger.error(f"Failed to connect with S3: {e}")
+            return
+
+        s3_path = (
+            os.path.join(self._model.base_path, plugin.s3_path)
+            if os.path.join(self._model.base_path, plugin.s3_path) != "/"
+            else plugin.s3_path
+        )
+        local_path = plugin.local_path
+
+        try:
+            logger.debug(f"Try to create local_path {local_path}")
+            self._charm.opensearch.create_directories([local_path])
+
+            logger.debug(f"Downloading plugin from S3: {s3_path} to {local_path}")
+            objects = s3_client.list_objects(
+                Bucket=self._model.bucket,
+                Prefix=s3_path,
+                Delimiter="/",
+            )
+            if not objects.get('Contents'):
+                logger.warning(f"No objects found in S3 for {plugin.name} on path: {s3_path}")
+                return
+
+            for obj in objects.get('Contents'):
+                local_file = os.path.join(local_path, obj['Key'])
+                s3_client.download_file(
+                    self._model.bucket,
+                    os.path.join(s3_path, obj['Key']),
+                    local_file,
+                )
+                self._charm.opensearch.setup_linux_perms(local_file)
+                logger.debug(f"Plugin downloaded successfully to {local_file}")
+        except Exception as e:
+            logger.error(f"Failed to download plugin {plugin.name} from S3: {e}")
+
+    def _on_plugin_folder_relation_changed(self, event):
+        """Handles the plugin folder relation changed event."""
+        for plugin in self._charm.plugin_manager.plugins:
+            # Download the plugin
+            self.download(plugin)

--- a/lib/charms/opensearch/v0/opensearch_plugin_manager.py
+++ b/lib/charms/opensearch/v0/opensearch_plugin_manager.py
@@ -118,17 +118,10 @@ class OpenSearchPluginManager:
     @functools.cached_property
     def plugins(self) -> List[OpenSearchPlugin]:
         """Returns List of installed plugins."""
-        nodes = []
-        try:
-            nodes = ClusterTopology.nodes(self._charm.opensearch, use_localhost=True, hosts=self._charm.alt_hosts)
-        except OpenSearchHttpError as e:
-            logger.error(f"Failed to get cluster topology: {e}")
-
         plugins_list = []
         for plugin_data in ConfigExposedPlugins.values():
             new_plugin = plugin_data["class"](
                 self._charm,
-                node_roles=nodes,
             )
             plugins_list.append(new_plugin)
         return plugins_list

--- a/lib/charms/opensearch/v0/opensearch_plugin_manager.py
+++ b/lib/charms/opensearch/v0/opensearch_plugin_manager.py
@@ -118,9 +118,18 @@ class OpenSearchPluginManager:
     @functools.cached_property
     def plugins(self) -> List[OpenSearchPlugin]:
         """Returns List of installed plugins."""
+        nodes = []
+        try:
+            nodes = ClusterTopology.nodes(self._charm.opensearch, use_localhost=True, hosts=self._charm.alt_hosts)
+        except OpenSearchHttpError as e:
+            logger.error(f"Failed to get cluster topology: {e}")
+
         plugins_list = []
         for plugin_data in ConfigExposedPlugins.values():
-            new_plugin = plugin_data["class"](self._charm)
+            new_plugin = plugin_data["class"](
+                self._charm,
+                node_roles=nodes,
+            )
             plugins_list.append(new_plugin)
         return plugins_list
 

--- a/lib/charms/opensearch/v0/opensearch_plugin_manager.py
+++ b/lib/charms/opensearch/v0/opensearch_plugin_manager.py
@@ -17,9 +17,6 @@ import os
 from typing import Dict, List, Tuple, Type
 
 import boto3
-
-from ops import Object
-
 from charms.opensearch.v0.constants_charm import PLUGIN_FOLDER_RELATION
 from charms.opensearch.v0.helper_cluster import ClusterTopology
 from charms.opensearch.v0.models import S3RelData
@@ -46,6 +43,7 @@ from charms.opensearch.v0.opensearch_plugins import (
     OpenSearchS3Plugin,
     PluginState,
 )
+from ops import Object
 
 # The unique Charmhub library identifier, never change it
 LIBID = "da838485175f47dbbbb83d76c07cab4c"
@@ -506,6 +504,7 @@ class PluginRepositoryHandler(Object):
         return None
 
     def download(self, plugin: OpenSearchPlugin):
+        """Downloads the given plugin's artifacts from S3."""
         if not self._model:
             logger.warning("S3 relation data is not available.")
             return
@@ -548,15 +547,15 @@ class PluginRepositoryHandler(Object):
                 Prefix=s3_path,
                 Delimiter="/",
             )
-            if not objects.get('Contents'):
+            if not objects.get("Contents"):
                 logger.warning(f"No objects found in S3 for {plugin.name} on path: {s3_path}")
                 return
 
-            for obj in objects.get('Contents'):
-                local_file = os.path.join(local_path, obj['Key'])
+            for obj in objects.get("Contents"):
+                local_file = os.path.join(local_path, obj["Key"])
                 s3_client.download_file(
                     self._model.bucket,
-                    os.path.join(s3_path, obj['Key']),
+                    os.path.join(s3_path, obj["Key"]),
                     local_file,
                 )
                 self._charm.opensearch.setup_linux_perms(local_file)

--- a/lib/charms/opensearch/v0/opensearch_plugins.py
+++ b/lib/charms/opensearch/v0/opensearch_plugins.py
@@ -299,7 +299,7 @@ from charms.opensearch.v0.constants_charm import (
 )
 from charms.opensearch.v0.constants_secrets import AZURE_CREDENTIALS, S3_CREDENTIALS
 from charms.opensearch.v0.helper_enums import BaseStrEnum
-from charms.opensearch.v0.models import AzureRelData, DeploymentType, S3RelData, Node
+from charms.opensearch.v0.models import AzureRelData, DeploymentType, S3RelData
 from charms.opensearch.v0.opensearch_exceptions import OpenSearchError
 from charms.opensearch.v0.opensearch_internal_data import Scope
 from jproperties import Properties
@@ -399,13 +399,12 @@ class OpenSearchPlugin:
     PLUGIN_PROPERTIES = "plugin-descriptor.properties"
     REMOVE_ON_DISABLE = False
 
-    def __init__(self, charm, node_roles: List[Node] = None):
+    def __init__(self, charm):
         """Creates the OpenSearchPlugin object."""
         self._plugins_path = (
             f"{charm.opensearch.paths.plugins}/{self.name}/{self.PLUGIN_PROPERTIES}"
         )
         self._extra_config = charm.config
-        self._nodes_roles = {node.name: node.roles for node in node_roles}
 
     @property
     def version(self) -> str:
@@ -530,7 +529,7 @@ class OpenSearchMlCommons(OpenSearchPlugin):
 
     def requested_to_enable(self) -> bool:
         """Returns True if at least one node is marked with "ml" role."""
-        return "ml" in [item for roles in self._nodes_roles.values() for item in roles]
+        return True
 
     def config(self) -> OpenSearchPluginConfig:
         """Returns a plugin config object to be applied for enabling the current plugin."""
@@ -642,9 +641,9 @@ class OpenSearchS3Plugin(OpenSearchPlugin):
     MODEL = S3RelData
     DATA_PROVIDER = OpenSearchPluginS3DataProvider
 
-    def __init__(self, charm, node_roles: List[Node] = None):
+    def __init__(self, charm):
         """Creates the OpenSearchBackupPlugin object."""
-        super().__init__(charm, node_roles)
+        super().__init__(charm)
         self.dp = self.DATA_PROVIDER(charm)
         self.repo_name = "default"
         self.charm = charm
@@ -777,9 +776,9 @@ class OpenSearchAzurePlugin(OpenSearchPlugin):
     MODEL = AzureRelData
     DATA_PROVIDER = OpenSearchPluginAzureDataProvider
 
-    def __init__(self, charm, node_roles: List[Node] = None):
+    def __init__(self, charm):
         """Creates the OpenSearchAzurePlugin object."""
-        super().__init__(charm, node_roles)
+        super().__init__(charm)
         self.dp = self.DATA_PROVIDER(charm)
         self.repo_name = "default"
         self.charm = charm

--- a/lib/charms/opensearch/v0/opensearch_plugins.py
+++ b/lib/charms/opensearch/v0/opensearch_plugins.py
@@ -299,7 +299,7 @@ from charms.opensearch.v0.constants_charm import (
 )
 from charms.opensearch.v0.constants_secrets import AZURE_CREDENTIALS, S3_CREDENTIALS
 from charms.opensearch.v0.helper_enums import BaseStrEnum
-from charms.opensearch.v0.models import AzureRelData, DeploymentType, S3RelData
+from charms.opensearch.v0.models import AzureRelData, DeploymentType, S3RelData, Node
 from charms.opensearch.v0.opensearch_exceptions import OpenSearchError
 from charms.opensearch.v0.opensearch_internal_data import Scope
 from jproperties import Properties
@@ -399,13 +399,13 @@ class OpenSearchPlugin:
     PLUGIN_PROPERTIES = "plugin-descriptor.properties"
     REMOVE_ON_DISABLE = False
 
-    def __init__(self, charm, node_roles: List[str] = None):
+    def __init__(self, charm, node_roles: List[Node] = None):
         """Creates the OpenSearchPlugin object."""
         self._plugins_path = (
             f"{charm.opensearch.paths.plugins}/{self.name}/{self.PLUGIN_PROPERTIES}"
         )
         self._extra_config = charm.config
-        self._node_roles = node_roles
+        self._nodes_roles = {node.name: node.roles for node in node_roles}
 
     @property
     def version(self) -> str:
@@ -530,7 +530,7 @@ class OpenSearchMlCommons(OpenSearchPlugin):
 
     def requested_to_enable(self) -> bool:
         """Returns True if at least one node is marked with "ml" role."""
-        return "ml" in self._node_roles
+        return "ml" in [item for roles in self._nodes_roles.values() for item in roles]
 
     def config(self) -> OpenSearchPluginConfig:
         """Returns a plugin config object to be applied for enabling the current plugin."""
@@ -542,13 +542,13 @@ class OpenSearchMlCommons(OpenSearchPlugin):
             "mlcommons.trust_url_regex": "^(https?|file)://(/var/snap/common/opensearch/var/lib/opensearch/ml_commons/|https://artifacts.opensearch.org/models/ml-models/)*",
         }
 
-        if self._extra_config["plugin_ml_commons_trust_url_regex"]:
+        if self._extra_config["plugin_ml_commons_override_trust_url_regex"]:
             return OpenSearchPluginConfig(
                 config_entries=config
                 | {
                     "plugins.ml_commons.allow_registering_model_via_url": True,
                     "mlcommons.trust_url_regex": self._extra_config[
-                        "plugin_ml_commons_trust_url_regex"
+                        "plugin_ml_commons_override_trust_url_regex"
                     ],
                 },
             )
@@ -562,7 +562,7 @@ class OpenSearchMlCommons(OpenSearchPlugin):
     def disable(self) -> OpenSearchPluginConfig:
         """Returns a plugin config object to be applied for disabling the current plugin.
 
-        This method disables the
+        This method disables the ml-commons plugin.
         """
         return OpenSearchPluginConfig(
             config_entries={"knn.plugin.enabled": False},
@@ -642,9 +642,9 @@ class OpenSearchS3Plugin(OpenSearchPlugin):
     MODEL = S3RelData
     DATA_PROVIDER = OpenSearchPluginS3DataProvider
 
-    def __init__(self, charm):
+    def __init__(self, charm, node_roles: List[Node] = None):
         """Creates the OpenSearchBackupPlugin object."""
-        super().__init__(charm)
+        super().__init__(charm, node_roles)
         self.dp = self.DATA_PROVIDER(charm)
         self.repo_name = "default"
         self.charm = charm
@@ -777,9 +777,9 @@ class OpenSearchAzurePlugin(OpenSearchPlugin):
     MODEL = AzureRelData
     DATA_PROVIDER = OpenSearchPluginAzureDataProvider
 
-    def __init__(self, charm):
+    def __init__(self, charm, node_roles: List[Node] = None):
         """Creates the OpenSearchAzurePlugin object."""
-        super().__init__(charm)
+        super().__init__(charm, node_roles)
         self.dp = self.DATA_PROVIDER(charm)
         self.repo_name = "default"
         self.charm = charm

--- a/lib/charms/opensearch/v0/opensearch_plugins.py
+++ b/lib/charms/opensearch/v0/opensearch_plugins.py
@@ -399,12 +399,13 @@ class OpenSearchPlugin:
     PLUGIN_PROPERTIES = "plugin-descriptor.properties"
     REMOVE_ON_DISABLE = False
 
-    def __init__(self, charm):
+    def __init__(self, charm, node_roles: List[str] = None):
         """Creates the OpenSearchPlugin object."""
         self._plugins_path = (
             f"{charm.opensearch.paths.plugins}/{self.name}/{self.PLUGIN_PROPERTIES}"
         )
         self._extra_config = charm.config
+        self._node_roles = node_roles
 
     @property
     def version(self) -> str:
@@ -419,6 +420,23 @@ class OpenSearchPlugin:
         with open(self._plugins_path) as f:
             properties.load(f.read())
         return properties._properties["version"]
+
+    @property
+    def local_path(self) -> Optional[str]:
+        """Returns the local folder path to receive any artifacts.
+
+        If not set to None, then the plugin manager must download the artifacts from S3
+        and place them in the local path.
+        """
+        return None
+
+    @property
+    def s3_path(self) -> Optional[str]:
+        """Returns the S3 path where the artifacts may be found.
+
+        Either, that is hardcoded or the user can set a config option to specify this path.
+        """
+        return None
 
     @property
     def dependencies(self) -> Optional[List[str]]:
@@ -500,6 +518,65 @@ class OpenSearchKnn(OpenSearchPlugin):
         return OpenSearchPluginConfig(
             config_entries={"knn.plugin.enabled": False},
         )
+
+    @property
+    def name(self) -> str:
+        """Returns the name of the plugin."""
+        return "opensearch-knn"
+
+
+class OpenSearchMlCommons(OpenSearchPlugin):
+    """Implements the ml-commons plugin."""
+
+    def requested_to_enable(self) -> bool:
+        """Returns True if at least one node is marked with "ml" role."""
+        return "ml" in self._node_roles
+
+    def config(self) -> OpenSearchPluginConfig:
+        """Returns a plugin config object to be applied for enabling the current plugin."""
+
+        config = {
+            "plugins.ml_commons.enable_inhouse_python_model": self._extra_config[
+                "plugin_ml_commons_enable_inhouse_python_model"
+            ],
+            "plugins.ml_commons.allow_registering_model_via_local_file": True,
+            "mlcommons.trust_url_regex": "^(https?|file)://(/var/snap/common/opensearch/var/lib/opensearch/ml_commons/|https://artifacts.opensearch.org/models/ml-models/)*",
+        }
+
+        if self._extra_config["plugin_ml_commons_trust_url_regex"]:
+            return OpenSearchPluginConfig(
+                config_entries=config
+                | {
+                    "plugins.ml_commons.allow_registering_model_via_url": True,
+                    "mlcommons.trust_url_regex": self._extra_config[
+                        "plugin_ml_commons_trust_url_regex"
+                    ],
+                },
+            )
+        return OpenSearchPluginConfig(
+            config_entries=config
+            | {
+                "plugins.ml_commons.allow_registering_model_via_url": False,
+            },
+        )
+
+    def disable(self) -> OpenSearchPluginConfig:
+        """Returns a plugin config object to be applied for disabling the current plugin.
+
+        This method disables the
+        """
+        return OpenSearchPluginConfig(
+            config_entries={"knn.plugin.enabled": False},
+        )
+
+    @property
+    def local_path(self) -> Optional[str]:
+        # Returns files with path /var.../model.<uuid>
+        return "/var/snap/common/opensearch/var/lib/opensearch/ml_commons"
+
+    @property
+    def s3_path(self) -> Optional[str]:
+        return self._extra_config.get("plugin_ml_commons_s3_path")
 
     @property
     def name(self) -> str:

--- a/lib/charms/opensearch/v0/opensearch_plugins.py
+++ b/lib/charms/opensearch/v0/opensearch_plugins.py
@@ -534,7 +534,6 @@ class OpenSearchMlCommons(OpenSearchPlugin):
 
     def config(self) -> OpenSearchPluginConfig:
         """Returns a plugin config object to be applied for enabling the current plugin."""
-
         config = {
             "plugins.ml_commons.enable_inhouse_python_model": self._extra_config[
                 "plugin_ml_commons_enable_inhouse_python_model"
@@ -571,11 +570,12 @@ class OpenSearchMlCommons(OpenSearchPlugin):
 
     @property
     def local_path(self) -> Optional[str]:
-        # Returns files with path /var.../model.<uuid>
+        """Returns the local folder path to receive any artifacts."""
         return "/var/snap/common/opensearch/var/lib/opensearch/ml_commons"
 
     @property
     def s3_path(self) -> Optional[str]:
+        """Returns the S3 path where the artifacts may be found."""
         return self._extra_config.get("plugin_ml_commons_s3_path")
 
     @property

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -49,6 +49,9 @@ requires:
   azure-credentials:
     interface: azure
     limit: 1
+  plugin-folder:
+    interface: s3
+    limit: 1
 
 storage:
   opensearch-data:

--- a/poetry.lock
+++ b/poetry.lock
@@ -2,18 +2,18 @@
 
 [[package]]
 name = "allure-pytest"
-version = "2.13.5"
+version = "2.14.0"
 description = "Allure pytest integration"
 optional = false
 python-versions = "*"
 groups = ["integration"]
 files = [
-    {file = "allure-pytest-2.13.5.tar.gz", hash = "sha256:0ef8e1790c44a988db6b83c4d4f5e91451e2c4c8ea10601dfa88528d23afcf6e"},
-    {file = "allure_pytest-2.13.5-py3-none-any.whl", hash = "sha256:94130bac32964b78058e62cf4b815ad97a5ac82a065e6dd2d43abac2be7640fc"},
+    {file = "allure_pytest-2.14.0-py3-none-any.whl", hash = "sha256:6ddb68ef42bd5a2dfbcc136a184bf3e78e631ede7b8c54750026ffd407bda9af"},
+    {file = "allure_pytest-2.14.0.tar.gz", hash = "sha256:2b485dc307755f8f3207783a69558ca1cc72f1e2c97bedc65c93fdb77adf328f"},
 ]
 
 [package.dependencies]
-allure-python-commons = "2.13.5"
+allure-python-commons = "2.14.0"
 pytest = ">=4.5.0"
 
 [[package]]
@@ -39,14 +39,14 @@ subdirectory = "python/pytest_plugins/allure_pytest_collection_report"
 
 [[package]]
 name = "allure-python-commons"
-version = "2.13.5"
-description = "('Contains the API for end users as well as helper functions and classes to build Allure adapters for Python test frameworks',)"
+version = "2.14.0"
+description = "Contains the API for end users as well as helper functions and classes to build Allure adapters for Python test frameworks"
 optional = false
 python-versions = ">=3.6"
 groups = ["integration"]
 files = [
-    {file = "allure-python-commons-2.13.5.tar.gz", hash = "sha256:a232e7955811f988e49a4c1dd6c16cce7e9b81d0ea0422b1e5654d3254e2caf3"},
-    {file = "allure_python_commons-2.13.5-py3-none-any.whl", hash = "sha256:8b0e837b6e32d810adec563f49e1d04127a5b6770e0232065b7cb09b9953980d"},
+    {file = "allure_python_commons-2.14.0-py3-none-any.whl", hash = "sha256:9200f40abee697133e9ed9f68887cde996a24b9eb33fcf528da8fe50fae88e43"},
+    {file = "allure_python_commons-2.14.0.tar.gz", hash = "sha256:9b217e2f6c74cdbd0e253f89059d4165346e95fcb28228fae333ff4dccea0bd5"},
 ]
 
 [package.dependencies]
@@ -71,34 +71,34 @@ test = ["astroid (>=2,<4)", "pytest", "pytest-cov", "pytest-xdist"]
 
 [[package]]
 name = "attrs"
-version = "25.1.0"
+version = "25.3.0"
 description = "Classes Without Boilerplate"
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "charm-libs", "integration"]
 files = [
-    {file = "attrs-25.1.0-py3-none-any.whl", hash = "sha256:c75a69e28a550a7e93789579c22aa26b0f5b83b75dc4e08fe092980051e1090a"},
-    {file = "attrs-25.1.0.tar.gz", hash = "sha256:1c97078a80c814273a76b2a298a932eb681c87415c11dee0a6921de7f1b02c3e"},
+    {file = "attrs-25.3.0-py3-none-any.whl", hash = "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3"},
+    {file = "attrs-25.3.0.tar.gz", hash = "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b"},
 ]
 
 [package.extras]
 benchmark = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4.3.0)", "pytest-codspeed", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
 cov = ["cloudpickle", "coverage[toml] (>=5.3)", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
 dev = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pre-commit-uv", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
-docs = ["cogapp", "furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
+docs = ["cogapp", "furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier"]
 tests = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
 tests-mypy = ["mypy (>=1.11.1)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "azure-core"
-version = "1.32.0"
+version = "1.33.0"
 description = "Microsoft Azure Core Library for Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["integration"]
 files = [
-    {file = "azure_core-1.32.0-py3-none-any.whl", hash = "sha256:eac191a0efb23bfa83fddf321b27b122b4ec847befa3091fa736a5c32c50d7b4"},
-    {file = "azure_core-1.32.0.tar.gz", hash = "sha256:22b3c35d6b2dae14990f6c1be2912bf23ffe50b220e708a28ab1bb92b1c730e5"},
+    {file = "azure_core-1.33.0-py3-none-any.whl", hash = "sha256:9b5b6d0223a1d38c37500e6971118c1e0f13f54951e6893968b38910bc9cda8f"},
+    {file = "azure_core-1.33.0.tar.gz", hash = "sha256:f367aa07b5e3005fec2c1e184b882b0b039910733907d001c20fb08ebb8c0eb9"},
 ]
 
 [package.dependencies]
@@ -108,17 +108,18 @@ typing-extensions = ">=4.6.0"
 
 [package.extras]
 aio = ["aiohttp (>=3.0)"]
+tracing = ["opentelemetry-api (>=1.26,<2.0)"]
 
 [[package]]
 name = "azure-identity"
-version = "1.20.0"
+version = "1.21.0"
 description = "Microsoft Azure Identity Library for Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["integration"]
 files = [
-    {file = "azure_identity-1.20.0-py3-none-any.whl", hash = "sha256:5f23fc4889a66330e840bd78830287e14f3761820fe3c5f77ac875edcb9ec998"},
-    {file = "azure_identity-1.20.0.tar.gz", hash = "sha256:40597210d56c83e15031b0fe2ea3b26420189e1e7f3e20bdbb292315da1ba014"},
+    {file = "azure_identity-1.21.0-py3-none-any.whl", hash = "sha256:258ea6325537352440f71b35c3dffe9d240eae4a5126c1b7ce5efd5766bd9fd9"},
+    {file = "azure_identity-1.21.0.tar.gz", hash = "sha256:ea22ce6e6b0f429bc1b8d9212d5b9f9877bd4c82f1724bfa910760612c07a9a6"},
 ]
 
 [package.dependencies]
@@ -130,14 +131,14 @@ typing-extensions = ">=4.0.0"
 
 [[package]]
 name = "azure-storage-blob"
-version = "12.24.1"
+version = "12.25.1"
 description = "Microsoft Azure Blob Storage Client Library for Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["integration"]
 files = [
-    {file = "azure_storage_blob-12.24.1-py3-none-any.whl", hash = "sha256:77fb823fdbac7f3c11f7d86a5892e2f85e161e8440a7489babe2195bf248f09e"},
-    {file = "azure_storage_blob-12.24.1.tar.gz", hash = "sha256:052b2a1ea41725ba12e2f4f17be85a54df1129e13ea0321f5a2fcc851cbf47d4"},
+    {file = "azure_storage_blob-12.25.1-py3-none-any.whl", hash = "sha256:1f337aab12e918ec3f1b638baada97550673911c4ceed892acc8e4e891b74167"},
+    {file = "azure_storage_blob-12.25.1.tar.gz", hash = "sha256:4f294ddc9bc47909ac66b8934bd26b50d2000278b10ad82cc109764fdc6e0e3b"},
 ]
 
 [package.dependencies]
@@ -276,18 +277,18 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "boto3"
-version = "1.37.8"
+version = "1.37.33"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "integration"]
 files = [
-    {file = "boto3-1.37.8-py3-none-any.whl", hash = "sha256:b9f506e08c9f54687d6c073ef1c550a24a62cc2d1e0bc7cda9f13112a38818bf"},
-    {file = "boto3-1.37.8.tar.gz", hash = "sha256:9448f4a079189e19c3253cfdc5b8ef6dc51a3b82431e8347a51f4c1b2d9dab42"},
+    {file = "boto3-1.37.33-py3-none-any.whl", hash = "sha256:7b1b1bc69762975824e5a5d570880abebf634f7594f88b3dc175e8800f35be1a"},
+    {file = "boto3-1.37.33.tar.gz", hash = "sha256:4390317a1578af73f1514651bd180ba25802dcbe0a23deafa13851d54d3c3203"},
 ]
 
 [package.dependencies]
-botocore = ">=1.37.8,<1.38.0"
+botocore = ">=1.37.33,<1.38.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.11.0,<0.12.0"
 
@@ -296,14 +297,14 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.37.8"
+version = "1.37.33"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "integration"]
 files = [
-    {file = "botocore-1.37.8-py3-none-any.whl", hash = "sha256:a6c94f33de12f4b10b10684019e554c980469b8394c6d82448a738cbd8452cef"},
-    {file = "botocore-1.37.8.tar.gz", hash = "sha256:b5825e08dd3e25642aa22a0d7d92bf81fef1ef857117e4155f923bbccf5aba63"},
+    {file = "botocore-1.37.33-py3-none-any.whl", hash = "sha256:4a167dfecae51e9140de24067de1c339acde5ade3dad524a4600ac2c72055e23"},
+    {file = "botocore-1.37.33.tar.gz", hash = "sha256:09b213b0d0500040f85c7daee912ea767c724e43ed61909e624c803ff6925222"},
 ]
 
 [package.dependencies]
@@ -586,75 +587,75 @@ typing-extensions = "*"
 
 [[package]]
 name = "coverage"
-version = "7.6.12"
+version = "7.8.0"
 description = "Code coverage measurement for Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["unit"]
 files = [
-    {file = "coverage-7.6.12-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:704c8c8c6ce6569286ae9622e534b4f5b9759b6f2cd643f1c1a61f666d534fe8"},
-    {file = "coverage-7.6.12-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ad7525bf0241e5502168ae9c643a2f6c219fa0a283001cee4cf23a9b7da75879"},
-    {file = "coverage-7.6.12-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:06097c7abfa611c91edb9e6920264e5be1d6ceb374efb4986f38b09eed4cb2fe"},
-    {file = "coverage-7.6.12-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:220fa6c0ad7d9caef57f2c8771918324563ef0d8272c94974717c3909664e674"},
-    {file = "coverage-7.6.12-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3688b99604a24492bcfe1c106278c45586eb819bf66a654d8a9a1433022fb2eb"},
-    {file = "coverage-7.6.12-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d1a987778b9c71da2fc8948e6f2656da6ef68f59298b7e9786849634c35d2c3c"},
-    {file = "coverage-7.6.12-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:cec6b9ce3bd2b7853d4a4563801292bfee40b030c05a3d29555fd2a8ee9bd68c"},
-    {file = "coverage-7.6.12-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:ace9048de91293e467b44bce0f0381345078389814ff6e18dbac8fdbf896360e"},
-    {file = "coverage-7.6.12-cp310-cp310-win32.whl", hash = "sha256:ea31689f05043d520113e0552f039603c4dd71fa4c287b64cb3606140c66f425"},
-    {file = "coverage-7.6.12-cp310-cp310-win_amd64.whl", hash = "sha256:676f92141e3c5492d2a1596d52287d0d963df21bf5e55c8b03075a60e1ddf8aa"},
-    {file = "coverage-7.6.12-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e18aafdfb3e9ec0d261c942d35bd7c28d031c5855dadb491d2723ba54f4c3015"},
-    {file = "coverage-7.6.12-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:66fe626fd7aa5982cdebad23e49e78ef7dbb3e3c2a5960a2b53632f1f703ea45"},
-    {file = "coverage-7.6.12-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ef01d70198431719af0b1f5dcbefc557d44a190e749004042927b2a3fed0702"},
-    {file = "coverage-7.6.12-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:07e92ae5a289a4bc4c0aae710c0948d3c7892e20fd3588224ebe242039573bf0"},
-    {file = "coverage-7.6.12-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e695df2c58ce526eeab11a2e915448d3eb76f75dffe338ea613c1201b33bab2f"},
-    {file = "coverage-7.6.12-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d74c08e9aaef995f8c4ef6d202dbd219c318450fe2a76da624f2ebb9c8ec5d9f"},
-    {file = "coverage-7.6.12-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e995b3b76ccedc27fe4f477b349b7d64597e53a43fc2961db9d3fbace085d69d"},
-    {file = "coverage-7.6.12-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b1f097878d74fe51e1ddd1be62d8e3682748875b461232cf4b52ddc6e6db0bba"},
-    {file = "coverage-7.6.12-cp311-cp311-win32.whl", hash = "sha256:1f7ffa05da41754e20512202c866d0ebfc440bba3b0ed15133070e20bf5aeb5f"},
-    {file = "coverage-7.6.12-cp311-cp311-win_amd64.whl", hash = "sha256:e216c5c45f89ef8971373fd1c5d8d1164b81f7f5f06bbf23c37e7908d19e8558"},
-    {file = "coverage-7.6.12-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b172f8e030e8ef247b3104902cc671e20df80163b60a203653150d2fc204d1ad"},
-    {file = "coverage-7.6.12-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:641dfe0ab73deb7069fb972d4d9725bf11c239c309ce694dd50b1473c0f641c3"},
-    {file = "coverage-7.6.12-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0e549f54ac5f301e8e04c569dfdb907f7be71b06b88b5063ce9d6953d2d58574"},
-    {file = "coverage-7.6.12-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:959244a17184515f8c52dcb65fb662808767c0bd233c1d8a166e7cf74c9ea985"},
-    {file = "coverage-7.6.12-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bda1c5f347550c359f841d6614fb8ca42ae5cb0b74d39f8a1e204815ebe25750"},
-    {file = "coverage-7.6.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1ceeb90c3eda1f2d8c4c578c14167dbd8c674ecd7d38e45647543f19839dd6ea"},
-    {file = "coverage-7.6.12-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:0f16f44025c06792e0fb09571ae454bcc7a3ec75eeb3c36b025eccf501b1a4c3"},
-    {file = "coverage-7.6.12-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b076e625396e787448d27a411aefff867db2bffac8ed04e8f7056b07024eed5a"},
-    {file = "coverage-7.6.12-cp312-cp312-win32.whl", hash = "sha256:00b2086892cf06c7c2d74983c9595dc511acca00665480b3ddff749ec4fb2a95"},
-    {file = "coverage-7.6.12-cp312-cp312-win_amd64.whl", hash = "sha256:7ae6eabf519bc7871ce117fb18bf14e0e343eeb96c377667e3e5dd12095e0288"},
-    {file = "coverage-7.6.12-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:488c27b3db0ebee97a830e6b5a3ea930c4a6e2c07f27a5e67e1b3532e76b9ef1"},
-    {file = "coverage-7.6.12-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5d1095bbee1851269f79fd8e0c9b5544e4c00c0c24965e66d8cba2eb5bb535fd"},
-    {file = "coverage-7.6.12-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0533adc29adf6a69c1baa88c3d7dbcaadcffa21afbed3ca7a225a440e4744bf9"},
-    {file = "coverage-7.6.12-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:53c56358d470fa507a2b6e67a68fd002364d23c83741dbc4c2e0680d80ca227e"},
-    {file = "coverage-7.6.12-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64cbb1a3027c79ca6310bf101014614f6e6e18c226474606cf725238cf5bc2d4"},
-    {file = "coverage-7.6.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:79cac3390bfa9836bb795be377395f28410811c9066bc4eefd8015258a7578c6"},
-    {file = "coverage-7.6.12-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:9b148068e881faa26d878ff63e79650e208e95cf1c22bd3f77c3ca7b1d9821a3"},
-    {file = "coverage-7.6.12-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8bec2ac5da793c2685ce5319ca9bcf4eee683b8a1679051f8e6ec04c4f2fd7dc"},
-    {file = "coverage-7.6.12-cp313-cp313-win32.whl", hash = "sha256:200e10beb6ddd7c3ded322a4186313d5ca9e63e33d8fab4faa67ef46d3460af3"},
-    {file = "coverage-7.6.12-cp313-cp313-win_amd64.whl", hash = "sha256:2b996819ced9f7dbb812c701485d58f261bef08f9b85304d41219b1496b591ef"},
-    {file = "coverage-7.6.12-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:299cf973a7abff87a30609879c10df0b3bfc33d021e1adabc29138a48888841e"},
-    {file = "coverage-7.6.12-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b467a8c56974bf06e543e69ad803c6865249d7a5ccf6980457ed2bc50312703"},
-    {file = "coverage-7.6.12-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2458f275944db8129f95d91aee32c828a408481ecde3b30af31d552c2ce284a0"},
-    {file = "coverage-7.6.12-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a9d8be07fb0832636a0f72b80d2a652fe665e80e720301fb22b191c3434d924"},
-    {file = "coverage-7.6.12-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14d47376a4f445e9743f6c83291e60adb1b127607a3618e3185bbc8091f0467b"},
-    {file = "coverage-7.6.12-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b95574d06aa9d2bd6e5cc35a5bbe35696342c96760b69dc4287dbd5abd4ad51d"},
-    {file = "coverage-7.6.12-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:ecea0c38c9079570163d663c0433a9af4094a60aafdca491c6a3d248c7432827"},
-    {file = "coverage-7.6.12-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2251fabcfee0a55a8578a9d29cecfee5f2de02f11530e7d5c5a05859aa85aee9"},
-    {file = "coverage-7.6.12-cp313-cp313t-win32.whl", hash = "sha256:eb5507795caabd9b2ae3f1adc95f67b1104971c22c624bb354232d65c4fc90b3"},
-    {file = "coverage-7.6.12-cp313-cp313t-win_amd64.whl", hash = "sha256:f60a297c3987c6c02ffb29effc70eadcbb412fe76947d394a1091a3615948e2f"},
-    {file = "coverage-7.6.12-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e7575ab65ca8399c8c4f9a7d61bbd2d204c8b8e447aab9d355682205c9dd948d"},
-    {file = "coverage-7.6.12-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8161d9fbc7e9fe2326de89cd0abb9f3599bccc1287db0aba285cb68d204ce929"},
-    {file = "coverage-7.6.12-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3a1e465f398c713f1b212400b4e79a09829cd42aebd360362cd89c5bdc44eb87"},
-    {file = "coverage-7.6.12-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f25d8b92a4e31ff1bd873654ec367ae811b3a943583e05432ea29264782dc32c"},
-    {file = "coverage-7.6.12-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a936309a65cc5ca80fa9f20a442ff9e2d06927ec9a4f54bcba9c14c066323f2"},
-    {file = "coverage-7.6.12-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:aa6f302a3a0b5f240ee201297fff0bbfe2fa0d415a94aeb257d8b461032389bd"},
-    {file = "coverage-7.6.12-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:f973643ef532d4f9be71dd88cf7588936685fdb576d93a79fe9f65bc337d9d73"},
-    {file = "coverage-7.6.12-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:78f5243bb6b1060aed6213d5107744c19f9571ec76d54c99cc15938eb69e0e86"},
-    {file = "coverage-7.6.12-cp39-cp39-win32.whl", hash = "sha256:69e62c5034291c845fc4df7f8155e8544178b6c774f97a99e2734b05eb5bed31"},
-    {file = "coverage-7.6.12-cp39-cp39-win_amd64.whl", hash = "sha256:b01a840ecc25dce235ae4c1b6a0daefb2a203dba0e6e980637ee9c2f6ee0df57"},
-    {file = "coverage-7.6.12-pp39.pp310-none-any.whl", hash = "sha256:7e39e845c4d764208e7b8f6a21c541ade741e2c41afabdfa1caa28687a3c98cf"},
-    {file = "coverage-7.6.12-py3-none-any.whl", hash = "sha256:eb8668cfbc279a536c633137deeb9435d2962caec279c3f8cf8b91fff6ff8953"},
-    {file = "coverage-7.6.12.tar.gz", hash = "sha256:48cfc4641d95d34766ad41d9573cc0f22a48aa88d22657a1fe01dca0dbae4de2"},
+    {file = "coverage-7.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2931f66991175369859b5fd58529cd4b73582461877ecfd859b6549869287ffe"},
+    {file = "coverage-7.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:52a523153c568d2c0ef8826f6cc23031dc86cffb8c6aeab92c4ff776e7951b28"},
+    {file = "coverage-7.8.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5c8a5c139aae4c35cbd7cadca1df02ea8cf28a911534fc1b0456acb0b14234f3"},
+    {file = "coverage-7.8.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5a26c0c795c3e0b63ec7da6efded5f0bc856d7c0b24b2ac84b4d1d7bc578d676"},
+    {file = "coverage-7.8.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:821f7bcbaa84318287115d54becb1915eece6918136c6f91045bb84e2f88739d"},
+    {file = "coverage-7.8.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a321c61477ff8ee705b8a5fed370b5710c56b3a52d17b983d9215861e37b642a"},
+    {file = "coverage-7.8.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:ed2144b8a78f9d94d9515963ed273d620e07846acd5d4b0a642d4849e8d91a0c"},
+    {file = "coverage-7.8.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:042e7841a26498fff7a37d6fda770d17519982f5b7d8bf5278d140b67b61095f"},
+    {file = "coverage-7.8.0-cp310-cp310-win32.whl", hash = "sha256:f9983d01d7705b2d1f7a95e10bbe4091fabc03a46881a256c2787637b087003f"},
+    {file = "coverage-7.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:5a570cd9bd20b85d1a0d7b009aaf6c110b52b5755c17be6962f8ccd65d1dbd23"},
+    {file = "coverage-7.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e7ac22a0bb2c7c49f441f7a6d46c9c80d96e56f5a8bc6972529ed43c8b694e27"},
+    {file = "coverage-7.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bf13d564d310c156d1c8e53877baf2993fb3073b2fc9f69790ca6a732eb4bfea"},
+    {file = "coverage-7.8.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5761c70c017c1b0d21b0815a920ffb94a670c8d5d409d9b38857874c21f70d7"},
+    {file = "coverage-7.8.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e5ff52d790c7e1628241ffbcaeb33e07d14b007b6eb00a19320c7b8a7024c040"},
+    {file = "coverage-7.8.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d39fc4817fd67b3915256af5dda75fd4ee10621a3d484524487e33416c6f3543"},
+    {file = "coverage-7.8.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b44674870709017e4b4036e3d0d6c17f06a0e6d4436422e0ad29b882c40697d2"},
+    {file = "coverage-7.8.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8f99eb72bf27cbb167b636eb1726f590c00e1ad375002230607a844d9e9a2318"},
+    {file = "coverage-7.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b571bf5341ba8c6bc02e0baeaf3b061ab993bf372d982ae509807e7f112554e9"},
+    {file = "coverage-7.8.0-cp311-cp311-win32.whl", hash = "sha256:e75a2ad7b647fd8046d58c3132d7eaf31b12d8a53c0e4b21fa9c4d23d6ee6d3c"},
+    {file = "coverage-7.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:3043ba1c88b2139126fc72cb48574b90e2e0546d4c78b5299317f61b7f718b78"},
+    {file = "coverage-7.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:bbb5cc845a0292e0c520656d19d7ce40e18d0e19b22cb3e0409135a575bf79fc"},
+    {file = "coverage-7.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4dfd9a93db9e78666d178d4f08a5408aa3f2474ad4d0e0378ed5f2ef71640cb6"},
+    {file = "coverage-7.8.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f017a61399f13aa6d1039f75cd467be388d157cd81f1a119b9d9a68ba6f2830d"},
+    {file = "coverage-7.8.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0915742f4c82208ebf47a2b154a5334155ed9ef9fe6190674b8a46c2fb89cb05"},
+    {file = "coverage-7.8.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a40fcf208e021eb14b0fac6bdb045c0e0cab53105f93ba0d03fd934c956143a"},
+    {file = "coverage-7.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a1f406a8e0995d654b2ad87c62caf6befa767885301f3b8f6f73e6f3c31ec3a6"},
+    {file = "coverage-7.8.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:77af0f6447a582fdc7de5e06fa3757a3ef87769fbb0fdbdeba78c23049140a47"},
+    {file = "coverage-7.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f2d32f95922927186c6dbc8bc60df0d186b6edb828d299ab10898ef3f40052fe"},
+    {file = "coverage-7.8.0-cp312-cp312-win32.whl", hash = "sha256:769773614e676f9d8e8a0980dd7740f09a6ea386d0f383db6821df07d0f08545"},
+    {file = "coverage-7.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:e5d2b9be5b0693cf21eb4ce0ec8d211efb43966f6657807f6859aab3814f946b"},
+    {file = "coverage-7.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5ac46d0c2dd5820ce93943a501ac5f6548ea81594777ca585bf002aa8854cacd"},
+    {file = "coverage-7.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:771eb7587a0563ca5bb6f622b9ed7f9d07bd08900f7589b4febff05f469bea00"},
+    {file = "coverage-7.8.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42421e04069fb2cbcbca5a696c4050b84a43b05392679d4068acbe65449b5c64"},
+    {file = "coverage-7.8.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:554fec1199d93ab30adaa751db68acec2b41c5602ac944bb19187cb9a41a8067"},
+    {file = "coverage-7.8.0-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5aaeb00761f985007b38cf463b1d160a14a22c34eb3f6a39d9ad6fc27cb73008"},
+    {file = "coverage-7.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:581a40c7b94921fffd6457ffe532259813fc68eb2bdda60fa8cc343414ce3733"},
+    {file = "coverage-7.8.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:f319bae0321bc838e205bf9e5bc28f0a3165f30c203b610f17ab5552cff90323"},
+    {file = "coverage-7.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:04bfec25a8ef1c5f41f5e7e5c842f6b615599ca8ba8391ec33a9290d9d2db3a3"},
+    {file = "coverage-7.8.0-cp313-cp313-win32.whl", hash = "sha256:dd19608788b50eed889e13a5d71d832edc34fc9dfce606f66e8f9f917eef910d"},
+    {file = "coverage-7.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:a9abbccd778d98e9c7e85038e35e91e67f5b520776781d9a1e2ee9d400869487"},
+    {file = "coverage-7.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:18c5ae6d061ad5b3e7eef4363fb27a0576012a7447af48be6c75b88494c6cf25"},
+    {file = "coverage-7.8.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:95aa6ae391a22bbbce1b77ddac846c98c5473de0372ba5c463480043a07bff42"},
+    {file = "coverage-7.8.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e013b07ba1c748dacc2a80e69a46286ff145935f260eb8c72df7185bf048f502"},
+    {file = "coverage-7.8.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d766a4f0e5aa1ba056ec3496243150698dc0481902e2b8559314368717be82b1"},
+    {file = "coverage-7.8.0-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad80e6b4a0c3cb6f10f29ae4c60e991f424e6b14219d46f1e7d442b938ee68a4"},
+    {file = "coverage-7.8.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b87eb6fc9e1bb8f98892a2458781348fa37e6925f35bb6ceb9d4afd54ba36c73"},
+    {file = "coverage-7.8.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:d1ba00ae33be84066cfbe7361d4e04dec78445b2b88bdb734d0d1cbab916025a"},
+    {file = "coverage-7.8.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f3c38e4e5ccbdc9198aecc766cedbb134b2d89bf64533973678dfcf07effd883"},
+    {file = "coverage-7.8.0-cp313-cp313t-win32.whl", hash = "sha256:379fe315e206b14e21db5240f89dc0774bdd3e25c3c58c2c733c99eca96f1ada"},
+    {file = "coverage-7.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2e4b6b87bb0c846a9315e3ab4be2d52fac905100565f4b92f02c445c8799e257"},
+    {file = "coverage-7.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fa260de59dfb143af06dcf30c2be0b200bed2a73737a8a59248fcb9fa601ef0f"},
+    {file = "coverage-7.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:96121edfa4c2dfdda409877ea8608dd01de816a4dc4a0523356067b305e4e17a"},
+    {file = "coverage-7.8.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b8af63b9afa1031c0ef05b217faa598f3069148eeee6bb24b79da9012423b82"},
+    {file = "coverage-7.8.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:89b1f4af0d4afe495cd4787a68e00f30f1d15939f550e869de90a86efa7e0814"},
+    {file = "coverage-7.8.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94ec0be97723ae72d63d3aa41961a0b9a6f5a53ff599813c324548d18e3b9e8c"},
+    {file = "coverage-7.8.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:8a1d96e780bdb2d0cbb297325711701f7c0b6f89199a57f2049e90064c29f6bd"},
+    {file = "coverage-7.8.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:f1d8a2a57b47142b10374902777e798784abf400a004b14f1b0b9eaf1e528ba4"},
+    {file = "coverage-7.8.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:cf60dd2696b457b710dd40bf17ad269d5f5457b96442f7f85722bdb16fa6c899"},
+    {file = "coverage-7.8.0-cp39-cp39-win32.whl", hash = "sha256:be945402e03de47ba1872cd5236395e0f4ad635526185a930735f66710e1bd3f"},
+    {file = "coverage-7.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:90e7fbc6216ecaffa5a880cdc9c77b7418c1dcb166166b78dbc630d07f278cc3"},
+    {file = "coverage-7.8.0-pp39.pp310.pp311-none-any.whl", hash = "sha256:b8194fb8e50d556d5849753de991d390c5a1edeeba50f68e3a9253fbd8bf8ccd"},
+    {file = "coverage-7.8.0-py3-none-any.whl", hash = "sha256:dbf364b4c5e7bae9250528167dfe40219b62e2d573c854d74be213e1e52069f7"},
+    {file = "coverage-7.8.0.tar.gz", hash = "sha256:7a3d62b3b03b4b6fd41a085f3574874cf946cb4604d2b4d3e8dca8cd570ca501"},
 ]
 
 [package.dependencies]
@@ -854,14 +855,14 @@ pydocstyle = ">=2.1"
 
 [[package]]
 name = "google-auth"
-version = "2.38.0"
+version = "2.39.0"
 description = "Google Authentication Library"
 optional = false
 python-versions = ">=3.7"
 groups = ["integration"]
 files = [
-    {file = "google_auth-2.38.0-py2.py3-none-any.whl", hash = "sha256:e7dae6694313f434a2727bf2906f27ad259bae090d7aa896590d86feec3d9d4a"},
-    {file = "google_auth-2.38.0.tar.gz", hash = "sha256:8285113607d3b80a3f1543b75962447ba8a09fe85783432a784fdeef6ac094c4"},
+    {file = "google_auth-2.39.0-py2.py3-none-any.whl", hash = "sha256:0150b6711e97fb9f52fe599f55648950cc4540015565d8fbb31be2ad6e1548a2"},
+    {file = "google_auth-2.39.0.tar.gz", hash = "sha256:73222d43cdc35a3aeacbfdcaf73142a97839f10de930550d89ebfe1d0a00cde7"},
 ]
 
 [package.dependencies]
@@ -870,12 +871,14 @@ pyasn1-modules = ">=0.2.1"
 rsa = ">=3.1.4,<5"
 
 [package.extras]
-aiohttp = ["aiohttp (>=3.6.2,<4.0.0.dev0)", "requests (>=2.20.0,<3.0.0.dev0)"]
+aiohttp = ["aiohttp (>=3.6.2,<4.0.0)", "requests (>=2.20.0,<3.0.0)"]
 enterprise-cert = ["cryptography", "pyopenssl"]
-pyjwt = ["cryptography (>=38.0.3)", "pyjwt (>=2.0)"]
-pyopenssl = ["cryptography (>=38.0.3)", "pyopenssl (>=20.0.0)"]
+pyjwt = ["cryptography (<39.0.0)", "cryptography (>=38.0.3)", "pyjwt (>=2.0)"]
+pyopenssl = ["cryptography (<39.0.0)", "cryptography (>=38.0.3)", "pyopenssl (>=20.0.0)"]
 reauth = ["pyu2f (>=0.1.5)"]
-requests = ["requests (>=2.20.0,<3.0.0.dev0)"]
+requests = ["requests (>=2.20.0,<3.0.0)"]
+testing = ["aiohttp (<3.10.0)", "aiohttp (>=3.6.2,<4.0.0)", "aioresponses", "cryptography (<39.0.0)", "cryptography (>=38.0.3)", "flask", "freezegun", "grpcio", "mock", "oauth2client", "packaging", "pyjwt (>=2.0)", "pyopenssl (<24.3.0)", "pyopenssl (>=20.0.0)", "pytest", "pytest-asyncio", "pytest-cov", "pytest-localserver", "pyu2f (>=0.1.5)", "requests (>=2.20.0,<3.0.0)", "responses", "urllib3"]
+urllib3 = ["packaging", "urllib3"]
 
 [[package]]
 name = "hvac"
@@ -912,14 +915,14 @@ all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2
 
 [[package]]
 name = "iniconfig"
-version = "2.0.0"
+version = "2.1.0"
 description = "brain-dead simple config-ini parsing"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 groups = ["integration", "unit"]
 files = [
-    {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
-    {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
+    {file = "iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"},
+    {file = "iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"},
 ]
 
 [[package]]
@@ -941,14 +944,14 @@ tomli = {version = "*", markers = "python_version > \"3.6\" and python_version <
 
 [[package]]
 name = "ipython"
-version = "8.33.0"
+version = "8.35.0"
 description = "IPython: Productive Interactive Computing"
 optional = false
 python-versions = ">=3.10"
 groups = ["integration"]
 files = [
-    {file = "ipython-8.33.0-py3-none-any.whl", hash = "sha256:aa5b301dfe1eaf0167ff3238a6825f810a029c9dad9d3f1597f30bd5ff65cc44"},
-    {file = "ipython-8.33.0.tar.gz", hash = "sha256:4c3e36a6dfa9e8e3702bd46f3df668624c975a22ff340e96ea7277afbd76217d"},
+    {file = "ipython-8.35.0-py3-none-any.whl", hash = "sha256:e6b7470468ba6f1f0a7b116bb688a3ece2f13e2f94138e508201fad677a788ba"},
+    {file = "ipython-8.35.0.tar.gz", hash = "sha256:d200b7d93c3f5883fc36ab9ce28a18249c7706e51347681f80a0aef9895f2520"},
 ]
 
 [package.dependencies]
@@ -976,7 +979,7 @@ notebook = ["ipywidgets", "notebook"]
 parallel = ["ipyparallel"]
 qtconsole = ["qtconsole"]
 test = ["packaging", "pickleshare", "pytest", "pytest-asyncio (<0.22)", "testpath"]
-test-extra = ["curio", "ipython[test]", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.23)", "pandas", "trio"]
+test-extra = ["curio", "ipython[test]", "jupyter_ai", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.23)", "pandas", "trio"]
 
 [[package]]
 name = "isodate"
@@ -1285,18 +1288,18 @@ files = [
 
 [[package]]
 name = "msal"
-version = "1.31.1"
+version = "1.32.0"
 description = "The Microsoft Authentication Library (MSAL) for Python library enables your app to access the Microsoft Cloud by supporting authentication of users with Microsoft Azure Active Directory accounts (AAD) and Microsoft Accounts (MSA) using industry standard OAuth2 and OpenID Connect."
 optional = false
 python-versions = ">=3.7"
 groups = ["integration"]
 files = [
-    {file = "msal-1.31.1-py3-none-any.whl", hash = "sha256:29d9882de247e96db01386496d59f29035e5e841bcac892e6d7bf4390bf6bd17"},
-    {file = "msal-1.31.1.tar.gz", hash = "sha256:11b5e6a3f802ffd3a72107203e20c4eac6ef53401961b880af2835b723d80578"},
+    {file = "msal-1.32.0-py3-none-any.whl", hash = "sha256:9dbac5384a10bbbf4dae5c7ea0d707d14e087b92c5aa4954b3feaa2d1aa0bcb7"},
+    {file = "msal-1.32.0.tar.gz", hash = "sha256:5445fe3af1da6be484991a7ab32eaa82461dc2347de105b76af92c610c3335c2"},
 ]
 
 [package.dependencies]
-cryptography = ">=2.5,<46"
+cryptography = ">=2.5,<47"
 PyJWT = {version = ">=1.0.0,<3", extras = ["crypto"]}
 requests = ">=2.0.0,<3"
 
@@ -1305,19 +1308,21 @@ broker = ["pymsalruntime (>=0.14,<0.18)", "pymsalruntime (>=0.17,<0.18)"]
 
 [[package]]
 name = "msal-extensions"
-version = "1.2.0"
+version = "1.3.1"
 description = "Microsoft Authentication Library extensions (MSAL EX) provides a persistence API that can save your data on disk, encrypted on Windows, macOS and Linux. Concurrent data access will be coordinated by a file lock mechanism."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.9"
 groups = ["integration"]
 files = [
-    {file = "msal_extensions-1.2.0-py3-none-any.whl", hash = "sha256:cf5ba83a2113fa6dc011a254a72f1c223c88d7dfad74cc30617c4679a417704d"},
-    {file = "msal_extensions-1.2.0.tar.gz", hash = "sha256:6f41b320bfd2933d631a215c91ca0dd3e67d84bd1a2f50ce917d5874ec646bef"},
+    {file = "msal_extensions-1.3.1-py3-none-any.whl", hash = "sha256:96d3de4d034504e969ac5e85bae8106c8373b5c6568e4c8fa7af2eca9dbe6bca"},
+    {file = "msal_extensions-1.3.1.tar.gz", hash = "sha256:c5b0fd10f65ef62b5f1d62f4251d51cbcaf003fcedae8c91b040a488614be1a4"},
 ]
 
 [package.dependencies]
 msal = ">=1.29,<2"
-portalocker = ">=1.4,<3"
+
+[package.extras]
+portalocker = ["portalocker (>=1.4,<4)"]
 
 [[package]]
 name = "mypy-extensions"
@@ -1375,39 +1380,39 @@ kerberos = ["requests_kerberos"]
 
 [[package]]
 name = "ops"
-version = "2.19.0"
+version = "2.20.0"
 description = "The Python library behind great charms"
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "charm-libs", "integration", "unit"]
 files = [
-    {file = "ops-2.19.0-py3-none-any.whl", hash = "sha256:4d17bff056a5a0ec97529d845fecc78d6322f34803d169109db5cab561b0bb51"},
-    {file = "ops-2.19.0.tar.gz", hash = "sha256:d30cbdc422391e3513650ed0ff6acef7132f7ec3d20e9e7acfb02b901d0aac2a"},
+    {file = "ops-2.20.0-py3-none-any.whl", hash = "sha256:94791a4b45f00c6902494a4934480c85947880b27f5ebf3a0ec32e8cc6279c99"},
+    {file = "ops-2.20.0.tar.gz", hash = "sha256:be1dcfd0bb748839fbc200bbd073a6acf9648401c3729db22d8594ebb4301e05"},
 ]
 
 [package.dependencies]
-ops-scenario = {version = ">=7.0.5,<8", optional = true, markers = "extra == \"testing\""}
+ops-scenario = {version = "7.20.0", optional = true, markers = "extra == \"testing\""}
 PyYAML = "==6.*"
 websocket-client = "==1.*"
 
 [package.extras]
 docs = ["canonical-sphinx-extensions", "furo", "linkify-it-py", "myst-parser", "pyspelling", "sphinx (>=8.0.0,<8.1.0)", "sphinx-autobuild", "sphinx-copybutton", "sphinx-design", "sphinx-notfound-page", "sphinx-tabs", "sphinxcontrib-jquery", "sphinxext-opengraph"]
-testing = ["ops-scenario (>=7.0.5,<8)"]
+testing = ["ops-scenario (==7.20.0)"]
 
 [[package]]
 name = "ops-scenario"
-version = "7.2.0"
+version = "7.20.0"
 description = "Python library providing a state-transition testing API for Operator Framework charms."
 optional = false
 python-versions = ">=3.8"
 groups = ["unit"]
 files = [
-    {file = "ops_scenario-7.2.0-py3-none-any.whl", hash = "sha256:836be56a6850dc990eb4a06b0fa5311dda66ae45faa24bbfe72b34e024ee521f"},
-    {file = "ops_scenario-7.2.0.tar.gz", hash = "sha256:11802302c803e18b205d00210031cf99d3d0b965d7ca3a78a28bdb7d68a1e4a7"},
+    {file = "ops_scenario-7.20.0-py3-none-any.whl", hash = "sha256:ee8defa368751d819e3b8ae08de672fa281af16274567f022c42a5f2c6c584a3"},
+    {file = "ops_scenario-7.20.0.tar.gz", hash = "sha256:f1c058dac51bb953389cbddedbf131fe545b9932ae8fe32c1e701833b31ea88b"},
 ]
 
 [package.dependencies]
-ops = ">=2.18,<3.0"
+ops = "2.20.0"
 PyYAML = ">=6.0.1"
 
 [[package]]
@@ -1532,20 +1537,20 @@ ptyprocess = ">=0.5"
 
 [[package]]
 name = "platformdirs"
-version = "4.3.6"
+version = "4.3.7"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["format", "lint"]
 files = [
-    {file = "platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb"},
-    {file = "platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907"},
+    {file = "platformdirs-4.3.7-py3-none-any.whl", hash = "sha256:a03875334331946f13c549dbd8f4bac7a13a50a895a0eb1e8c6a8ace80d40a94"},
+    {file = "platformdirs-4.3.7.tar.gz", hash = "sha256:eb437d586b6a0986388f0d6f74aa0cde27b48d0e3d66843640bfb6bdcdb6e351"},
 ]
 
 [package.extras]
-docs = ["furo (>=2024.8.6)", "proselint (>=0.14)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.2)", "pytest-cov (>=5)", "pytest-mock (>=3.14)"]
-type = ["mypy (>=1.11.2)"]
+docs = ["furo (>=2024.8.6)", "proselint (>=0.14)", "sphinx (>=8.1.3)", "sphinx-autodoc-typehints (>=3)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.4)", "pytest-cov (>=6)", "pytest-mock (>=3.14)"]
+type = ["mypy (>=1.14.1)"]
 
 [[package]]
 name = "pluggy"
@@ -1576,26 +1581,6 @@ files = [
 ]
 
 [[package]]
-name = "portalocker"
-version = "2.10.1"
-description = "Wraps the portalocker recipe for easy usage"
-optional = false
-python-versions = ">=3.8"
-groups = ["integration"]
-files = [
-    {file = "portalocker-2.10.1-py3-none-any.whl", hash = "sha256:53a5984ebc86a025552264b459b46a2086e269b21823cb572f8f28ee759e45bf"},
-    {file = "portalocker-2.10.1.tar.gz", hash = "sha256:ef1bf844e878ab08aee7e40184156e1151f228f103aa5c6bd0724cc330960f8f"},
-]
-
-[package.dependencies]
-pywin32 = {version = ">=226", markers = "platform_system == \"Windows\""}
-
-[package.extras]
-docs = ["sphinx (>=1.7.1)"]
-redis = ["redis"]
-tests = ["pytest (>=5.4.1)", "pytest-cov (>=2.8.1)", "pytest-mypy (>=0.8.0)", "pytest-timeout (>=2.1.0)", "redis", "sphinx (>=6.0.0)", "types-redis"]
-
-[[package]]
 name = "prompt-toolkit"
 version = "3.0.50"
 description = "Library for building powerful interactive command lines in Python"
@@ -1612,23 +1597,23 @@ wcwidth = "*"
 
 [[package]]
 name = "protobuf"
-version = "5.29.3"
+version = "5.29.4"
 description = ""
 optional = false
 python-versions = ">=3.8"
 groups = ["integration"]
 files = [
-    {file = "protobuf-5.29.3-cp310-abi3-win32.whl", hash = "sha256:3ea51771449e1035f26069c4c7fd51fba990d07bc55ba80701c78f886bf9c888"},
-    {file = "protobuf-5.29.3-cp310-abi3-win_amd64.whl", hash = "sha256:a4fa6f80816a9a0678429e84973f2f98cbc218cca434abe8db2ad0bffc98503a"},
-    {file = "protobuf-5.29.3-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:a8434404bbf139aa9e1300dbf989667a83d42ddda9153d8ab76e0d5dcaca484e"},
-    {file = "protobuf-5.29.3-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:daaf63f70f25e8689c072cfad4334ca0ac1d1e05a92fc15c54eb9cf23c3efd84"},
-    {file = "protobuf-5.29.3-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:c027e08a08be10b67c06bf2370b99c811c466398c357e615ca88c91c07f0910f"},
-    {file = "protobuf-5.29.3-cp38-cp38-win32.whl", hash = "sha256:84a57163a0ccef3f96e4b6a20516cedcf5bb3a95a657131c5c3ac62200d23252"},
-    {file = "protobuf-5.29.3-cp38-cp38-win_amd64.whl", hash = "sha256:b89c115d877892a512f79a8114564fb435943b59067615894c3b13cd3e1fa107"},
-    {file = "protobuf-5.29.3-cp39-cp39-win32.whl", hash = "sha256:0eb32bfa5219fc8d4111803e9a690658aa2e6366384fd0851064b963b6d1f2a7"},
-    {file = "protobuf-5.29.3-cp39-cp39-win_amd64.whl", hash = "sha256:6ce8cc3389a20693bfde6c6562e03474c40851b44975c9b2bf6df7d8c4f864da"},
-    {file = "protobuf-5.29.3-py3-none-any.whl", hash = "sha256:0a18ed4a24198528f2333802eb075e59dea9d679ab7a6c5efb017a59004d849f"},
-    {file = "protobuf-5.29.3.tar.gz", hash = "sha256:5da0f41edaf117bde316404bad1a486cb4ededf8e4a54891296f648e8e076620"},
+    {file = "protobuf-5.29.4-cp310-abi3-win32.whl", hash = "sha256:13eb236f8eb9ec34e63fc8b1d6efd2777d062fa6aaa68268fb67cf77f6839ad7"},
+    {file = "protobuf-5.29.4-cp310-abi3-win_amd64.whl", hash = "sha256:bcefcdf3976233f8a502d265eb65ea740c989bacc6c30a58290ed0e519eb4b8d"},
+    {file = "protobuf-5.29.4-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:307ecba1d852ec237e9ba668e087326a67564ef83e45a0189a772ede9e854dd0"},
+    {file = "protobuf-5.29.4-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:aec4962f9ea93c431d5714ed1be1c93f13e1a8618e70035ba2b0564d9e633f2e"},
+    {file = "protobuf-5.29.4-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:d7d3f7d1d5a66ed4942d4fefb12ac4b14a29028b209d4bfb25c68ae172059922"},
+    {file = "protobuf-5.29.4-cp38-cp38-win32.whl", hash = "sha256:1832f0515b62d12d8e6ffc078d7e9eb06969aa6dc13c13e1036e39d73bebc2de"},
+    {file = "protobuf-5.29.4-cp38-cp38-win_amd64.whl", hash = "sha256:476cb7b14914c780605a8cf62e38c2a85f8caff2e28a6a0bad827ec7d6c85d68"},
+    {file = "protobuf-5.29.4-cp39-cp39-win32.whl", hash = "sha256:fd32223020cb25a2cc100366f1dedc904e2d71d9322403224cdde5fdced0dabe"},
+    {file = "protobuf-5.29.4-cp39-cp39-win_amd64.whl", hash = "sha256:678974e1e3a9b975b8bc2447fca458db5f93a2fb6b0c8db46b6675b5b5346812"},
+    {file = "protobuf-5.29.4-py3-none-any.whl", hash = "sha256:3fde11b505e1597f71b875ef2fc52062b6a9740e5f7c8997ce878b6009145862"},
+    {file = "protobuf-5.29.4.tar.gz", hash = "sha256:4f1dfcd7997b31ef8f53ec82781ff434a28bf71d9102ddde14d076adcfc78c99"},
 ]
 
 [[package]]
@@ -1673,18 +1658,18 @@ files = [
 
 [[package]]
 name = "pyasn1-modules"
-version = "0.4.1"
+version = "0.4.2"
 description = "A collection of ASN.1-based protocols modules"
 optional = false
 python-versions = ">=3.8"
 groups = ["integration"]
 files = [
-    {file = "pyasn1_modules-0.4.1-py3-none-any.whl", hash = "sha256:49bfa96b45a292b711e986f222502c1c9a5e1f4e568fc30e2574a6c7d07838fd"},
-    {file = "pyasn1_modules-0.4.1.tar.gz", hash = "sha256:c28e2dbf9c06ad61c71a075c7e0f9fd0f1b0bb2d2ad4377f240d33ac2ab60a7c"},
+    {file = "pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a"},
+    {file = "pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6"},
 ]
 
 [package.dependencies]
-pyasn1 = ">=0.4.6,<0.7.0"
+pyasn1 = ">=0.6.1,<0.7.0"
 
 [[package]]
 name = "pycodestyle"
@@ -2075,43 +2060,14 @@ six = ">=1.5"
 
 [[package]]
 name = "pytz"
-version = "2025.1"
+version = "2025.2"
 description = "World timezone definitions, modern and historical"
 optional = false
 python-versions = "*"
 groups = ["integration"]
 files = [
-    {file = "pytz-2025.1-py2.py3-none-any.whl", hash = "sha256:89dd22dca55b46eac6eda23b2d72721bf1bdfef212645d81513ef5d03038de57"},
-    {file = "pytz-2025.1.tar.gz", hash = "sha256:c2db42be2a2518b28e65f9207c4d05e6ff547d1efa4086469ef855e4ab70178e"},
-]
-
-[[package]]
-name = "pywin32"
-version = "308"
-description = "Python for Window Extensions"
-optional = false
-python-versions = "*"
-groups = ["integration"]
-markers = "platform_system == \"Windows\""
-files = [
-    {file = "pywin32-308-cp310-cp310-win32.whl", hash = "sha256:796ff4426437896550d2981b9c2ac0ffd75238ad9ea2d3bfa67a1abd546d262e"},
-    {file = "pywin32-308-cp310-cp310-win_amd64.whl", hash = "sha256:4fc888c59b3c0bef905ce7eb7e2106a07712015ea1c8234b703a088d46110e8e"},
-    {file = "pywin32-308-cp310-cp310-win_arm64.whl", hash = "sha256:a5ab5381813b40f264fa3495b98af850098f814a25a63589a8e9eb12560f450c"},
-    {file = "pywin32-308-cp311-cp311-win32.whl", hash = "sha256:5d8c8015b24a7d6855b1550d8e660d8daa09983c80e5daf89a273e5c6fb5095a"},
-    {file = "pywin32-308-cp311-cp311-win_amd64.whl", hash = "sha256:575621b90f0dc2695fec346b2d6302faebd4f0f45c05ea29404cefe35d89442b"},
-    {file = "pywin32-308-cp311-cp311-win_arm64.whl", hash = "sha256:100a5442b7332070983c4cd03f2e906a5648a5104b8a7f50175f7906efd16bb6"},
-    {file = "pywin32-308-cp312-cp312-win32.whl", hash = "sha256:587f3e19696f4bf96fde9d8a57cec74a57021ad5f204c9e627e15c33ff568897"},
-    {file = "pywin32-308-cp312-cp312-win_amd64.whl", hash = "sha256:00b3e11ef09ede56c6a43c71f2d31857cf7c54b0ab6e78ac659497abd2834f47"},
-    {file = "pywin32-308-cp312-cp312-win_arm64.whl", hash = "sha256:9b4de86c8d909aed15b7011182c8cab38c8850de36e6afb1f0db22b8959e3091"},
-    {file = "pywin32-308-cp313-cp313-win32.whl", hash = "sha256:1c44539a37a5b7b21d02ab34e6a4d314e0788f1690d65b48e9b0b89f31abbbed"},
-    {file = "pywin32-308-cp313-cp313-win_amd64.whl", hash = "sha256:fd380990e792eaf6827fcb7e187b2b4b1cede0585e3d0c9e84201ec27b9905e4"},
-    {file = "pywin32-308-cp313-cp313-win_arm64.whl", hash = "sha256:ef313c46d4c18dfb82a2431e3051ac8f112ccee1a34f29c263c583c568db63cd"},
-    {file = "pywin32-308-cp37-cp37m-win32.whl", hash = "sha256:1f696ab352a2ddd63bd07430080dd598e6369152ea13a25ebcdd2f503a38f1ff"},
-    {file = "pywin32-308-cp37-cp37m-win_amd64.whl", hash = "sha256:13dcb914ed4347019fbec6697a01a0aec61019c1046c2b905410d197856326a6"},
-    {file = "pywin32-308-cp38-cp38-win32.whl", hash = "sha256:5794e764ebcabf4ff08c555b31bd348c9025929371763b2183172ff4708152f0"},
-    {file = "pywin32-308-cp38-cp38-win_amd64.whl", hash = "sha256:3b92622e29d651c6b783e368ba7d6722b1634b8e70bd376fd7610fe1992e19de"},
-    {file = "pywin32-308-cp39-cp39-win32.whl", hash = "sha256:7873ca4dc60ab3287919881a7d4f88baee4a6e639aa6962de25a98ba6b193341"},
-    {file = "pywin32-308-cp39-cp39-win_amd64.whl", hash = "sha256:71b3322d949b4cc20776436a9c9ba0eeedcbc9c650daa536df63f0ff111bb920"},
+    {file = "pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00"},
+    {file = "pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3"},
 ]
 
 [[package]]
@@ -2237,14 +2193,14 @@ rsa = ["oauthlib[signedtoken] (>=3.0.0)"]
 
 [[package]]
 name = "responses"
-version = "0.25.6"
+version = "0.25.7"
 description = "A utility library for mocking out the `requests` Python library."
 optional = false
 python-versions = ">=3.8"
 groups = ["unit"]
 files = [
-    {file = "responses-0.25.6-py3-none-any.whl", hash = "sha256:9cac8f21e1193bb150ec557875377e41ed56248aed94e4567ed644db564bacf1"},
-    {file = "responses-0.25.6.tar.gz", hash = "sha256:eae7ce61a9603004e76c05691e7c389e59652d91e94b419623c12bbfb8e331d8"},
+    {file = "responses-0.25.7-py3-none-any.whl", hash = "sha256:92ca17416c90fe6b35921f52179bff29332076bb32694c0df02dcac2c6bc043c"},
+    {file = "responses-0.25.7.tar.gz", hash = "sha256:8ebae11405d7a5df79ab6fd54277f6f2bc29b2d002d0dd2d5c632594d1ddcedb"},
 ]
 
 [package.dependencies]
@@ -2257,115 +2213,126 @@ tests = ["coverage (>=6.0.0)", "flake8", "mypy", "pytest (>=7.0.0)", "pytest-asy
 
 [[package]]
 name = "rpds-py"
-version = "0.23.1"
+version = "0.24.0"
 description = "Python bindings to Rust's persistent data structures (rpds)"
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "charm-libs"]
 files = [
-    {file = "rpds_py-0.23.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2a54027554ce9b129fc3d633c92fa33b30de9f08bc61b32c053dc9b537266fed"},
-    {file = "rpds_py-0.23.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b5ef909a37e9738d146519657a1aab4584018746a18f71c692f2f22168ece40c"},
-    {file = "rpds_py-0.23.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3ee9d6f0b38efb22ad94c3b68ffebe4c47865cdf4b17f6806d6c674e1feb4246"},
-    {file = "rpds_py-0.23.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f7356a6da0562190558c4fcc14f0281db191cdf4cb96e7604c06acfcee96df15"},
-    {file = "rpds_py-0.23.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9441af1d25aed96901f97ad83d5c3e35e6cd21a25ca5e4916c82d7dd0490a4fa"},
-    {file = "rpds_py-0.23.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3d8abf7896a91fb97e7977d1aadfcc2c80415d6dc2f1d0fca5b8d0df247248f3"},
-    {file = "rpds_py-0.23.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1b08027489ba8fedde72ddd233a5ea411b85a6ed78175f40285bd401bde7466d"},
-    {file = "rpds_py-0.23.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fee513135b5a58f3bb6d89e48326cd5aa308e4bcdf2f7d59f67c861ada482bf8"},
-    {file = "rpds_py-0.23.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:35d5631ce0af26318dba0ae0ac941c534453e42f569011585cb323b7774502a5"},
-    {file = "rpds_py-0.23.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:a20cb698c4a59c534c6701b1c24a968ff2768b18ea2991f886bd8985ce17a89f"},
-    {file = "rpds_py-0.23.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e9c206a1abc27e0588cf8b7c8246e51f1a16a103734f7750830a1ccb63f557a"},
-    {file = "rpds_py-0.23.1-cp310-cp310-win32.whl", hash = "sha256:d9f75a06ecc68f159d5d7603b734e1ff6daa9497a929150f794013aa9f6e3f12"},
-    {file = "rpds_py-0.23.1-cp310-cp310-win_amd64.whl", hash = "sha256:f35eff113ad430b5272bbfc18ba111c66ff525828f24898b4e146eb479a2cdda"},
-    {file = "rpds_py-0.23.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:b79f5ced71efd70414a9a80bbbfaa7160da307723166f09b69773153bf17c590"},
-    {file = "rpds_py-0.23.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c9e799dac1ffbe7b10c1fd42fe4cd51371a549c6e108249bde9cd1200e8f59b4"},
-    {file = "rpds_py-0.23.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:721f9c4011b443b6e84505fc00cc7aadc9d1743f1c988e4c89353e19c4a968ee"},
-    {file = "rpds_py-0.23.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f88626e3f5e57432e6191cd0c5d6d6b319b635e70b40be2ffba713053e5147dd"},
-    {file = "rpds_py-0.23.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:285019078537949cecd0190f3690a0b0125ff743d6a53dfeb7a4e6787af154f5"},
-    {file = "rpds_py-0.23.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b92f5654157de1379c509b15acec9d12ecf6e3bc1996571b6cb82a4302060447"},
-    {file = "rpds_py-0.23.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e768267cbe051dd8d1c5305ba690bb153204a09bf2e3de3ae530de955f5b5580"},
-    {file = "rpds_py-0.23.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c5334a71f7dc1160382d45997e29f2637c02f8a26af41073189d79b95d3321f1"},
-    {file = "rpds_py-0.23.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d6adb81564af0cd428910f83fa7da46ce9ad47c56c0b22b50872bc4515d91966"},
-    {file = "rpds_py-0.23.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:cafa48f2133d4daa028473ede7d81cd1b9f9e6925e9e4003ebdf77010ee02f35"},
-    {file = "rpds_py-0.23.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0fced9fd4a07a1ded1bac7e961ddd9753dd5d8b755ba8e05acba54a21f5f1522"},
-    {file = "rpds_py-0.23.1-cp311-cp311-win32.whl", hash = "sha256:243241c95174b5fb7204c04595852fe3943cc41f47aa14c3828bc18cd9d3b2d6"},
-    {file = "rpds_py-0.23.1-cp311-cp311-win_amd64.whl", hash = "sha256:11dd60b2ffddba85715d8a66bb39b95ddbe389ad2cfcf42c833f1bcde0878eaf"},
-    {file = "rpds_py-0.23.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3902df19540e9af4cc0c3ae75974c65d2c156b9257e91f5101a51f99136d834c"},
-    {file = "rpds_py-0.23.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:66f8d2a17e5838dd6fb9be6baaba8e75ae2f5fa6b6b755d597184bfcd3cb0eba"},
-    {file = "rpds_py-0.23.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:112b8774b0b4ee22368fec42749b94366bd9b536f8f74c3d4175d4395f5cbd31"},
-    {file = "rpds_py-0.23.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e0df046f2266e8586cf09d00588302a32923eb6386ced0ca5c9deade6af9a149"},
-    {file = "rpds_py-0.23.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0f3288930b947cbebe767f84cf618d2cbe0b13be476e749da0e6a009f986248c"},
-    {file = "rpds_py-0.23.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ce473a2351c018b06dd8d30d5da8ab5a0831056cc53b2006e2a8028172c37ce5"},
-    {file = "rpds_py-0.23.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d550d7e9e7d8676b183b37d65b5cd8de13676a738973d330b59dc8312df9c5dc"},
-    {file = "rpds_py-0.23.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e14f86b871ea74c3fddc9a40e947d6a5d09def5adc2076ee61fb910a9014fb35"},
-    {file = "rpds_py-0.23.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1bf5be5ba34e19be579ae873da515a2836a2166d8d7ee43be6ff909eda42b72b"},
-    {file = "rpds_py-0.23.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:d7031d493c4465dbc8d40bd6cafefef4bd472b17db0ab94c53e7909ee781b9ef"},
-    {file = "rpds_py-0.23.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:55ff4151cfd4bc635e51cfb1c59ac9f7196b256b12e3a57deb9e5742e65941ad"},
-    {file = "rpds_py-0.23.1-cp312-cp312-win32.whl", hash = "sha256:a9d3b728f5a5873d84cba997b9d617c6090ca5721caaa691f3b1a78c60adc057"},
-    {file = "rpds_py-0.23.1-cp312-cp312-win_amd64.whl", hash = "sha256:b03a8d50b137ee758e4c73638b10747b7c39988eb8e6cd11abb7084266455165"},
-    {file = "rpds_py-0.23.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:4caafd1a22e5eaa3732acb7672a497123354bef79a9d7ceed43387d25025e935"},
-    {file = "rpds_py-0.23.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:178f8a60fc24511c0eb756af741c476b87b610dba83270fce1e5a430204566a4"},
-    {file = "rpds_py-0.23.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c632419c3870507ca20a37c8f8f5352317aca097639e524ad129f58c125c61c6"},
-    {file = "rpds_py-0.23.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:698a79d295626ee292d1730bc2ef6e70a3ab135b1d79ada8fde3ed0047b65a10"},
-    {file = "rpds_py-0.23.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:271fa2184cf28bdded86bb6217c8e08d3a169fe0bbe9be5e8d96e8476b707122"},
-    {file = "rpds_py-0.23.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b91cceb5add79ee563bd1f70b30896bd63bc5f78a11c1f00a1e931729ca4f1f4"},
-    {file = "rpds_py-0.23.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3a6cb95074777f1ecda2ca4fa7717caa9ee6e534f42b7575a8f0d4cb0c24013"},
-    {file = "rpds_py-0.23.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:50fb62f8d8364978478b12d5f03bf028c6bc2af04082479299139dc26edf4c64"},
-    {file = "rpds_py-0.23.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c8f7e90b948dc9dcfff8003f1ea3af08b29c062f681c05fd798e36daa3f7e3e8"},
-    {file = "rpds_py-0.23.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:5b98b6c953e5c2bda51ab4d5b4f172617d462eebc7f4bfdc7c7e6b423f6da957"},
-    {file = "rpds_py-0.23.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2893d778d4671ee627bac4037a075168b2673c57186fb1a57e993465dbd79a93"},
-    {file = "rpds_py-0.23.1-cp313-cp313-win32.whl", hash = "sha256:2cfa07c346a7ad07019c33fb9a63cf3acb1f5363c33bc73014e20d9fe8b01cdd"},
-    {file = "rpds_py-0.23.1-cp313-cp313-win_amd64.whl", hash = "sha256:3aaf141d39f45322e44fc2c742e4b8b4098ead5317e5f884770c8df0c332da70"},
-    {file = "rpds_py-0.23.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:759462b2d0aa5a04be5b3e37fb8183615f47014ae6b116e17036b131985cb731"},
-    {file = "rpds_py-0.23.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3e9212f52074fc9d72cf242a84063787ab8e21e0950d4d6709886fb62bcb91d5"},
-    {file = "rpds_py-0.23.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9e9f3a3ac919406bc0414bbbd76c6af99253c507150191ea79fab42fdb35982a"},
-    {file = "rpds_py-0.23.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c04ca91dda8a61584165825907f5c967ca09e9c65fe8966ee753a3f2b019fe1e"},
-    {file = "rpds_py-0.23.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4ab923167cfd945abb9b51a407407cf19f5bee35001221f2911dc85ffd35ff4f"},
-    {file = "rpds_py-0.23.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ed6f011bedca8585787e5082cce081bac3d30f54520097b2411351b3574e1219"},
-    {file = "rpds_py-0.23.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6959bb9928c5c999aba4a3f5a6799d571ddc2c59ff49917ecf55be2bbb4e3722"},
-    {file = "rpds_py-0.23.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1ed7de3c86721b4e83ac440751329ec6a1102229aa18163f84c75b06b525ad7e"},
-    {file = "rpds_py-0.23.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5fb89edee2fa237584e532fbf78f0ddd1e49a47c7c8cfa153ab4849dc72a35e6"},
-    {file = "rpds_py-0.23.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:7e5413d2e2d86025e73f05510ad23dad5950ab8417b7fc6beaad99be8077138b"},
-    {file = "rpds_py-0.23.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d31ed4987d72aabdf521eddfb6a72988703c091cfc0064330b9e5f8d6a042ff5"},
-    {file = "rpds_py-0.23.1-cp313-cp313t-win32.whl", hash = "sha256:f3429fb8e15b20961efca8c8b21432623d85db2228cc73fe22756c6637aa39e7"},
-    {file = "rpds_py-0.23.1-cp313-cp313t-win_amd64.whl", hash = "sha256:d6f6512a90bd5cd9030a6237f5346f046c6f0e40af98657568fa45695d4de59d"},
-    {file = "rpds_py-0.23.1-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:09cd7dbcb673eb60518231e02874df66ec1296c01a4fcd733875755c02014b19"},
-    {file = "rpds_py-0.23.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c6760211eee3a76316cf328f5a8bd695b47b1626d21c8a27fb3b2473a884d597"},
-    {file = "rpds_py-0.23.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:72e680c1518733b73c994361e4b06441b92e973ef7d9449feec72e8ee4f713da"},
-    {file = "rpds_py-0.23.1-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ae28144c1daa61366205d32abd8c90372790ff79fc60c1a8ad7fd3c8553a600e"},
-    {file = "rpds_py-0.23.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c698d123ce5d8f2d0cd17f73336615f6a2e3bdcedac07a1291bb4d8e7d82a05a"},
-    {file = "rpds_py-0.23.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:98b257ae1e83f81fb947a363a274c4eb66640212516becaff7bef09a5dceacaa"},
-    {file = "rpds_py-0.23.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c9ff044eb07c8468594d12602291c635da292308c8c619244e30698e7fc455a"},
-    {file = "rpds_py-0.23.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7938c7b0599a05246d704b3f5e01be91a93b411d0d6cc62275f025293b8a11ce"},
-    {file = "rpds_py-0.23.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:e9cb79ecedfc156c0692257ac7ed415243b6c35dd969baa461a6888fc79f2f07"},
-    {file = "rpds_py-0.23.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:7b77e07233925bd33fc0022b8537774423e4c6680b6436316c5075e79b6384f4"},
-    {file = "rpds_py-0.23.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:a970bfaf130c29a679b1d0a6e0f867483cea455ab1535fb427566a475078f27f"},
-    {file = "rpds_py-0.23.1-cp39-cp39-win32.whl", hash = "sha256:4233df01a250b3984465faed12ad472f035b7cd5240ea3f7c76b7a7016084495"},
-    {file = "rpds_py-0.23.1-cp39-cp39-win_amd64.whl", hash = "sha256:c617d7453a80e29d9973b926983b1e700a9377dbe021faa36041c78537d7b08c"},
-    {file = "rpds_py-0.23.1-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c1f8afa346ccd59e4e5630d5abb67aba6a9812fddf764fd7eb11f382a345f8cc"},
-    {file = "rpds_py-0.23.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:fad784a31869747df4ac968a351e070c06ca377549e4ace94775aaa3ab33ee06"},
-    {file = "rpds_py-0.23.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5a96fcac2f18e5a0a23a75cd27ce2656c66c11c127b0318e508aab436b77428"},
-    {file = "rpds_py-0.23.1-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3e77febf227a1dc3220159355dba68faa13f8dca9335d97504abf428469fb18b"},
-    {file = "rpds_py-0.23.1-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26bb3e8de93443d55e2e748e9fd87deb5f8075ca7bc0502cfc8be8687d69a2ec"},
-    {file = "rpds_py-0.23.1-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:db7707dde9143a67b8812c7e66aeb2d843fe33cc8e374170f4d2c50bd8f2472d"},
-    {file = "rpds_py-0.23.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1eedaaccc9bb66581d4ae7c50e15856e335e57ef2734dbc5fd8ba3e2a4ab3cb6"},
-    {file = "rpds_py-0.23.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:28358c54fffadf0ae893f6c1050e8f8853e45df22483b7fff2f6ab6152f5d8bf"},
-    {file = "rpds_py-0.23.1-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:633462ef7e61d839171bf206551d5ab42b30b71cac8f10a64a662536e057fdef"},
-    {file = "rpds_py-0.23.1-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:a98f510d86f689fcb486dc59e6e363af04151e5260ad1bdddb5625c10f1e95f8"},
-    {file = "rpds_py-0.23.1-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:e0397dd0b3955c61ef9b22838144aa4bef6f0796ba5cc8edfc64d468b93798b4"},
-    {file = "rpds_py-0.23.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:75307599f0d25bf6937248e5ac4e3bde5ea72ae6618623b86146ccc7845ed00b"},
-    {file = "rpds_py-0.23.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:3614d280bf7aab0d3721b5ce0e73434acb90a2c993121b6e81a1c15c665298ac"},
-    {file = "rpds_py-0.23.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:e5963ea87f88bddf7edd59644a35a0feecf75f8985430124c253612d4f7d27ae"},
-    {file = "rpds_py-0.23.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad76f44f70aac3a54ceb1813ca630c53415da3a24fd93c570b2dfb4856591017"},
-    {file = "rpds_py-0.23.1-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2c6ae11e6e93728d86aafc51ced98b1658a0080a7dd9417d24bfb955bb09c3c2"},
-    {file = "rpds_py-0.23.1-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc869af5cba24d45fb0399b0cfdbcefcf6910bf4dee5d74036a57cf5264b3ff4"},
-    {file = "rpds_py-0.23.1-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c76b32eb2ab650a29e423525e84eb197c45504b1c1e6e17b6cc91fcfeb1a4b1d"},
-    {file = "rpds_py-0.23.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4263320ed887ed843f85beba67f8b2d1483b5947f2dc73a8b068924558bfeace"},
-    {file = "rpds_py-0.23.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7f9682a8f71acdf59fd554b82b1c12f517118ee72c0f3944eda461606dfe7eb9"},
-    {file = "rpds_py-0.23.1-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:754fba3084b70162a6b91efceee8a3f06b19e43dac3f71841662053c0584209a"},
-    {file = "rpds_py-0.23.1-pp39-pypy39_pp73-musllinux_1_2_i686.whl", hash = "sha256:a1c66e71ecfd2a4acf0e4bd75e7a3605afa8f9b28a3b497e4ba962719df2be57"},
-    {file = "rpds_py-0.23.1-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:8d67beb6002441faef8251c45e24994de32c4c8686f7356a1f601ad7c466f7c3"},
-    {file = "rpds_py-0.23.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:a1e17d8dc8e57d8e0fd21f8f0f0a5211b3fa258b2e444c2053471ef93fe25a00"},
-    {file = "rpds_py-0.23.1.tar.gz", hash = "sha256:7f3240dcfa14d198dba24b8b9cb3b108c06b68d45b7babd9eefc1038fdf7e707"},
+    {file = "rpds_py-0.24.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:006f4342fe729a368c6df36578d7a348c7c716be1da0a1a0f86e3021f8e98724"},
+    {file = "rpds_py-0.24.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2d53747da70a4e4b17f559569d5f9506420966083a31c5fbd84e764461c4444b"},
+    {file = "rpds_py-0.24.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8acd55bd5b071156bae57b555f5d33697998752673b9de554dd82f5b5352727"},
+    {file = "rpds_py-0.24.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7e80d375134ddb04231a53800503752093dbb65dad8dabacce2c84cccc78e964"},
+    {file = "rpds_py-0.24.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:60748789e028d2a46fc1c70750454f83c6bdd0d05db50f5ae83e2db500b34da5"},
+    {file = "rpds_py-0.24.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6e1daf5bf6c2be39654beae83ee6b9a12347cb5aced9a29eecf12a2d25fff664"},
+    {file = "rpds_py-0.24.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1b221c2457d92a1fb3c97bee9095c874144d196f47c038462ae6e4a14436f7bc"},
+    {file = "rpds_py-0.24.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:66420986c9afff67ef0c5d1e4cdc2d0e5262f53ad11e4f90e5e22448df485bf0"},
+    {file = "rpds_py-0.24.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:43dba99f00f1d37b2a0265a259592d05fcc8e7c19d140fe51c6e6f16faabeb1f"},
+    {file = "rpds_py-0.24.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:a88c0d17d039333a41d9bf4616bd062f0bd7aa0edeb6cafe00a2fc2a804e944f"},
+    {file = "rpds_py-0.24.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:cc31e13ce212e14a539d430428cd365e74f8b2d534f8bc22dd4c9c55b277b875"},
+    {file = "rpds_py-0.24.0-cp310-cp310-win32.whl", hash = "sha256:fc2c1e1b00f88317d9de6b2c2b39b012ebbfe35fe5e7bef980fd2a91f6100a07"},
+    {file = "rpds_py-0.24.0-cp310-cp310-win_amd64.whl", hash = "sha256:c0145295ca415668420ad142ee42189f78d27af806fcf1f32a18e51d47dd2052"},
+    {file = "rpds_py-0.24.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:2d3ee4615df36ab8eb16c2507b11e764dcc11fd350bbf4da16d09cda11fcedef"},
+    {file = "rpds_py-0.24.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e13ae74a8a3a0c2f22f450f773e35f893484fcfacb00bb4344a7e0f4f48e1f97"},
+    {file = "rpds_py-0.24.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf86f72d705fc2ef776bb7dd9e5fbba79d7e1f3e258bf9377f8204ad0fc1c51e"},
+    {file = "rpds_py-0.24.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c43583ea8517ed2e780a345dd9960896afc1327e8cf3ac8239c167530397440d"},
+    {file = "rpds_py-0.24.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4cd031e63bc5f05bdcda120646a0d32f6d729486d0067f09d79c8db5368f4586"},
+    {file = "rpds_py-0.24.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:34d90ad8c045df9a4259c47d2e16a3f21fdb396665c94520dbfe8766e62187a4"},
+    {file = "rpds_py-0.24.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e838bf2bb0b91ee67bf2b889a1a841e5ecac06dd7a2b1ef4e6151e2ce155c7ae"},
+    {file = "rpds_py-0.24.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:04ecf5c1ff4d589987b4d9882872f80ba13da7d42427234fce8f22efb43133bc"},
+    {file = "rpds_py-0.24.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:630d3d8ea77eabd6cbcd2ea712e1c5cecb5b558d39547ac988351195db433f6c"},
+    {file = "rpds_py-0.24.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:ebcb786b9ff30b994d5969213a8430cbb984cdd7ea9fd6df06663194bd3c450c"},
+    {file = "rpds_py-0.24.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:174e46569968ddbbeb8a806d9922f17cd2b524aa753b468f35b97ff9c19cb718"},
+    {file = "rpds_py-0.24.0-cp311-cp311-win32.whl", hash = "sha256:5ef877fa3bbfb40b388a5ae1cb00636a624690dcb9a29a65267054c9ea86d88a"},
+    {file = "rpds_py-0.24.0-cp311-cp311-win_amd64.whl", hash = "sha256:e274f62cbd274359eff63e5c7e7274c913e8e09620f6a57aae66744b3df046d6"},
+    {file = "rpds_py-0.24.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:d8551e733626afec514b5d15befabea0dd70a343a9f23322860c4f16a9430205"},
+    {file = "rpds_py-0.24.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e374c0ce0ca82e5b67cd61fb964077d40ec177dd2c4eda67dba130de09085c7"},
+    {file = "rpds_py-0.24.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d69d003296df4840bd445a5d15fa5b6ff6ac40496f956a221c4d1f6f7b4bc4d9"},
+    {file = "rpds_py-0.24.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8212ff58ac6dfde49946bea57474a386cca3f7706fc72c25b772b9ca4af6b79e"},
+    {file = "rpds_py-0.24.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:528927e63a70b4d5f3f5ccc1fa988a35456eb5d15f804d276709c33fc2f19bda"},
+    {file = "rpds_py-0.24.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a824d2c7a703ba6daaca848f9c3d5cb93af0505be505de70e7e66829affd676e"},
+    {file = "rpds_py-0.24.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:44d51febb7a114293ffd56c6cf4736cb31cd68c0fddd6aa303ed09ea5a48e029"},
+    {file = "rpds_py-0.24.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3fab5f4a2c64a8fb64fc13b3d139848817a64d467dd6ed60dcdd6b479e7febc9"},
+    {file = "rpds_py-0.24.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9be4f99bee42ac107870c61dfdb294d912bf81c3c6d45538aad7aecab468b6b7"},
+    {file = "rpds_py-0.24.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:564c96b6076a98215af52f55efa90d8419cc2ef45d99e314fddefe816bc24f91"},
+    {file = "rpds_py-0.24.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:75a810b7664c17f24bf2ffd7f92416c00ec84b49bb68e6a0d93e542406336b56"},
+    {file = "rpds_py-0.24.0-cp312-cp312-win32.whl", hash = "sha256:f6016bd950be4dcd047b7475fdf55fb1e1f59fc7403f387be0e8123e4a576d30"},
+    {file = "rpds_py-0.24.0-cp312-cp312-win_amd64.whl", hash = "sha256:998c01b8e71cf051c28f5d6f1187abbdf5cf45fc0efce5da6c06447cba997034"},
+    {file = "rpds_py-0.24.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:3d2d8e4508e15fc05b31285c4b00ddf2e0eb94259c2dc896771966a163122a0c"},
+    {file = "rpds_py-0.24.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0f00c16e089282ad68a3820fd0c831c35d3194b7cdc31d6e469511d9bffc535c"},
+    {file = "rpds_py-0.24.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:951cc481c0c395c4a08639a469d53b7d4afa252529a085418b82a6b43c45c240"},
+    {file = "rpds_py-0.24.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c9ca89938dff18828a328af41ffdf3902405a19f4131c88e22e776a8e228c5a8"},
+    {file = "rpds_py-0.24.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0ef550042a8dbcd657dfb284a8ee00f0ba269d3f2286b0493b15a5694f9fe8"},
+    {file = "rpds_py-0.24.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b2356688e5d958c4d5cb964af865bea84db29971d3e563fb78e46e20fe1848b"},
+    {file = "rpds_py-0.24.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78884d155fd15d9f64f5d6124b486f3d3f7fd7cd71a78e9670a0f6f6ca06fb2d"},
+    {file = "rpds_py-0.24.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6a4a535013aeeef13c5532f802708cecae8d66c282babb5cd916379b72110cf7"},
+    {file = "rpds_py-0.24.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:84e0566f15cf4d769dade9b366b7b87c959be472c92dffb70462dd0844d7cbad"},
+    {file = "rpds_py-0.24.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:823e74ab6fbaa028ec89615ff6acb409e90ff45580c45920d4dfdddb069f2120"},
+    {file = "rpds_py-0.24.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c61a2cb0085c8783906b2f8b1f16a7e65777823c7f4d0a6aaffe26dc0d358dd9"},
+    {file = "rpds_py-0.24.0-cp313-cp313-win32.whl", hash = "sha256:60d9b630c8025b9458a9d114e3af579a2c54bd32df601c4581bd054e85258143"},
+    {file = "rpds_py-0.24.0-cp313-cp313-win_amd64.whl", hash = "sha256:6eea559077d29486c68218178ea946263b87f1c41ae7f996b1f30a983c476a5a"},
+    {file = "rpds_py-0.24.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:d09dc82af2d3c17e7dd17120b202a79b578d79f2b5424bda209d9966efeed114"},
+    {file = "rpds_py-0.24.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5fc13b44de6419d1e7a7e592a4885b323fbc2f46e1f22151e3a8ed3b8b920405"},
+    {file = "rpds_py-0.24.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c347a20d79cedc0a7bd51c4d4b7dbc613ca4e65a756b5c3e57ec84bd43505b47"},
+    {file = "rpds_py-0.24.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:20f2712bd1cc26a3cc16c5a1bfee9ed1abc33d4cdf1aabd297fe0eb724df4272"},
+    {file = "rpds_py-0.24.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aad911555286884be1e427ef0dc0ba3929e6821cbeca2194b13dc415a462c7fd"},
+    {file = "rpds_py-0.24.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0aeb3329c1721c43c58cae274d7d2ca85c1690d89485d9c63a006cb79a85771a"},
+    {file = "rpds_py-0.24.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2a0f156e9509cee987283abd2296ec816225145a13ed0391df8f71bf1d789e2d"},
+    {file = "rpds_py-0.24.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:aa6800adc8204ce898c8a424303969b7aa6a5e4ad2789c13f8648739830323b7"},
+    {file = "rpds_py-0.24.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a18fc371e900a21d7392517c6f60fe859e802547309e94313cd8181ad9db004d"},
+    {file = "rpds_py-0.24.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:9168764133fd919f8dcca2ead66de0105f4ef5659cbb4fa044f7014bed9a1797"},
+    {file = "rpds_py-0.24.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5f6e3cec44ba05ee5cbdebe92d052f69b63ae792e7d05f1020ac5e964394080c"},
+    {file = "rpds_py-0.24.0-cp313-cp313t-win32.whl", hash = "sha256:8ebc7e65ca4b111d928b669713865f021b7773350eeac4a31d3e70144297baba"},
+    {file = "rpds_py-0.24.0-cp313-cp313t-win_amd64.whl", hash = "sha256:675269d407a257b8c00a6b58205b72eec8231656506c56fd429d924ca00bb350"},
+    {file = "rpds_py-0.24.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:a36b452abbf29f68527cf52e181fced56685731c86b52e852053e38d8b60bc8d"},
+    {file = "rpds_py-0.24.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8b3b397eefecec8e8e39fa65c630ef70a24b09141a6f9fc17b3c3a50bed6b50e"},
+    {file = "rpds_py-0.24.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdabcd3beb2a6dca7027007473d8ef1c3b053347c76f685f5f060a00327b8b65"},
+    {file = "rpds_py-0.24.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5db385bacd0c43f24be92b60c857cf760b7f10d8234f4bd4be67b5b20a7c0b6b"},
+    {file = "rpds_py-0.24.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8097b3422d020ff1c44effc40ae58e67d93e60d540a65649d2cdaf9466030791"},
+    {file = "rpds_py-0.24.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:493fe54318bed7d124ce272fc36adbf59d46729659b2c792e87c3b95649cdee9"},
+    {file = "rpds_py-0.24.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8aa362811ccdc1f8dadcc916c6d47e554169ab79559319ae9fae7d7752d0d60c"},
+    {file = "rpds_py-0.24.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d8f9a6e7fd5434817526815f09ea27f2746c4a51ee11bb3439065f5fc754db58"},
+    {file = "rpds_py-0.24.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:8205ee14463248d3349131bb8099efe15cd3ce83b8ef3ace63c7e976998e7124"},
+    {file = "rpds_py-0.24.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:921ae54f9ecba3b6325df425cf72c074cd469dea843fb5743a26ca7fb2ccb149"},
+    {file = "rpds_py-0.24.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:32bab0a56eac685828e00cc2f5d1200c548f8bc11f2e44abf311d6b548ce2e45"},
+    {file = "rpds_py-0.24.0-cp39-cp39-win32.whl", hash = "sha256:f5c0ed12926dec1dfe7d645333ea59cf93f4d07750986a586f511c0bc61fe103"},
+    {file = "rpds_py-0.24.0-cp39-cp39-win_amd64.whl", hash = "sha256:afc6e35f344490faa8276b5f2f7cbf71f88bc2cda4328e00553bd451728c571f"},
+    {file = "rpds_py-0.24.0-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:619ca56a5468f933d940e1bf431c6f4e13bef8e688698b067ae68eb4f9b30e3a"},
+    {file = "rpds_py-0.24.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:4b28e5122829181de1898c2c97f81c0b3246d49f585f22743a1246420bb8d399"},
+    {file = "rpds_py-0.24.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8e5ab32cf9eb3647450bc74eb201b27c185d3857276162c101c0f8c6374e098"},
+    {file = "rpds_py-0.24.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:208b3a70a98cf3710e97cabdc308a51cd4f28aa6e7bb11de3d56cd8b74bab98d"},
+    {file = "rpds_py-0.24.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bbc4362e06f950c62cad3d4abf1191021b2ffaf0b31ac230fbf0526453eee75e"},
+    {file = "rpds_py-0.24.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ebea2821cdb5f9fef44933617be76185b80150632736f3d76e54829ab4a3b4d1"},
+    {file = "rpds_py-0.24.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b9a4df06c35465ef4d81799999bba810c68d29972bf1c31db61bfdb81dd9d5bb"},
+    {file = "rpds_py-0.24.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d3aa13bdf38630da298f2e0d77aca967b200b8cc1473ea05248f6c5e9c9bdb44"},
+    {file = "rpds_py-0.24.0-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:041f00419e1da7a03c46042453598479f45be3d787eb837af382bfc169c0db33"},
+    {file = "rpds_py-0.24.0-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:d8754d872a5dfc3c5bf9c0e059e8107451364a30d9fd50f1f1a85c4fb9481164"},
+    {file = "rpds_py-0.24.0-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:896c41007931217a343eff197c34513c154267636c8056fb409eafd494c3dcdc"},
+    {file = "rpds_py-0.24.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:92558d37d872e808944c3c96d0423b8604879a3d1c86fdad508d7ed91ea547d5"},
+    {file = "rpds_py-0.24.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:f9e0057a509e096e47c87f753136c9b10d7a91842d8042c2ee6866899a717c0d"},
+    {file = "rpds_py-0.24.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d6e109a454412ab82979c5b1b3aee0604eca4bbf9a02693bb9df027af2bfa91a"},
+    {file = "rpds_py-0.24.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fc1c892b1ec1f8cbd5da8de287577b455e388d9c328ad592eabbdcb6fc93bee5"},
+    {file = "rpds_py-0.24.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9c39438c55983d48f4bb3487734d040e22dad200dab22c41e331cee145e7a50d"},
+    {file = "rpds_py-0.24.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d7e8ce990ae17dda686f7e82fd41a055c668e13ddcf058e7fb5e9da20b57793"},
+    {file = "rpds_py-0.24.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9ea7f4174d2e4194289cb0c4e172d83e79a6404297ff95f2875cf9ac9bced8ba"},
+    {file = "rpds_py-0.24.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb2954155bb8f63bb19d56d80e5e5320b61d71084617ed89efedb861a684baea"},
+    {file = "rpds_py-0.24.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:04f2b712a2206e13800a8136b07aaedc23af3facab84918e7aa89e4be0260032"},
+    {file = "rpds_py-0.24.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:eda5c1e2a715a4cbbca2d6d304988460942551e4e5e3b7457b50943cd741626d"},
+    {file = "rpds_py-0.24.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:9abc80fe8c1f87218db116016de575a7998ab1629078c90840e8d11ab423ee25"},
+    {file = "rpds_py-0.24.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:6a727fd083009bc83eb83d6950f0c32b3c94c8b80a9b667c87f4bd1274ca30ba"},
+    {file = "rpds_py-0.24.0-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:e0f3ef95795efcd3b2ec3fe0a5bcfb5dadf5e3996ea2117427e524d4fbf309c6"},
+    {file = "rpds_py-0.24.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:2c13777ecdbbba2077670285dd1fe50828c8742f6a4119dbef6f83ea13ad10fb"},
+    {file = "rpds_py-0.24.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79e8d804c2ccd618417e96720ad5cd076a86fa3f8cb310ea386a3e6229bae7d1"},
+    {file = "rpds_py-0.24.0-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fd822f019ccccd75c832deb7aa040bb02d70a92eb15a2f16c7987b7ad4ee8d83"},
+    {file = "rpds_py-0.24.0-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0047638c3aa0dbcd0ab99ed1e549bbf0e142c9ecc173b6492868432d8989a046"},
+    {file = "rpds_py-0.24.0-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a5b66d1b201cc71bc3081bc2f1fc36b0c1f268b773e03bbc39066651b9e18391"},
+    {file = "rpds_py-0.24.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dbcbb6db5582ea33ce46a5d20a5793134b5365110d84df4e30b9d37c6fd40ad3"},
+    {file = "rpds_py-0.24.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:63981feca3f110ed132fd217bf7768ee8ed738a55549883628ee3da75bb9cb78"},
+    {file = "rpds_py-0.24.0-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:3a55fc10fdcbf1a4bd3c018eea422c52cf08700cf99c28b5cb10fe97ab77a0d3"},
+    {file = "rpds_py-0.24.0-pp39-pypy39_pp73-musllinux_1_2_i686.whl", hash = "sha256:c30ff468163a48535ee7e9bf21bd14c7a81147c0e58a36c1078289a8ca7af0bd"},
+    {file = "rpds_py-0.24.0-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:369d9c6d4c714e36d4a03957b4783217a3ccd1e222cdd67d464a3a479fc17796"},
+    {file = "rpds_py-0.24.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:24795c099453e3721fda5d8ddd45f5dfcc8e5a547ce7b8e9da06fecc3832e26f"},
+    {file = "rpds_py-0.24.0.tar.gz", hash = "sha256:772cc1b2cd963e7e17e6cc55fe0371fb9c704d63e44cacec7b9b7f523b78919e"},
 ]
 
 [[package]]
@@ -2479,19 +2446,19 @@ crt = ["botocore[crt] (>=1.37.4,<2.0a.0)"]
 
 [[package]]
 name = "setuptools"
-version = "75.8.2"
+version = "78.1.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.9"
 groups = ["lint"]
 files = [
-    {file = "setuptools-75.8.2-py3-none-any.whl", hash = "sha256:558e47c15f1811c1fa7adbd0096669bf76c1d3f433f58324df69f3f5ecac4e8f"},
-    {file = "setuptools-75.8.2.tar.gz", hash = "sha256:4880473a969e5f23f2a2be3646b2dfd84af9028716d398e46192f84bc36900d2"},
+    {file = "setuptools-78.1.0-py3-none-any.whl", hash = "sha256:3e386e96793c8702ae83d17b853fb93d3e09ef82ec62722e61da5cd22376dcd8"},
+    {file = "setuptools-78.1.0.tar.gz", hash = "sha256:18fd474d4a82a5f83dac888df697af65afa82dec7323d09c3e37d1f14288da54"},
 ]
 
 [package.extras]
 check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)", "ruff (>=0.8.0)"]
-core = ["importlib_metadata (>=6)", "jaraco.collections", "jaraco.functools (>=4)", "jaraco.text (>=3.7)", "more_itertools", "more_itertools (>=8.8)", "packaging", "packaging (>=24.2)", "platformdirs (>=4.2.2)", "tomli (>=2.0.1)", "wheel (>=0.43.0)"]
+core = ["importlib_metadata (>=6)", "jaraco.functools (>=4)", "jaraco.text (>=3.7)", "more_itertools", "more_itertools (>=8.8)", "packaging (>=24.2)", "platformdirs (>=4.2.2)", "tomli (>=2.0.1)", "wheel (>=0.43.0)"]
 cover = ["pytest-cov"]
 doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
 enabler = ["pytest-enabler (>=2.2)"]
@@ -2658,14 +2625,14 @@ test = ["argcomplete (>=3.0.3)", "mypy (>=1.7.0)", "pre-commit", "pytest (>=7.0,
 
 [[package]]
 name = "typing-extensions"
-version = "4.12.2"
+version = "4.13.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "charm-libs", "format", "integration", "lint"]
 files = [
-    {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
-    {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
+    {file = "typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c"},
+    {file = "typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef"},
 ]
 markers = {format = "python_version < \"3.11\"", lint = "python_version < \"3.11\""}
 
@@ -2687,14 +2654,14 @@ typing-extensions = ">=3.7.4"
 
 [[package]]
 name = "urllib3"
-version = "2.3.0"
+version = "2.4.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "integration", "unit"]
 files = [
-    {file = "urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df"},
-    {file = "urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d"},
+    {file = "urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813"},
+    {file = "urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466"},
 ]
 
 [package.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ jsonschema = "^4.23.0"
 data-platform-helpers = "^0.1.4"
 poetry-core = "<2.0.0"
 
-
 [tool.poetry.group.charm-libs.dependencies]
 # data_platform_libs/v0/data_interfaces.py
 ops = ">=2.19.0"

--- a/src/opensearch.py
+++ b/src/opensearch.py
@@ -205,6 +205,19 @@ class OpenSearchSnap(OpenSearchDistribution):
         gid = grp.getgrnam("root").gr_gid
         os.chown(path, uid, gid)
 
+    def create_directories(self, dirs: list[str] = []) -> None:
+        """Create the directories defined in self.paths."""
+        for dir_path in dirs:
+            Path(dir_path).mkdir(parents=True, exist_ok=True)
+            self.setup_linux_perms(dir_path)
+
+    def setup_linux_perms(self, path):
+        """Create ubuntu:ubuntu user:group."""
+        uid = pwd.getpwnam("snap_daemon").pw_uid
+        gid = grp.getgrnam("root").gr_gid
+        os.chown(path, uid, gid)
+
+
 
 class OpenSearchTarball(OpenSearchDistribution):
     """Tarball distro of opensearch, only overrides properties and logic proper to the tar."""

--- a/src/opensearch.py
+++ b/src/opensearch.py
@@ -218,7 +218,6 @@ class OpenSearchSnap(OpenSearchDistribution):
         os.chown(path, uid, gid)
 
 
-
 class OpenSearchTarball(OpenSearchDistribution):
     """Tarball distro of opensearch, only overrides properties and logic proper to the tar."""
 

--- a/tests/integration/plugins/helpers.py
+++ b/tests/integration/plugins/helpers.py
@@ -26,10 +26,10 @@ logger = logging.getLogger(__name__)
 
 def generate_bulk_training_data(
     index_name: str,
-    vector_name: str,
     docs_count: int = 100,
     dimensions: int = 4,
     has_result: bool = False,
+    vector_name: Optional[str] = None,
 ) -> Tuple[str, List[str]]:
     random.seed("seed")
     print("The seed for randomness is: 'seed'")
@@ -45,6 +45,7 @@ def generate_bulk_training_data(
         inter = {vector_name: result_list[i]}
         if has_result:
             inter["price"] = float(responses[i])
+
         result += json.dumps(inter) + "\n"
     return result, result_list
 
@@ -129,3 +130,78 @@ async def create_index_and_bulk_insert(
     # Insert data in bulk
     await bulk_insert(ops_test, app, endpoint, payload)
     return payload_list
+
+
+@retry(
+    wait=wait_fixed(wait=10),
+    stop=stop_after_attempt(7),
+)
+async def mlcommons_register_model(
+    ops_test: OpsTest,
+    app: str,
+    unit_ip: str,
+    model_config: Dict[str, Any],
+) -> Optional[List[Dict[str, Any]]]:
+    """Uploads models."""
+    endpoint = f"https://{unit_ip}:9200/_plugins/_ml/models/_register"
+
+    resp = await http_request(ops_test, "POST", endpoint, payload=model_config, app=app)
+    logger.info(resp)
+    return resp["task_id"]
+
+
+@retry(
+    wait=wait_fixed(wait=10),
+    stop=stop_after_attempt(7),
+)
+async def mlcommons_wait_task_model(
+    ops_test: OpsTest,
+    app: str,
+    unit_ip: str,
+    task_id: str,
+) -> Optional[str]:
+    """Waits to load model and returns model_id or None."""
+    endpoint = f"https://{unit_ip}:9200/_plugins/_ml/tasks/{task_id}"
+
+    resp = await http_request(ops_test, "GET", endpoint, app=app)
+    logger.info(resp)
+    return resp["model_id"]
+
+
+@retry(
+    wait=wait_fixed(wait=10),
+    stop=stop_after_attempt(7),
+)
+async def mlcommons_load_model_to_node(
+    ops_test: OpsTest,
+    app: str,
+    unit_ip: str,
+    model_id: str,
+    node_ids: Dict[Any, Any] = {},
+) -> Optional[List[Dict[str, Any]]]:
+    """Loads model_id to the node."""
+    endpoint = f"https://{unit_ip}:9200/_plugins/_ml/models/{model_id}/_load"
+
+    resp = await http_request(ops_test, "POST", endpoint, payload=node_ids, app=app)
+    logger.info(resp)
+    return resp
+
+
+@retry(
+    wait=wait_fixed(wait=5),
+    stop=stop_after_attempt(5),
+)
+async def mlcommons_model_predict(
+    ops_test: OpsTest,
+    app: str,
+    unit_ip: str,
+    model_id: str,
+    prediction_type: str = "text_embedding",
+    prediction_configs: Dict[str, Any] = {},
+) -> str:
+    """Returns model prediction response."""
+    endpoint = f"https://{unit_ip}:9200/_plugins/_ml/_predict/{prediction_type}/{model_id}"
+
+    resp = await http_request(ops_test, "POST", endpoint, payload=prediction_configs, app=app)
+    logger.info(resp)
+    return resp

--- a/tests/integration/plugins/helpers.py
+++ b/tests/integration/plugins/helpers.py
@@ -188,6 +188,24 @@ async def mlcommons_load_model_to_node(
 
 
 @retry(
+    wait=wait_fixed(wait=10),
+    stop=stop_after_attempt(7),
+)
+async def mlcommons_deploy_model(
+    ops_test: OpsTest,
+    app: str,
+    unit_ip: str,
+    model_id: str,
+) -> Optional[List[Dict[str, Any]]]:
+    """Loads model_id to the node."""
+    endpoint = f"https://{unit_ip}:9200/_plugins/_ml/models/{model_id}/_deploy"
+
+    resp = await http_request(ops_test, "POST", endpoint, app=app)
+    logger.info(resp)
+    return resp
+
+
+@retry(
     wait=wait_fixed(wait=5),
     stop=stop_after_attempt(5),
 )

--- a/tests/integration/plugins/test_ml_commons.py
+++ b/tests/integration/plugins/test_ml_commons.py
@@ -9,7 +9,7 @@ import pytest
 from pytest_operator.plugin import OpsTest
 
 from ..ha.helpers import app_name
-from ..ha.helpers_data import create_index
+from ..ha.helpers_data import bulk_insert, create_index
 from ..ha.test_horizontal_scaling import IDLE_PERIOD
 from ..helpers import (
     APP_NAME,
@@ -23,6 +23,7 @@ from ..helpers import (
 from ..helpers_deployments import wait_until
 from ..tls.test_tls import TLS_CERTIFICATES_APP_NAME, TLS_STABLE_CHANNEL
 from .helpers import (
+    generate_bulk_training_data,
     mlcommons_load_model_to_node,
     mlcommons_model_predict,
     mlcommons_register_model,

--- a/tests/integration/plugins/test_ml_commons.py
+++ b/tests/integration/plugins/test_ml_commons.py
@@ -131,6 +131,7 @@ async def test_mlcommons_llm_model_register_and_prediction(ops_test: OpsTest) ->
     assert shape_count == len(result["inference_results"][0]["output"][0]["data"])
 
 
+@pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_mlcommons_kmeans_model(ops_test: OpsTest) -> None:
     """Uploads and runs the model. This method reuses the data index used for FAISS IVF."""

--- a/tests/integration/plugins/test_ml_commons.py
+++ b/tests/integration/plugins/test_ml_commons.py
@@ -9,7 +9,7 @@ import pytest
 from pytest_operator.plugin import OpsTest
 
 from ..ha.helpers import app_name
-from ..ha.helpers_data import bulk_insert, create_index
+from ..ha.helpers_data import create_index
 from ..ha.test_horizontal_scaling import IDLE_PERIOD
 from ..helpers import (
     APP_NAME,
@@ -27,15 +27,12 @@ from .helpers import (
     mlcommons_model_predict,
     mlcommons_register_model,
     mlcommons_wait_task_model,
-    mlcommons_deploy_model,
 )
 
 logger = logging.getLogger(__name__)
 
 
 TRAINING_END_TO_END_DATA_INDEX = "test_end_to_end"
-RAG_INGEST_PIPELINE_INDEX = "rag-ingest-pipeline-index"
-RAG_INGEST_PIPELINE_NAME = "rag-ingest-pipeline"
 
 
 @pytest.mark.group(1)
@@ -81,203 +78,47 @@ async def test_build_and_deploy_small_deployment(ops_test: OpsTest) -> None:
     assert len(ops_test.model.applications[APP_NAME].units) == 3
 
 
-# @pytest.mark.group(1)
-# @pytest.mark.abort_on_fail
-# async def test_mlcommons_llm_model_register_and_prediction(ops_test: OpsTest) -> None:
-#     """Uploads and runs the model."""
-#     app = (await app_name(ops_test)) or APP_NAME
-
-#     leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
-
-#     # Redefine sync-up job time
-#     await http_request(
-#         ops_test,
-#         "PUT",
-#         f"https://{leader_unit_ip}:9200/_cluster/settings",
-#         app=app,
-#         payload={"persistent": {"plugins.ml_commons.sync_up_job_interval_in_seconds": 600}},
-#     )
-
-#     task_id = await mlcommons_register_model(
-#         ops_test,
-#         app,
-#         leader_unit_ip,
-#         model_config={
-#             "name": "huggingface/sentence-transformers/all-MiniLM-L12-v2",
-#             "version": "1.0.1",
-#             "model_format": "TORCH_SCRIPT",
-#         },
-#     )
-
-#     model_id = await mlcommons_wait_task_model(ops_test, app, leader_unit_ip, task_id)
-#     assert model_id is not None, "The model_id is None when registering model"
-
-#     task_id = (await mlcommons_load_model_to_node(ops_test, app, leader_unit_ip, model_id)).get(
-#         "task_id", None
-#     )
-#     await mlcommons_wait_task_model(ops_test, app, leader_unit_ip, task_id)
-
-#     result = await mlcommons_model_predict(
-#         ops_test,
-#         app,
-#         leader_unit_ip,
-#         model_id,
-#         prediction_configs={
-#             "text_docs": ["This test worked?"],
-#             "return_number": True,
-#             "target_response": ["sentence_embedding"],
-#         },
-#     )
-#     shape_count = result["inference_results"][0]["output"][0]["shape"][0]
-#     assert shape_count > 0
-#     assert shape_count == len(result["inference_results"][0]["output"][0]["data"])
-
-
-# @pytest.mark.group(1)
-# @pytest.mark.abort_on_fail
-# async def test_mlcommons_kmeans_model(ops_test: OpsTest) -> None:
-#     """Uploads and runs the model. This method reuses the data index used for FAISS IVF."""
-#     app = (await app_name(ops_test)) or APP_NAME
-
-#     units = await get_application_unit_ids_ips(ops_test, app=app)
-#     leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
-
-#     await create_index(
-#         ops_test,
-#         app,
-#         leader_unit_ip,
-#         TRAINING_END_TO_END_DATA_INDEX,
-#         r_shards=len(units) - 1,
-#     )
-#     payload, _ = generate_bulk_training_data(
-#         TRAINING_END_TO_END_DATA_INDEX,
-#         docs_count=100,
-#         dimensions=4,
-#         has_result=True,
-#         vector_name=TRAINING_END_TO_END_DATA_INDEX + "_vector",
-#     )
-#     # Insert data in bulk
-#     await bulk_insert(ops_test, app, leader_unit_ip, payload)
-
-#     # Redefine sync-up job time
-#     await http_request(
-#         ops_test,
-#         "PUT",
-#         f"https://{leader_unit_ip}:9200/_cluster/settings",
-#         app=app,
-#         payload={"persistent": {"plugins.ml_commons.sync_up_job_interval_in_seconds": 600}},
-#     )
-
-#     # train kmeans
-#     output = await http_request(
-#         ops_test,
-#         "POST",
-#         f"https://{leader_unit_ip}:9200/_plugins/_ml/_train/kmeans",
-#         app=app,
-#         payload={
-#             "parameters": {"centroids": 3, "iterations": 10, "distance_type": "COSINE"},
-#             "input_query": {"_source": ["price"], "size": 100},
-#             "input_index": [TRAINING_END_TO_END_DATA_INDEX],
-#         },
-#     )
-#     print(output)
-#     assert output["status"] == "COMPLETED", "Failed during kmeans training"
-#     model_id = output["model_id"]
-
-#     task_id = (await mlcommons_load_model_to_node(ops_test, app, leader_unit_ip, model_id)).get(
-#         "task_id", None
-#     )
-#     await mlcommons_wait_task_model(ops_test, app, leader_unit_ip, task_id)
-
-#     result = await mlcommons_model_predict(
-#         ops_test,
-#         app,
-#         leader_unit_ip,
-#         model_id,
-#         prediction_type="kmeans",
-#         prediction_configs={
-#             "input_query": {"_source": ["price"], "size": 1},
-#             "input_index": [TRAINING_END_TO_END_DATA_INDEX],
-#         },
-#     )
-#     assert result["status"] == "COMPLETED"
-#     assert len(result["prediction_result"]["rows"]) > 0
-
-
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
-async def test_rag_part1_embedding_pipeline(ops_test: OpsTest) -> None:
-    """Deploys the RAG embedding model."""
+async def test_mlcommons_llm_model_register_and_prediction(ops_test: OpsTest) -> None:
+    """Uploads and runs the model."""
     app = (await app_name(ops_test)) or APP_NAME
 
     leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
 
-
-    import pdb; pdb.set_trace()
-
-
-    # Set parameters for the RAG
+    # Redefine sync-up job time
     await http_request(
         ops_test,
         "PUT",
         f"https://{leader_unit_ip}:9200/_cluster/settings",
         app=app,
-        payload={
-            "persistent": {
-                "plugins.ml_commons.memory_feature_enabled": True,
-                "plugins.ml_commons.rag_pipeline_feature_enabled": True,
-            }
-        },
+        payload={"persistent": {"plugins.ml_commons.sync_up_job_interval_in_seconds": 600}},
     )
 
-    # Create a model group
-    output = await http_request(
-        ops_test,
-        "POST",
-        f"https://{leader_unit_ip}:9200/_plugins/_ml/model_groups/_register",
-        app=app,
-        payload={
-            "name": "rag-model-group",
-            "description": "A model group for RAG use case models",
-        },
-    )
-    print(output)
-    assert output["status"] == "CREATED", "Failed during embedding model creation"
-    global rag_model_group_id
-    rag_model_group_id = output["model_group_id"]
-
-    # Set the embedding model
     task_id = await mlcommons_register_model(
         ops_test,
         app,
         leader_unit_ip,
         model_config={
-            "name": "huggingface/sentence-transformers/msmarco-distilbert-base-tas-b",
-            "version": "1.0.2",
-            "model_group_id": rag_model_group_id,
-            "model_format": "TORCH_SCRIPT"
+            "name": "huggingface/sentence-transformers/all-MiniLM-L12-v2",
+            "version": "1.0.1",
+            "model_format": "TORCH_SCRIPT",
         },
     )
-    print(task_id)
-    global rag_embedding_id
-    rag_embedding_id = await mlcommons_wait_task_model(ops_test, app, leader_unit_ip, task_id)
-    assert rag_embedding_id is not None, "The embedding_id is None when registering embedding model"
 
-    task_id = (await mlcommons_load_model_to_node(ops_test, app, leader_unit_ip, rag_embedding_id)).get(
-        "task_id", None
-    )
-    await mlcommons_wait_task_model(ops_test, app, leader_unit_ip, task_id)
-    task_id = (await mlcommons_deploy_model(ops_test, app, leader_unit_ip, rag_embedding_id)).get(
+    model_id = await mlcommons_wait_task_model(ops_test, app, leader_unit_ip, task_id)
+    assert model_id is not None, "The model_id is None when registering model"
+
+    task_id = (await mlcommons_load_model_to_node(ops_test, app, leader_unit_ip, model_id)).get(
         "task_id", None
     )
     await mlcommons_wait_task_model(ops_test, app, leader_unit_ip, task_id)
 
-    # Test the embedding model
     result = await mlcommons_model_predict(
         ops_test,
         app,
         leader_unit_ip,
-        rag_embedding_id,
+        model_id,
         prediction_configs={
             "text_docs": ["This test worked?"],
             "return_number": True,
@@ -291,111 +132,70 @@ async def test_rag_part1_embedding_pipeline(ops_test: OpsTest) -> None:
 
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
-async def test_rag_part2_create_ingest_pipeline(ops_test: OpsTest) -> None:
-    """Deploys the RAG pipeline."""
+async def test_mlcommons_kmeans_model(ops_test: OpsTest) -> None:
+    """Uploads and runs the model. This method reuses the data index used for FAISS IVF."""
     app = (await app_name(ops_test)) or APP_NAME
 
-
-    import pdb; pdb.set_trace()
-
-
-
-
-    leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
     units = await get_application_unit_ids_ips(ops_test, app=app)
-
-    output = await http_request(
-        ops_test,
-        "PUT",
-        f"https://{leader_unit_ip}:9200/_ingest/pipeline/{RAG_INGEST_PIPELINE_NAME}",
-        app=app,
-        payload={
-            "description": "An RAG ingest pipeline",
-            "processors": [
-                {
-                    "text_embedding": {
-                            "model_id": rag_embedding_id,
-                            "field_map": {
-                            "text": "sentence_embedding"
-                        }
-                    }
-                }
-            ]
-        },
-    )
-    print(output)
-    assert output["acknowledged"] == "true", "Failed during RAG pipeline creation"
+    leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
 
     await create_index(
         ops_test,
         app,
         leader_unit_ip,
-        RAG_INGEST_PIPELINE_INDEX,
+        TRAINING_END_TO_END_DATA_INDEX,
         r_shards=len(units) - 1,
-        extra_index_settings={"knn": "true", "default_pipeline": RAG_INGEST_PIPELINE_NAME},
-        extra_mappings={
-            "properties": {
-                "id": {
-                    "type": "text"
-                },
-                "sentence_embedding": {
-                    "type": "knn_vector",
-                    "dimension": 768,
-                    "method": {
-                    "name": "hnsw",
-                    "engine": "faiss",
-                    "space_type": "l2",
-                    "parameters": {
-                            "encoder": {
-                                "name": "sq",
-                                "parameters": {
-                                    "type": "fp16"
-                                }
-                            },
-                            "ef_construction": 256,
-                            "m": 8
-                        }
-                    }
-                },
-                "text": {
-                    "type": "text"
-                }
-            }
-        },
     )
+    payload, _ = generate_bulk_training_data(
+        TRAINING_END_TO_END_DATA_INDEX,
+        docs_count=100,
+        dimensions=4,
+        has_result=True,
+        vector_name=TRAINING_END_TO_END_DATA_INDEX + "_vector",
+    )
+    # Insert data in bulk
+    await bulk_insert(ops_test, app, leader_unit_ip, payload)
 
+    # Redefine sync-up job time
     await http_request(
         ops_test,
-        "POST",
-        f"https://{leader_unit_ip}:9200/{RAG_INGEST_PIPELINE_INDEX}/_doc",
+        "PUT",
+        f"https://{leader_unit_ip}:9200/_cluster/settings",
         app=app,
-        payload={
-            "text": "The best OS is Ubuntu.",
-        },
+        payload={"persistent": {"plugins.ml_commons.sync_up_job_interval_in_seconds": 600}},
     )
 
-    # Test the Neural Search
-    result = await http_request(
+    # train kmeans
+    output = await http_request(
         ops_test,
         "POST",
-        f"https://{leader_unit_ip}:9200/{RAG_INGEST_PIPELINE_INDEX}/_search",
+        f"https://{leader_unit_ip}:9200/_plugins/_ml/_train/kmeans",
         app=app,
         payload={
-            "_source": {
-                "excludes": [
-                    "sentence_embedding"
-                ]
-            },
-            "query": {
-                    "neural": {
-                    "sentence_embedding": {
-                        "query_text": "What is Ubuntu?",
-                        "model_id": rag_embedding_id,
-                        "k": 15
-                    }
-                }
-            }
+            "parameters": {"centroids": 3, "iterations": 10, "distance_type": "COSINE"},
+            "input_query": {"_source": ["price"], "size": 100},
+            "input_index": [TRAINING_END_TO_END_DATA_INDEX],
         },
     )
-    print(result)
-    assert result["hits"]["total"]["value"] > 0, "Failed during RAG pipeline creation"
+    print(output)
+    assert output["status"] == "COMPLETED", "Failed during kmeans training"
+    model_id = output["model_id"]
+
+    task_id = (await mlcommons_load_model_to_node(ops_test, app, leader_unit_ip, model_id)).get(
+        "task_id", None
+    )
+    await mlcommons_wait_task_model(ops_test, app, leader_unit_ip, task_id)
+
+    result = await mlcommons_model_predict(
+        ops_test,
+        app,
+        leader_unit_ip,
+        model_id,
+        prediction_type="kmeans",
+        prediction_configs={
+            "input_query": {"_source": ["price"], "size": 1},
+            "input_index": [TRAINING_END_TO_END_DATA_INDEX],
+        },
+    )
+    assert result["status"] == "COMPLETED"
+    assert len(result["prediction_result"]["rows"]) > 0

--- a/tests/integration/plugins/test_ml_commons.py
+++ b/tests/integration/plugins/test_ml_commons.py
@@ -23,17 +23,19 @@ from ..helpers import (
 from ..helpers_deployments import wait_until
 from ..tls.test_tls import TLS_CERTIFICATES_APP_NAME, TLS_STABLE_CHANNEL
 from .helpers import (
-    generate_bulk_training_data,
     mlcommons_load_model_to_node,
     mlcommons_model_predict,
     mlcommons_register_model,
     mlcommons_wait_task_model,
+    mlcommons_deploy_model,
 )
 
 logger = logging.getLogger(__name__)
 
 
 TRAINING_END_TO_END_DATA_INDEX = "test_end_to_end"
+RAG_INGEST_PIPELINE_INDEX = "rag-ingest-pipeline-index"
+RAG_INGEST_PIPELINE_NAME = "rag-ingest-pipeline"
 
 
 @pytest.mark.group(1)
@@ -59,9 +61,9 @@ async def test_build_and_deploy_small_deployment(ops_test: OpsTest) -> None:
     await asyncio.gather(
         ops_test.model.deploy(
             charm,
-            num_units=3,
+            num_units=2,
             series=SERIES,
-            config={"plugin_opensearch_knn": False} | CONFIG_OPTS,
+            config=CONFIG_OPTS,
         ),
         ops_test.model.deploy(
             TLS_CERTIFICATES_APP_NAME, channel=TLS_STABLE_CHANNEL, config=config
@@ -79,47 +81,203 @@ async def test_build_and_deploy_small_deployment(ops_test: OpsTest) -> None:
     assert len(ops_test.model.applications[APP_NAME].units) == 3
 
 
+# @pytest.mark.group(1)
+# @pytest.mark.abort_on_fail
+# async def test_mlcommons_llm_model_register_and_prediction(ops_test: OpsTest) -> None:
+#     """Uploads and runs the model."""
+#     app = (await app_name(ops_test)) or APP_NAME
+
+#     leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
+
+#     # Redefine sync-up job time
+#     await http_request(
+#         ops_test,
+#         "PUT",
+#         f"https://{leader_unit_ip}:9200/_cluster/settings",
+#         app=app,
+#         payload={"persistent": {"plugins.ml_commons.sync_up_job_interval_in_seconds": 600}},
+#     )
+
+#     task_id = await mlcommons_register_model(
+#         ops_test,
+#         app,
+#         leader_unit_ip,
+#         model_config={
+#             "name": "huggingface/sentence-transformers/all-MiniLM-L12-v2",
+#             "version": "1.0.1",
+#             "model_format": "TORCH_SCRIPT",
+#         },
+#     )
+
+#     model_id = await mlcommons_wait_task_model(ops_test, app, leader_unit_ip, task_id)
+#     assert model_id is not None, "The model_id is None when registering model"
+
+#     task_id = (await mlcommons_load_model_to_node(ops_test, app, leader_unit_ip, model_id)).get(
+#         "task_id", None
+#     )
+#     await mlcommons_wait_task_model(ops_test, app, leader_unit_ip, task_id)
+
+#     result = await mlcommons_model_predict(
+#         ops_test,
+#         app,
+#         leader_unit_ip,
+#         model_id,
+#         prediction_configs={
+#             "text_docs": ["This test worked?"],
+#             "return_number": True,
+#             "target_response": ["sentence_embedding"],
+#         },
+#     )
+#     shape_count = result["inference_results"][0]["output"][0]["shape"][0]
+#     assert shape_count > 0
+#     assert shape_count == len(result["inference_results"][0]["output"][0]["data"])
+
+
+# @pytest.mark.group(1)
+# @pytest.mark.abort_on_fail
+# async def test_mlcommons_kmeans_model(ops_test: OpsTest) -> None:
+#     """Uploads and runs the model. This method reuses the data index used for FAISS IVF."""
+#     app = (await app_name(ops_test)) or APP_NAME
+
+#     units = await get_application_unit_ids_ips(ops_test, app=app)
+#     leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
+
+#     await create_index(
+#         ops_test,
+#         app,
+#         leader_unit_ip,
+#         TRAINING_END_TO_END_DATA_INDEX,
+#         r_shards=len(units) - 1,
+#     )
+#     payload, _ = generate_bulk_training_data(
+#         TRAINING_END_TO_END_DATA_INDEX,
+#         docs_count=100,
+#         dimensions=4,
+#         has_result=True,
+#         vector_name=TRAINING_END_TO_END_DATA_INDEX + "_vector",
+#     )
+#     # Insert data in bulk
+#     await bulk_insert(ops_test, app, leader_unit_ip, payload)
+
+#     # Redefine sync-up job time
+#     await http_request(
+#         ops_test,
+#         "PUT",
+#         f"https://{leader_unit_ip}:9200/_cluster/settings",
+#         app=app,
+#         payload={"persistent": {"plugins.ml_commons.sync_up_job_interval_in_seconds": 600}},
+#     )
+
+#     # train kmeans
+#     output = await http_request(
+#         ops_test,
+#         "POST",
+#         f"https://{leader_unit_ip}:9200/_plugins/_ml/_train/kmeans",
+#         app=app,
+#         payload={
+#             "parameters": {"centroids": 3, "iterations": 10, "distance_type": "COSINE"},
+#             "input_query": {"_source": ["price"], "size": 100},
+#             "input_index": [TRAINING_END_TO_END_DATA_INDEX],
+#         },
+#     )
+#     print(output)
+#     assert output["status"] == "COMPLETED", "Failed during kmeans training"
+#     model_id = output["model_id"]
+
+#     task_id = (await mlcommons_load_model_to_node(ops_test, app, leader_unit_ip, model_id)).get(
+#         "task_id", None
+#     )
+#     await mlcommons_wait_task_model(ops_test, app, leader_unit_ip, task_id)
+
+#     result = await mlcommons_model_predict(
+#         ops_test,
+#         app,
+#         leader_unit_ip,
+#         model_id,
+#         prediction_type="kmeans",
+#         prediction_configs={
+#             "input_query": {"_source": ["price"], "size": 1},
+#             "input_index": [TRAINING_END_TO_END_DATA_INDEX],
+#         },
+#     )
+#     assert result["status"] == "COMPLETED"
+#     assert len(result["prediction_result"]["rows"]) > 0
+
+
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
-async def test_mlcommons_llm_model_register_and_prediction(ops_test: OpsTest) -> None:
-    """Uploads and runs the model."""
+async def test_rag_part1_embedding_pipeline(ops_test: OpsTest) -> None:
+    """Deploys the RAG embedding model."""
     app = (await app_name(ops_test)) or APP_NAME
 
     leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
 
-    # Redefine sync-up job time
+
+    import pdb; pdb.set_trace()
+
+
+    # Set parameters for the RAG
     await http_request(
         ops_test,
         "PUT",
         f"https://{leader_unit_ip}:9200/_cluster/settings",
         app=app,
-        payload={"persistent": {"plugins.ml_commons.sync_up_job_interval_in_seconds": 600}},
+        payload={
+            "persistent": {
+                "plugins.ml_commons.memory_feature_enabled": True,
+                "plugins.ml_commons.rag_pipeline_feature_enabled": True,
+            }
+        },
     )
 
+    # Create a model group
+    output = await http_request(
+        ops_test,
+        "POST",
+        f"https://{leader_unit_ip}:9200/_plugins/_ml/model_groups/_register",
+        app=app,
+        payload={
+            "name": "rag-model-group",
+            "description": "A model group for RAG use case models",
+        },
+    )
+    print(output)
+    assert output["status"] == "CREATED", "Failed during embedding model creation"
+    global rag_model_group_id
+    rag_model_group_id = output["model_group_id"]
+
+    # Set the embedding model
     task_id = await mlcommons_register_model(
         ops_test,
         app,
         leader_unit_ip,
         model_config={
-            "name": "huggingface/sentence-transformers/all-MiniLM-L12-v2",
-            "version": "1.0.1",
-            "model_format": "TORCH_SCRIPT",
+            "name": "huggingface/sentence-transformers/msmarco-distilbert-base-tas-b",
+            "version": "1.0.2",
+            "model_group_id": rag_model_group_id,
+            "model_format": "TORCH_SCRIPT"
         },
     )
+    print(task_id)
+    global rag_embedding_id
+    rag_embedding_id = await mlcommons_wait_task_model(ops_test, app, leader_unit_ip, task_id)
+    assert rag_embedding_id is not None, "The embedding_id is None when registering embedding model"
 
-    model_id = await mlcommons_wait_task_model(ops_test, app, leader_unit_ip, task_id)
-    assert model_id is not None, "The model_id is None when registering model"
-
-    task_id = (await mlcommons_load_model_to_node(ops_test, app, leader_unit_ip, model_id)).get(
+    task_id = (await mlcommons_load_model_to_node(ops_test, app, leader_unit_ip, rag_embedding_id)).get(
+        "task_id", None
+    )
+    await mlcommons_wait_task_model(ops_test, app, leader_unit_ip, task_id)
+    task_id = (await mlcommons_deploy_model(ops_test, app, leader_unit_ip, rag_embedding_id)).get(
         "task_id", None
     )
     await mlcommons_wait_task_model(ops_test, app, leader_unit_ip, task_id)
 
+    # Test the embedding model
     result = await mlcommons_model_predict(
         ops_test,
         app,
         leader_unit_ip,
-        model_id,
+        rag_embedding_id,
         prediction_configs={
             "text_docs": ["This test worked?"],
             "return_number": True,
@@ -133,70 +291,111 @@ async def test_mlcommons_llm_model_register_and_prediction(ops_test: OpsTest) ->
 
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
-async def test_mlcommons_kmeans_model(ops_test: OpsTest) -> None:
-    """Uploads and runs the model. This method reuses the data index used for FAISS IVF."""
+async def test_rag_part2_create_ingest_pipeline(ops_test: OpsTest) -> None:
+    """Deploys the RAG pipeline."""
     app = (await app_name(ops_test)) or APP_NAME
 
-    units = await get_application_unit_ids_ips(ops_test, app=app)
+
+    import pdb; pdb.set_trace()
+
+
+
+
     leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
+    units = await get_application_unit_ids_ips(ops_test, app=app)
+
+    output = await http_request(
+        ops_test,
+        "PUT",
+        f"https://{leader_unit_ip}:9200/_ingest/pipeline/{RAG_INGEST_PIPELINE_NAME}",
+        app=app,
+        payload={
+            "description": "An RAG ingest pipeline",
+            "processors": [
+                {
+                    "text_embedding": {
+                            "model_id": rag_embedding_id,
+                            "field_map": {
+                            "text": "sentence_embedding"
+                        }
+                    }
+                }
+            ]
+        },
+    )
+    print(output)
+    assert output["acknowledged"] == "true", "Failed during RAG pipeline creation"
 
     await create_index(
         ops_test,
         app,
         leader_unit_ip,
-        TRAINING_END_TO_END_DATA_INDEX,
+        RAG_INGEST_PIPELINE_INDEX,
         r_shards=len(units) - 1,
+        extra_index_settings={"knn": "true", "default_pipeline": RAG_INGEST_PIPELINE_NAME},
+        extra_mappings={
+            "properties": {
+                "id": {
+                    "type": "text"
+                },
+                "sentence_embedding": {
+                    "type": "knn_vector",
+                    "dimension": 768,
+                    "method": {
+                    "name": "hnsw",
+                    "engine": "faiss",
+                    "space_type": "l2",
+                    "parameters": {
+                            "encoder": {
+                                "name": "sq",
+                                "parameters": {
+                                    "type": "fp16"
+                                }
+                            },
+                            "ef_construction": 256,
+                            "m": 8
+                        }
+                    }
+                },
+                "text": {
+                    "type": "text"
+                }
+            }
+        },
     )
-    payload, _ = generate_bulk_training_data(
-        TRAINING_END_TO_END_DATA_INDEX,
-        docs_count=100,
-        dimensions=4,
-        has_result=True,
-        vector_name=TRAINING_END_TO_END_DATA_INDEX + "_vector",
-    )
-    # Insert data in bulk
-    await bulk_insert(ops_test, app, leader_unit_ip, payload)
 
-    # Redefine sync-up job time
     await http_request(
         ops_test,
-        "PUT",
-        f"https://{leader_unit_ip}:9200/_cluster/settings",
-        app=app,
-        payload={"persistent": {"plugins.ml_commons.sync_up_job_interval_in_seconds": 600}},
-    )
-
-    # train kmeans
-    output = await http_request(
-        ops_test,
         "POST",
-        f"https://{leader_unit_ip}:9200/_plugins/_ml/_train/kmeans",
+        f"https://{leader_unit_ip}:9200/{RAG_INGEST_PIPELINE_INDEX}/_doc",
         app=app,
         payload={
-            "parameters": {"centroids": 3, "iterations": 10, "distance_type": "COSINE"},
-            "input_query": {"_source": ["price"], "size": 100},
-            "input_index": [TRAINING_END_TO_END_DATA_INDEX],
+            "text": "The best OS is Ubuntu.",
         },
     )
-    print(output)
-    assert output["status"] == "COMPLETED", "Failed during kmeans training"
-    model_id = output["model_id"]
 
-    task_id = (await mlcommons_load_model_to_node(ops_test, app, leader_unit_ip, model_id)).get(
-        "task_id", None
-    )
-    await mlcommons_wait_task_model(ops_test, app, leader_unit_ip, task_id)
-
-    result = await mlcommons_model_predict(
+    # Test the Neural Search
+    result = await http_request(
         ops_test,
-        app,
-        leader_unit_ip,
-        model_id,
-        prediction_type="kmeans",
-        prediction_configs={
-            "input_query": {"_source": ["price"], "size": 1},
-            "input_index": [TRAINING_END_TO_END_DATA_INDEX],
+        "POST",
+        f"https://{leader_unit_ip}:9200/{RAG_INGEST_PIPELINE_INDEX}/_search",
+        app=app,
+        payload={
+            "_source": {
+                "excludes": [
+                    "sentence_embedding"
+                ]
+            },
+            "query": {
+                    "neural": {
+                    "sentence_embedding": {
+                        "query_text": "What is Ubuntu?",
+                        "model_id": rag_embedding_id,
+                        "k": 15
+                    }
+                }
+            }
         },
     )
-    assert result["status"] == "COMPLETED"
-    assert len(result["prediction_result"]["rows"]) > 0
+    print(result)
+    assert result["hits"]["total"]["value"] > 0, "Failed during RAG pipeline creation"

--- a/tests/integration/plugins/test_ml_commons.py
+++ b/tests/integration/plugins/test_ml_commons.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+
+import pytest
+from pytest_operator.plugin import OpsTest
+
+from ..ha.helpers import app_name
+from ..ha.helpers_data import bulk_insert, create_index
+from ..ha.test_horizontal_scaling import IDLE_PERIOD
+from ..helpers import (
+    APP_NAME,
+    CONFIG_OPTS,
+    MODEL_CONFIG,
+    SERIES,
+    get_application_unit_ids_ips,
+    get_leader_unit_ip,
+    http_request,
+)
+from ..helpers_deployments import wait_until
+from ..tls.test_tls import TLS_CERTIFICATES_APP_NAME, TLS_STABLE_CHANNEL
+from .helpers import (
+    generate_bulk_training_data,
+    mlcommons_load_model_to_node,
+    mlcommons_model_predict,
+    mlcommons_register_model,
+    mlcommons_wait_task_model,
+)
+
+logger = logging.getLogger(__name__)
+
+
+TRAINING_END_TO_END_DATA_INDEX = "test_end_to_end"
+
+
+@pytest.mark.abort_on_fail
+@pytest.mark.skip_if_deployed
+async def test_build_and_deploy_small_deployment(ops_test: OpsTest) -> None:
+    """Build and deploy an OpenSearch cluster."""
+    if await app_name(ops_test):
+        return
+
+    charm = await ops_test.build_charm(".")
+
+    model_conf = MODEL_CONFIG.copy()
+    # Make it more regular as COS relation-broken really happens on the
+    # next hook call in each opensearch unit.
+    # If this value is changed, then update the sleep accordingly at:
+    #  test_prometheus_exporter_disabled_by_cos_relation_gone
+    model_conf["update-status-hook-interval"] = "1m"
+    await ops_test.model.set_config(model_conf)
+
+    # Deploy TLS Certificates operator.
+    config = {"ca-common-name": "CN_CA"}
+    await asyncio.gather(
+        ops_test.model.deploy(
+            charm,
+            num_units=3,
+            series=SERIES,
+            config={"plugin_opensearch_knn": False} | CONFIG_OPTS,
+        ),
+        ops_test.model.deploy(
+            TLS_CERTIFICATES_APP_NAME, channel=TLS_STABLE_CHANNEL, config=config
+        ),
+    )
+
+    await wait_until(
+        ops_test,
+        apps=[APP_NAME],
+        units_statuses=["blocked"],
+        wait_for_exact_units={APP_NAME: 3},
+        timeout=3400,
+        idle_period=IDLE_PERIOD,
+    )
+    assert len(ops_test.model.applications[APP_NAME].units) == 3
+
+
+@pytest.mark.abort_on_fail
+async def test_mlcommons_llm_model_register_and_prediction(ops_test: OpsTest) -> None:
+    """Uploads and runs the model."""
+    app = (await app_name(ops_test)) or APP_NAME
+
+    leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
+
+    # Redefine sync-up job time
+    await http_request(
+        ops_test,
+        "PUT",
+        f"https://{leader_unit_ip}:9200/_cluster/settings",
+        app=app,
+        payload={"persistent": {"plugins.ml_commons.sync_up_job_interval_in_seconds": 600}},
+    )
+
+    task_id = await mlcommons_register_model(
+        ops_test,
+        app,
+        leader_unit_ip,
+        model_config={
+            "name": "huggingface/sentence-transformers/all-MiniLM-L12-v2",
+            "version": "1.0.1",
+            "model_format": "TORCH_SCRIPT",
+        },
+    )
+
+    model_id = await mlcommons_wait_task_model(ops_test, app, leader_unit_ip, task_id)
+    assert model_id is not None, "The model_id is None when registering model"
+
+    task_id = (await mlcommons_load_model_to_node(ops_test, app, leader_unit_ip, model_id)).get(
+        "task_id", None
+    )
+    await mlcommons_wait_task_model(ops_test, app, leader_unit_ip, task_id)
+
+    result = await mlcommons_model_predict(
+        ops_test,
+        app,
+        leader_unit_ip,
+        model_id,
+        prediction_configs={
+            "text_docs": ["This test worked?"],
+            "return_number": True,
+            "target_response": ["sentence_embedding"],
+        },
+    )
+    shape_count = result["inference_results"][0]["output"][0]["shape"][0]
+    assert shape_count > 0
+    assert shape_count == len(result["inference_results"][0]["output"][0]["data"])
+
+
+@pytest.mark.abort_on_fail
+async def test_mlcommons_kmeans_model(ops_test: OpsTest) -> None:
+    """Uploads and runs the model. This method reuses the data index used for FAISS IVF."""
+    app = (await app_name(ops_test)) or APP_NAME
+
+    units = await get_application_unit_ids_ips(ops_test, app=app)
+    leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
+
+    await create_index(
+        ops_test,
+        app,
+        leader_unit_ip,
+        TRAINING_END_TO_END_DATA_INDEX,
+        r_shards=len(units) - 1,
+    )
+    payload, _ = generate_bulk_training_data(
+        TRAINING_END_TO_END_DATA_INDEX,
+        docs_count=100,
+        dimensions=4,
+        has_result=True,
+        vector_name=TRAINING_END_TO_END_DATA_INDEX + "_vector",
+    )
+    # Insert data in bulk
+    await bulk_insert(ops_test, app, leader_unit_ip, payload)
+
+    # Redefine sync-up job time
+    await http_request(
+        ops_test,
+        "PUT",
+        f"https://{leader_unit_ip}:9200/_cluster/settings",
+        app=app,
+        payload={"persistent": {"plugins.ml_commons.sync_up_job_interval_in_seconds": 600}},
+    )
+
+    # train kmeans
+    output = await http_request(
+        ops_test,
+        "POST",
+        f"https://{leader_unit_ip}:9200/_plugins/_ml/_train/kmeans",
+        app=app,
+        payload={
+            "parameters": {"centroids": 3, "iterations": 10, "distance_type": "COSINE"},
+            "input_query": {"_source": ["price"], "size": 100},
+            "input_index": [TRAINING_END_TO_END_DATA_INDEX],
+        },
+    )
+    print(output)
+    assert output["status"] == "COMPLETED", "Failed during kmeans training"
+    model_id = output["model_id"]
+
+    task_id = (await mlcommons_load_model_to_node(ops_test, app, leader_unit_ip, model_id)).get(
+        "task_id", None
+    )
+    await mlcommons_wait_task_model(ops_test, app, leader_unit_ip, task_id)
+
+    result = await mlcommons_model_predict(
+        ops_test,
+        app,
+        leader_unit_ip,
+        model_id,
+        prediction_type="kmeans",
+        prediction_configs={
+            "input_query": {"_source": ["price"], "size": 1},
+            "input_index": [TRAINING_END_TO_END_DATA_INDEX],
+        },
+    )
+    assert result["status"] == "COMPLETED"
+    assert len(result["prediction_result"]["rows"]) > 0

--- a/tests/integration/plugins/test_ml_commons.py
+++ b/tests/integration/plugins/test_ml_commons.py
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 TRAINING_END_TO_END_DATA_INDEX = "test_end_to_end"
 
 
+@pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 @pytest.mark.skip_if_deployed
 async def test_build_and_deploy_small_deployment(ops_test: OpsTest) -> None:
@@ -78,6 +79,7 @@ async def test_build_and_deploy_small_deployment(ops_test: OpsTest) -> None:
     assert len(ops_test.model.applications[APP_NAME].units) == 3
 
 
+@pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_mlcommons_llm_model_register_and_prediction(ops_test: OpsTest) -> None:
     """Uploads and runs the model."""

--- a/tests/integration/plugins/test_plugins.py
+++ b/tests/integration/plugins/test_plugins.py
@@ -491,7 +491,11 @@ async def test_knn_search_with_hnsw_faiss(ops_test: OpsTest, deploy_type: str) -
         },
     )
     payload, payload_list = generate_bulk_training_data(
-        index_name, vector_name, docs_count=100, dimensions=4, has_result=True
+        index_name,
+        docs_count=100,
+        dimensions=4,
+        has_result=True,
+        vector_name=vector_name,
     )
     # Insert data in bulk
     await bulk_insert(ops_test, app, leader_unit_ip, payload)
@@ -535,7 +539,11 @@ async def test_knn_search_with_hnsw_nmslib(ops_test: OpsTest, deploy_type: str) 
         },
     )
     payload, payload_list = generate_bulk_training_data(
-        index_name, vector_name, docs_count=100, dimensions=4, has_result=True
+        index_name,
+        docs_count=100,
+        dimensions=4,
+        has_result=True,
+        vector_name=vector_name,
     )
     # Insert data in bulk
     await bulk_insert(ops_test, app, leader_unit_ip, payload)

--- a/tests/integration/plugins/test_rag.py
+++ b/tests/integration/plugins/test_rag.py
@@ -23,10 +23,10 @@ from ..helpers import (
 from ..helpers_deployments import wait_until
 from ..tls.test_tls import TLS_CERTIFICATES_APP_NAME, TLS_STABLE_CHANNEL
 from .helpers import (
+    mlcommons_deploy_model,
     mlcommons_model_predict,
     mlcommons_register_model,
     mlcommons_wait_task_model,
-    mlcommons_deploy_model,
 )
 
 logger = logging.getLogger(__name__)
@@ -42,7 +42,7 @@ RAG_GROUP_NAME = "rag-model-group"
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 @pytest.mark.skip_if_deployed
-async def test_build_and_deploy_large_RAG_deployment(ops_test: OpsTest, charm) -> None:
+async def test_build_and_deploy_large_rag_deployment(ops_test: OpsTest, charm) -> None:
     """Build and deploy an OpenSearch cluster."""
     if await app_name(ops_test):
         return
@@ -77,7 +77,6 @@ async def test_build_and_deploy_large_RAG_deployment(ops_test: OpsTest, charm) -
             series=SERIES,
             config=main_orchestrator_conf | CONFIG_OPTS,
         ),
-
         ops_test.model.deploy(
             charm,
             application_name="failover",
@@ -85,7 +84,6 @@ async def test_build_and_deploy_large_RAG_deployment(ops_test: OpsTest, charm) -
             series=SERIES,
             config=failover_orchestrator_conf | CONFIG_OPTS,
         ),
-
         ops_test.model.deploy(
             charm,
             application_name="ingest",
@@ -93,7 +91,6 @@ async def test_build_and_deploy_large_RAG_deployment(ops_test: OpsTest, charm) -
             series=SERIES,
             config=app_conf | {"roles": "ingest,ml"} | CONFIG_OPTS,
         ),
-
         ops_test.model.deploy(
             charm,
             application_name="vectordb",
@@ -101,7 +98,6 @@ async def test_build_and_deploy_large_RAG_deployment(ops_test: OpsTest, charm) -
             series=SERIES,
             config=app_conf | {"roles": "data"} | CONFIG_OPTS,
         ),
-
         ops_test.model.deploy(
             charm,
             application_name=APP_NAME,
@@ -109,7 +105,6 @@ async def test_build_and_deploy_large_RAG_deployment(ops_test: OpsTest, charm) -
             series=SERIES,
             config=app_conf | {"roles": "ml"} | CONFIG_OPTS,
         ),
-
         ops_test.model.deploy(
             TLS_CERTIFICATES_APP_NAME, channel=TLS_STABLE_CHANNEL, config=config
         ),
@@ -117,22 +112,12 @@ async def test_build_and_deploy_large_RAG_deployment(ops_test: OpsTest, charm) -
 
     # Large deployment setup
     await ops_test.model.integrate("main:peer-cluster-orchestrator", "failover:peer-cluster")
-    await ops_test.model.integrate(
-        "main:peer-cluster-orchestrator", f"ingest:peer-cluster"
-    )
-    await ops_test.model.integrate(
-        "main:peer-cluster-orchestrator", f"vectordb:peer-cluster"
-    )
-    await ops_test.model.integrate(
-        "main:peer-cluster-orchestrator", f"{APP_NAME}:peer-cluster"
-    )
+    await ops_test.model.integrate("main:peer-cluster-orchestrator", "ingest:peer-cluster")
+    await ops_test.model.integrate("main:peer-cluster-orchestrator", "vectordb:peer-cluster")
+    await ops_test.model.integrate("main:peer-cluster-orchestrator", f"{APP_NAME}:peer-cluster")
 
-    await ops_test.model.integrate(
-        "failover:peer-cluster-orchestrator", f"ingest:peer-cluster"
-    )
-    await ops_test.model.integrate(
-        "failover:peer-cluster-orchestrator", f"vectordb:peer-cluster"
-    )
+    await ops_test.model.integrate("failover:peer-cluster-orchestrator", "ingest:peer-cluster")
+    await ops_test.model.integrate("failover:peer-cluster-orchestrator", "vectordb:peer-cluster")
     await ops_test.model.integrate(
         "failover:peer-cluster-orchestrator", f"{APP_NAME}:peer-cluster"
     )
@@ -209,7 +194,9 @@ async def test_rag_part1_embedding_pipeline(ops_test: OpsTest) -> None:
     print(task_id)
     global rag_embedding_id
     rag_embedding_id = await mlcommons_wait_task_model(ops_test, app, leader_unit_ip, task_id)
-    assert rag_embedding_id is not None, "The embedding_id is None when registering embedding model"
+    assert (
+        rag_embedding_id is not None
+    ), "The embedding_id is None when registering embedding model"
     task_id = (await mlcommons_deploy_model(ops_test, app, leader_unit_ip, rag_embedding_id)).get(
         "task_id", None
     )
@@ -252,13 +239,11 @@ async def test_rag_part2_create_ingest_pipeline(ops_test: OpsTest) -> None:
             "processors": [
                 {
                     "text_embedding": {
-                            "model_id": rag_embedding_id,
-                            "field_map": {
-                            "text": "sentence_embedding"
-                        }
+                        "model_id": rag_embedding_id,
+                        "field_map": {"text": "sentence_embedding"},
                     }
                 }
-            ]
+            ],
         },
     )
     print(output)
@@ -273,31 +258,22 @@ async def test_rag_part2_create_ingest_pipeline(ops_test: OpsTest) -> None:
         extra_index_settings={"knn": "true", "default_pipeline": RAG_INGEST_PIPELINE_NAME},
         extra_mappings={
             "properties": {
-                "id": {
-                    "type": "text"
-                },
+                "id": {"type": "text"},
                 "sentence_embedding": {
                     "type": "knn_vector",
                     "dimension": 768,
                     "method": {
-                    "name": "hnsw",
-                    "engine": "faiss",
-                    "space_type": "l2",
-                    "parameters": {
-                            "encoder": {
-                                "name": "sq",
-                                "parameters": {
-                                    "type": "fp16"
-                                }
-                            },
+                        "name": "hnsw",
+                        "engine": "faiss",
+                        "space_type": "l2",
+                        "parameters": {
+                            "encoder": {"name": "sq", "parameters": {"type": "fp16"}},
                             "ef_construction": 256,
-                            "m": 8
-                        }
-                    }
+                            "m": 8,
+                        },
+                    },
                 },
-                "text": {
-                    "type": "text"
-                }
+                "text": {"type": "text"},
             }
         },
     )
@@ -319,20 +295,16 @@ async def test_rag_part2_create_ingest_pipeline(ops_test: OpsTest) -> None:
         f"https://{leader_unit_ip}:9200/{RAG_INGEST_PIPELINE_INDEX}/_search",
         app=app,
         payload={
-            "_source": {
-                "excludes": [
-                    "sentence_embedding"
-                ]
-            },
+            "_source": {"excludes": ["sentence_embedding"]},
             "query": {
-                    "neural": {
+                "neural": {
                     "sentence_embedding": {
                         "query_text": "What is Ubuntu?",
                         "model_id": rag_embedding_id,
-                        "k": 15
+                        "k": 15,
                     }
                 }
-            }
+            },
         },
     )
     print(result)
@@ -342,6 +314,6 @@ async def test_rag_part2_create_ingest_pipeline(ops_test: OpsTest) -> None:
 @pytest.mark.skip(reason="This test is too large for local CI")
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
-async def test_rag_part3_connect_to_LLM_model(ops_test: OpsTest) -> None:
+async def test_rag_part3_connect_to_llm_model(ops_test: OpsTest) -> None:
     """Set the connector and test the LLM model."""
     return

--- a/tests/integration/plugins/test_rag.py
+++ b/tests/integration/plugins/test_rag.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import logging
+
+import pytest
+from pytest_operator.plugin import OpsTest
+
+from ..ha.helpers import app_name
+from ..ha.helpers_data import create_index
+from ..ha.test_horizontal_scaling import IDLE_PERIOD
+from ..helpers import (
+    APP_NAME,
+    CONFIG_OPTS,
+    MODEL_CONFIG,
+    SERIES,
+    get_application_unit_ids_ips,
+    get_leader_unit_ip,
+    http_request,
+)
+from ..helpers_deployments import wait_until
+from ..tls.test_tls import TLS_CERTIFICATES_APP_NAME, TLS_STABLE_CHANNEL
+from .helpers import (
+    mlcommons_model_predict,
+    mlcommons_register_model,
+    mlcommons_wait_task_model,
+    mlcommons_deploy_model,
+)
+
+logger = logging.getLogger(__name__)
+
+
+TRAINING_END_TO_END_DATA_INDEX = "test_end_to_end"
+RAG_INGEST_PIPELINE_INDEX = "rag-ingest-pipeline-index"
+RAG_INGEST_PIPELINE_NAME = "rag-ingest-pipeline"
+RAG_GROUP_NAME = "rag-model-group"
+
+
+@pytest.mark.skip(reason="This test is too large for local CI")
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+@pytest.mark.skip_if_deployed
+async def test_build_and_deploy_large_RAG_deployment(ops_test: OpsTest, charm) -> None:
+    """Build and deploy an OpenSearch cluster."""
+    if await app_name(ops_test):
+        return
+
+    model_conf = MODEL_CONFIG.copy()
+    # Make it more regular as COS relation-broken really happens on the
+    # next hook call in each opensearch unit.
+    # If this value is changed, then update the sleep accordingly at:
+    #  test_prometheus_exporter_disabled_by_cos_relation_gone
+    model_conf["update-status-hook-interval"] = "1m"
+    await ops_test.model.set_config(model_conf)
+
+    main_orchestrator_conf = {
+        "cluster_name": "rag",
+        "init_hold": False,
+        "roles": "cluster_manager,data",
+    }
+    failover_orchestrator_conf = {
+        "cluster_name": "rag",
+        "init_hold": True,
+        "roles": "cluster_manager",
+    }
+    app_conf = {"cluster_name": "rag", "init_hold": True}
+
+    # Deploy TLS Certificates operator.
+    config = {"ca-common-name": "CN_CA"}
+    await asyncio.gather(
+        ops_test.model.deploy(
+            charm,
+            application_name="main",
+            num_units=3,
+            series=SERIES,
+            config=main_orchestrator_conf | CONFIG_OPTS,
+        ),
+
+        ops_test.model.deploy(
+            charm,
+            application_name="failover",
+            num_units=2,
+            series=SERIES,
+            config=failover_orchestrator_conf | CONFIG_OPTS,
+        ),
+
+        ops_test.model.deploy(
+            charm,
+            application_name="ingest",
+            num_units=1,
+            series=SERIES,
+            config=app_conf | {"roles": "ingest,ml"} | CONFIG_OPTS,
+        ),
+
+        ops_test.model.deploy(
+            charm,
+            application_name="vectordb",
+            num_units=1,
+            series=SERIES,
+            config=app_conf | {"roles": "data"} | CONFIG_OPTS,
+        ),
+
+        ops_test.model.deploy(
+            charm,
+            application_name=APP_NAME,
+            num_units=1,
+            series=SERIES,
+            config=app_conf | {"roles": "ml"} | CONFIG_OPTS,
+        ),
+
+        ops_test.model.deploy(
+            TLS_CERTIFICATES_APP_NAME, channel=TLS_STABLE_CHANNEL, config=config
+        ),
+    )
+
+    # Large deployment setup
+    await ops_test.model.integrate("main:peer-cluster-orchestrator", "failover:peer-cluster")
+    await ops_test.model.integrate(
+        "main:peer-cluster-orchestrator", f"ingest:peer-cluster"
+    )
+    await ops_test.model.integrate(
+        "main:peer-cluster-orchestrator", f"vectordb:peer-cluster"
+    )
+    await ops_test.model.integrate(
+        "main:peer-cluster-orchestrator", f"{APP_NAME}:peer-cluster"
+    )
+
+    await ops_test.model.integrate(
+        "failover:peer-cluster-orchestrator", f"ingest:peer-cluster"
+    )
+    await ops_test.model.integrate(
+        "failover:peer-cluster-orchestrator", f"vectordb:peer-cluster"
+    )
+    await ops_test.model.integrate(
+        "failover:peer-cluster-orchestrator", f"{APP_NAME}:peer-cluster"
+    )
+
+    # TLS setup
+    await ops_test.model.integrate("main", TLS_CERTIFICATES_APP_NAME)
+    await ops_test.model.integrate("failover", TLS_CERTIFICATES_APP_NAME)
+    await ops_test.model.integrate("ingest", TLS_CERTIFICATES_APP_NAME)
+    await ops_test.model.integrate("vectordb", TLS_CERTIFICATES_APP_NAME)
+    await ops_test.model.integrate(APP_NAME, TLS_CERTIFICATES_APP_NAME)
+
+    await wait_until(
+        ops_test,
+        apps=[APP_NAME],
+        units_statuses=["blocked"],
+        wait_for_exact_units={APP_NAME: 1},
+        timeout=3400,
+        idle_period=IDLE_PERIOD,
+    )
+    assert len(ops_test.model.applications[APP_NAME].units) == 1
+
+
+@pytest.mark.skip(reason="This test is too large for local CI")
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_rag_part1_embedding_pipeline(ops_test: OpsTest) -> None:
+    """Deploys the RAG embedding model."""
+    app = (await app_name(ops_test)) or APP_NAME
+
+    leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
+
+    # Set parameters for the RAG
+    await http_request(
+        ops_test,
+        "PUT",
+        f"https://{leader_unit_ip}:9200/_cluster/settings",
+        app=app,
+        payload={
+            "persistent": {
+                "plugins.ml_commons.memory_feature_enabled": True,
+                "plugins.ml_commons.rag_pipeline_feature_enabled": True,
+            }
+        },
+    )
+
+    # Create a model group
+    output = await http_request(
+        ops_test,
+        "POST",
+        f"https://{leader_unit_ip}:9200/_plugins/_ml/model_groups/_register",
+        app=app,
+        payload={
+            "name": RAG_GROUP_NAME,
+            "description": "A model group for RAG use case models",
+        },
+    )
+    print(output)
+    assert output["status"] == "CREATED", "Failed during embedding model creation"
+    global rag_model_group_id
+    rag_model_group_id = output["model_group_id"]
+
+    # Set the embedding model
+    task_id = await mlcommons_register_model(
+        ops_test,
+        app,
+        leader_unit_ip,
+        model_config={
+            "name": "huggingface/sentence-transformers/msmarco-distilbert-base-tas-b",
+            "version": "1.0.2",
+            "model_group_id": rag_model_group_id,
+            "model_format": "TORCH_SCRIPT",
+        },
+    )
+    print(task_id)
+    global rag_embedding_id
+    rag_embedding_id = await mlcommons_wait_task_model(ops_test, app, leader_unit_ip, task_id)
+    assert rag_embedding_id is not None, "The embedding_id is None when registering embedding model"
+    task_id = (await mlcommons_deploy_model(ops_test, app, leader_unit_ip, rag_embedding_id)).get(
+        "task_id", None
+    )
+    await mlcommons_wait_task_model(ops_test, app, leader_unit_ip, task_id)
+
+    # Test the embedding model
+    result = await mlcommons_model_predict(
+        ops_test,
+        app,
+        leader_unit_ip,
+        rag_embedding_id,
+        prediction_configs={
+            "text_docs": ["This test worked?"],
+            "return_number": True,
+            "target_response": ["sentence_embedding"],
+        },
+    )
+    shape_count = result["inference_results"][0]["output"][0]["shape"][0]
+    assert shape_count > 0
+    assert shape_count == len(result["inference_results"][0]["output"][0]["data"])
+
+
+@pytest.mark.skip(reason="This test is too large for local CI")
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_rag_part2_create_ingest_pipeline(ops_test: OpsTest) -> None:
+    """Deploys the RAG pipeline."""
+    app = (await app_name(ops_test)) or APP_NAME
+
+    leader_unit_ip = await get_leader_unit_ip(ops_test, app=app)
+    units = await get_application_unit_ids_ips(ops_test, app=app)
+
+    output = await http_request(
+        ops_test,
+        "PUT",
+        f"https://{leader_unit_ip}:9200/_ingest/pipeline/{RAG_INGEST_PIPELINE_NAME}",
+        app=app,
+        payload={
+            "description": "An RAG ingest pipeline",
+            "processors": [
+                {
+                    "text_embedding": {
+                            "model_id": rag_embedding_id,
+                            "field_map": {
+                            "text": "sentence_embedding"
+                        }
+                    }
+                }
+            ]
+        },
+    )
+    print(output)
+    assert output["acknowledged"] is True, "Failed during RAG pipeline creation"
+
+    await create_index(
+        ops_test,
+        app,
+        leader_unit_ip,
+        RAG_INGEST_PIPELINE_INDEX,
+        r_shards=len(units) - 1,
+        extra_index_settings={"knn": "true", "default_pipeline": RAG_INGEST_PIPELINE_NAME},
+        extra_mappings={
+            "properties": {
+                "id": {
+                    "type": "text"
+                },
+                "sentence_embedding": {
+                    "type": "knn_vector",
+                    "dimension": 768,
+                    "method": {
+                    "name": "hnsw",
+                    "engine": "faiss",
+                    "space_type": "l2",
+                    "parameters": {
+                            "encoder": {
+                                "name": "sq",
+                                "parameters": {
+                                    "type": "fp16"
+                                }
+                            },
+                            "ef_construction": 256,
+                            "m": 8
+                        }
+                    }
+                },
+                "text": {
+                    "type": "text"
+                }
+            }
+        },
+    )
+
+    await http_request(
+        ops_test,
+        "POST",
+        f"https://{leader_unit_ip}:9200/{RAG_INGEST_PIPELINE_INDEX}/_doc",
+        app=app,
+        payload={
+            "text": "The best OS is Ubuntu.",
+        },
+    )
+
+    # Test the Neural Search
+    result = await http_request(
+        ops_test,
+        "POST",
+        f"https://{leader_unit_ip}:9200/{RAG_INGEST_PIPELINE_INDEX}/_search",
+        app=app,
+        payload={
+            "_source": {
+                "excludes": [
+                    "sentence_embedding"
+                ]
+            },
+            "query": {
+                    "neural": {
+                    "sentence_embedding": {
+                        "query_text": "What is Ubuntu?",
+                        "model_id": rag_embedding_id,
+                        "k": 15
+                    }
+                }
+            }
+        },
+    )
+    print(result)
+    assert result["hits"]["total"]["value"] > 0, "Failed during RAG pipeline creation"
+
+
+@pytest.mark.skip(reason="This test is too large for local CI")
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_rag_part3_connect_to_LLM_model(ops_test: OpsTest) -> None:
+    """Set the connector and test the LLM model."""
+    return

--- a/tests/unit/resources/config/opensearch-security/internal_users.yml
+++ b/tests/unit/resources/config/opensearch-security/internal_users.yml
@@ -9,8 +9,12 @@ _meta:
 
 ## Demo users
 
+kibanaserver:
+  hash: $2b$12$/.IKi38CCbrgm0A1ZUCjO.4zxTgnulBn/7WplBhPOWdkePC9wuk0y
+  reserved: false
+  description: Kibanaserver user
 admin:
-  hash: $2b$12$EvZtNb9SCoETOwkcSmEWf.t5ajBjlTgZ0Tr71TBZnojtW5kn3BGeO
+  hash: $2b$12$5ngppC4ziGQ3sKtoz9suCOl/k7b7zQqrcBHR7q5L6vWZ..a4iT9PG
   reserved: false
   backend_roles:
   - admin
@@ -18,7 +22,3 @@ admin:
   - security_rest_api_access
   - all_access
   description: Admin user
-kibanaserver:
-  hash: $2b$12$6FZ/pncpY8VCNW2Wh/mofeACxbI1IPd56jLV1CA0sKveQ8mINlkwG
-  reserved: false
-  description: Kibanaserver user


### PR DESCRIPTION
Certain plugins may need artifacts to be downloaded and set on a given path in OpenSearch. The idea is to have an s3 relation dedicated to managing these artifacts: the user uploads the artifacts to specific folders in a given bucket and then informs the charm deployed which paths corresponds to each.

This is still a draft PR representing a propotype for that.