### PR TITLE
Add continue-on-error to terraform step of CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,13 +3,13 @@
 name: Tests
 
 concurrency:
-  group: "${{ github.workflow }}-${{ github.ref }}"
+  group: '${{ github.workflow }}-${{ github.ref }}'
   cancel-in-progress: true
 
 on:
   pull_request:
   schedule:
-    - cron: "53 0 * * *" # Daily at 00:53 UTC
+    - cron: '53 0 * * *' # Daily at 00:53 UTC
   # Triggered on push to branch "main" by .github/workflows/release.yaml
   workflow_call:
     outputs:
@@ -56,6 +56,8 @@ jobs:
 
   terraform-test:
     name: Terraform - Validation and Simple Deployment product
+    # TODO remove this when terraform units=0 bug is fixed
+    continue-on-error: true
     runs-on: ubuntu-22.04
     timeout-minutes: 120
     steps:


### PR DESCRIPTION
### Workflow configuration updates:

* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL6-R12): Changed double quotes to single quotes for string values in the `concurrency` and `schedule` sections to ensure consistent formatting.
* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR59-R60): Added `continue-on-error: true` to the `terraform-test` job as a temporary measure to bypass failures caused by a known Terraform bug. A TODO comment was added to remove this once the bug is resolved.