### PR TITLE
[DPE 7352] Stabilize backup tests

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_backups.py
+++ b/lib/charms/opensearch/v0/opensearch_backups.py
@@ -714,10 +714,11 @@ class OpenSearchBackupBase(Object):
         if self.charm.unit.is_leader():
             self.charm.status.clear(BackupRelShouldNotExist, app=True)
 
-        if (
-            not (deployment_desc := self.charm.opensearch_peer_cm.deployment_desc())
-            or deployment_desc.typ != DeploymentType.MAIN_ORCHESTRATOR
-        ):
+        if not (deployment_desc := self.charm.opensearch_peer_cm.deployment_desc()):
+            event.defer()
+            return
+
+        if deployment_desc.typ != DeploymentType.MAIN_ORCHESTRATOR:
             # Nothing to do besides fixing the status
             return
 

--- a/lib/charms/opensearch/v0/opensearch_backups.py
+++ b/lib/charms/opensearch/v0/opensearch_backups.py
@@ -715,8 +715,8 @@ class OpenSearchBackupBase(Object):
             self.charm.status.clear(BackupRelShouldNotExist, app=True)
 
         if (
-            not (deplopyment_desc := self.charm.opensearch_peer_cm.deployment_desc())
-            or deplopyment_desc.typ != DeploymentType.MAIN_ORCHESTRATOR
+            not (deployment_desc := self.charm.opensearch_peer_cm.deployment_desc())
+            or deployment_desc.typ != DeploymentType.MAIN_ORCHESTRATOR
         ):
             # Nothing to do besides fixing the status
             return

--- a/lib/charms/opensearch/v0/opensearch_backups.py
+++ b/lib/charms/opensearch/v0/opensearch_backups.py
@@ -714,7 +714,10 @@ class OpenSearchBackupBase(Object):
         if self.charm.unit.is_leader():
             self.charm.status.clear(BackupRelShouldNotExist, app=True)
 
-        if self.charm.opensearch_peer_cm.deployment_desc().typ != DeploymentType.MAIN_ORCHESTRATOR:
+        if (
+            not (deplopyment_desc := self.charm.opensearch_peer_cm.deployment_desc())
+            or deplopyment_desc.typ != DeploymentType.MAIN_ORCHESTRATOR
+        ):
             # Nothing to do besides fixing the status
             return
 


### PR DESCRIPTION
## Issue
The deployment description can be `None` if the cluster is being removed, the `on_backups_disable` hook accesses a deployment description property which raises an error in this case.

## Solution
Defer the event if there is no deployment description

closes #640. 
