### PR TITLE
Fix terraform failure caused by grafana agent units number

### DIFF
--- a/terraform/product/large_deployment/main.tf
+++ b/terraform/product/large_deployment/main.tf
@@ -90,7 +90,6 @@ resource "juju_application" "grafana_agents" {
   }
   model  = each.value
   config = var.grafana-agent.config
-  units  = 0
 }
 
 #--------------------------------------------------------

--- a/terraform/product/simple_deployment/main.tf
+++ b/terraform/product/simple_deployment/main.tf
@@ -68,7 +68,6 @@ resource "juju_application" "grafana-agent" {
   }
   model  = var.opensearch.model
   config = var.grafana-agent.config
-  units  = 0
 }
 
 resource "juju_application" "backups-integrator" {


### PR DESCRIPTION
This pull request includes a minor update to the Terraform configuration files for Juju applications. The changes remove the `units = 0` line from the `juju_application` resources for Grafana agents in both large and simple deployment configurations.

Terraform configuration updates:

* [`terraform/product/large_deployment/main.tf`](diffhunk://#diff-3b4333288993c43c97225494e9fc9a567c4e4f0d7c494ab73f006445751b1f5eL93): Removed the `units = 0` line from the `juju_application "grafana_agents"` resource.
* [`terraform/product/simple_deployment/main.tf`](diffhunk://#diff-ae6808edad8d1d401fcbbb5fec2bc6c0603fedfb5710585d588072c7969cd990L71): Removed the `units = 0` line from the `juju_application "grafana-agent"` resource.