### PR TITLE
avoid-plugin-check-if-not-ready

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -719,8 +719,8 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             event.defer()
             return
 
-        if not self.opensearch_peer_cm.deployment_desc():
-            logger.info("Deployment description not ready yet, deferring and trying later.")
+        if not self.opensearch.is_node_up():
+            logger.debug("Node not up yet, deferring plugin check")
             event.defer()
             return
 
@@ -738,7 +738,6 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
                 self.status.set(MaintenanceStatus(PluginConfigCheck))
 
             plugin_needs_restart = self.plugin_manager.run()
-
         except (OpenSearchNotFullyReadyError, OpenSearchPluginError) as e:
             if isinstance(e, OpenSearchNotFullyReadyError):
                 logger.warning("Plugin management: cluster not ready yet at config changed")

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -721,6 +721,9 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
 
         if not self.opensearch.is_node_up():
             logger.debug("Node not up yet, deferring plugin check")
+            # possible enhancement:
+            # currently we wait for Opensearch to be started before applying any plugin
+            # this could be improved as some plugins don't require the service to run
             event.defer()
             return
 

--- a/tests/integration/plugins/test_plugins.py
+++ b/tests/integration/plugins/test_plugins.py
@@ -212,12 +212,17 @@ async def test_config_switch_before_cluster_ready(ops_test: OpsTest, deploy_type
         timeout=3400,
         idle_period=IDLE_PERIOD,
     )
-    await assert_knn_config_updated(ops_test, True, check_api=False)
+    # disabled as plugins can currently only be activated after Opensearch has started
+    # see https://github.com/canonical/opensearch-operator/pull/633
+    # await assert_knn_config_updated(ops_test, True, check_api=False)
 
     # Relate it to OpenSearch to set up TLS.
     await ops_test.model.integrate(APP_NAME, TLS_CERTIFICATES_APP_NAME)
     await _wait_for_units(ops_test, deploy_type)
     assert len(ops_test.model.applications[APP_NAME].units) == 3
+
+    # to be removed here once enabling plugins before startup is possible again
+    await assert_knn_config_updated(ops_test, True, check_api=False)
 
 
 @pytest.mark.parametrize("deploy_type", SMALL_DEPLOYMENTS)


### PR DESCRIPTION
## Issue
When deploying Opensearch, the operator runs a plugin check and tries to enable configured plugins on the initial `config_changed` event. This is unnecessary and fails with `OpenSearchKeystoreNotReadyError` because Opensearch was not started and its API's are not available yet. 

## Solution
Wait with the plugin check/enabling until Opensearch is started.
