### PR TITLE
[DPE-7018] stabilize CA rotation in large deployments

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -842,7 +842,9 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
 
         # store the app admin TLS resources if not stored
         self.charm.tls.store_new_tls_resources(CertType.APP_ADMIN, data.credentials.admin_tls)
-        self.charm.tls.update_request_ca_bundle()
+        if self.charm.tls.ca_rotation_complete_in_cluster():
+            # must only happen if no CA-rotation, otherwise will cause TLS errors for API-requests
+            self.charm.tls.update_request_ca_bundle()
 
         # take over the internal users from the main orchestrator
         self.charm.user_manager.put_internal_user(AdminUser, data.credentials.admin_password_hash)

--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -665,6 +665,7 @@ class OpenSearchTLS(Object):
 
     def update_request_ca_bundle(self) -> None:
         """Create a new chain.pem file for requests module"""
+        logger.debug("Updating requests TLS CA bundle")
         admin_secret = self.charm.secrets.get_object(Scope.APP, CertType.APP_ADMIN.val, peek=True)
 
         # we store the pem format to make it easier for the python requests lib


### PR DESCRIPTION
## Issue
When executing a CA rotation in a large deployments setting, the non-Main-Orchestrator units update their local CA bundle (used for API-requests to Opensearch) too early in the process. 

This results in API-errors like `Max retries exceeded with url: / (Caused by SSLError(SSLCertVerificationError)` when performing requests against the unit's API. Depending on the specific API-requests executed, this can lead to failures on `is_node_up()` or `node_lock.acquire()`, causing the CA rotation workflow to fail.

## Solution
Make sure the ca bundle for requests is only updated in large deployment non-main-orchestrators if there is no CA-rotation going on.