### PR TITLE
[DPE-7545] Fix s3-uri-style handling

### DIFF
--- a/lib/charms/opensearch/v0/models.py
+++ b/lib/charms/opensearch/v0/models.py
@@ -314,7 +314,6 @@ class S3RelData(Model):
     @root_validator
     def validate_core_fields(cls, values):  # noqa: N805
         """Validate the core fields of the S3 relation data."""
-        # Do not raise an exception if we are missing all the fields:
         if (
             not (s3_creds := values.get("credentials"))
             or not s3_creds.access_key

--- a/lib/charms/opensearch/v0/models.py
+++ b/lib/charms/opensearch/v0/models.py
@@ -301,10 +301,10 @@ class S3RelData(Model):
     region: str = Field(default="")
     base_path: Optional[str] = Field(alias="path", default=S3_REPO_BASE_PATH)
     protocol: Optional[str] = None
-    storage_class: Optional[str] = Field(alias="storage-class")
-    tls_ca_chain: Optional[str] = Field(alias="tls-ca-chain")
+    storage_class: Optional[str] = Field(alias="storage-class", default=None)
+    tls_ca_chain: Optional[str] = Field(alias="tls-ca-chain", default=None)
     credentials: S3RelDataCredentials = Field(alias=S3_CREDENTIALS, default=S3RelDataCredentials())
-    path_style_access: Optional[bool] = False
+    path_style_access: bool = Field(alias="s3-uri-style", default=False)
 
     class Config:
         """Model config of this pydantic model."""
@@ -317,8 +317,8 @@ class S3RelData(Model):
         # Do not raise an exception if we are missing all the fields:
         if (
             not (s3_creds := values.get("credentials"))
-            and not s3_creds.access_key
-            and not s3_creds.secret_key
+            or not s3_creds.access_key
+            or not s3_creds.secret_key
         ):
             raise ValueError("Missing fields: access_key, secret_key")
 
@@ -332,10 +332,14 @@ class S3RelData(Model):
         if not values.get("region"):
             raise ValueError("Missing field: region")
 
-        if values.get("s3-uri-style") == "path":
-            values["bucket_path_style"] = True
-
         return values
+
+    @validator("path_style_access", pre=True)
+    def change_path_style_type(cls, value) -> bool:  # noqa: N805
+        """Coerce a type change of the path_style_access into a bool."""
+        if isinstance(value, str):
+            return value.lower() == "path"
+        return bool(value)
 
     @validator(S3_CREDENTIALS, check_fields=False)
     def ensure_secret_content(cls, conf: Dict[str, str] | S3RelDataCredentials):  # noqa: N805
@@ -416,8 +420,8 @@ class AzureRelData(Model):
         """Validate the core fields of the azure relation data."""
         if (
             not (creds := values.get("credentials"))
-            and not creds.storage_account
-            and not creds.secret_key
+            or not creds.storage_account
+            or not creds.secret_key
         ):
             raise ValueError("Missing fields: storage_account, secret_key")
 

--- a/tests/unit/lib/test_backups.py
+++ b/tests/unit/lib/test_backups.py
@@ -630,7 +630,9 @@ class TestBackups(unittest.TestCase):
         event = MagicMock()
         self.charm.backup.backup_manager.is_set = MagicMock(return_value=True)
         self.charm.backup.backup_manager.is_backup_in_progress = MagicMock(return_value=False)
-        mock_request.side_effect = OpenSearchHttpError("Internal Server Error", 500)
+        mock_request.side_effect = OpenSearchHttpError(
+            response_text="Internal Server Error", response_code=500
+        )
         self.charm.backup._on_create_backup_action(event)
         event.fail.assert_called_with(
             "Failed with exception: HTTP error self.response_code='Internal Server Error'\nself.response_text=500"

--- a/tests/unit/lib/test_backups.py
+++ b/tests/unit/lib/test_backups.py
@@ -17,6 +17,7 @@ from charms.opensearch.v0.constants_charm import (
     RestoreInProgress,
 )
 from charms.opensearch.v0.helper_cluster import IndexStateEnum
+from charms.opensearch.v0.models import PerformanceType
 from charms.opensearch.v0.opensearch_backups import (
     S3_REPOSITORY,
     BackupServiceState,
@@ -69,13 +70,14 @@ def create_deployment_desc(*args, **kwargs):
             cluster_name="logs",
             init_hold=False,
             roles=["cluster_manager", "data"],
-            profile="production",
+            profile=PerformanceType.PRODUCTION,
         ),
         start=StartMode.WITH_PROVIDED_ROLES,
         pending_directives=[],
         app=App(model_uuid="model-uuid", name="opensearch"),
         typ=DeploymentType.MAIN_ORCHESTRATOR,
         state=DeploymentState(value=State.ACTIVE),
+        promotion_time=None,
     )
 
 
@@ -628,7 +630,7 @@ class TestBackups(unittest.TestCase):
         event = MagicMock()
         self.charm.backup.backup_manager.is_set = MagicMock(return_value=True)
         self.charm.backup.backup_manager.is_backup_in_progress = MagicMock(return_value=False)
-        mock_request.side_effect = OpenSearchHttpError(500, "Internal Server Error")
+        mock_request.side_effect = OpenSearchHttpError("Internal Server Error", 500)
         self.charm.backup._on_create_backup_action(event)
         event.fail.assert_called_with(
             "Failed with exception: HTTP error self.response_code='Internal Server Error'\nself.response_text=500"

--- a/tests/unit/lib/test_backups.py
+++ b/tests/unit/lib/test_backups.py
@@ -635,7 +635,7 @@ class TestBackups(unittest.TestCase):
         )
         self.charm.backup._on_create_backup_action(event)
         event.fail.assert_called_with(
-            "Failed with exception: HTTP error self.response_code='Internal Server Error'\nself.response_text=500"
+            "Failed with exception: HTTP error self.response_code=500\nself.response_text='Internal Server Error'"
         )
 
     def test_on_restore_backup_action(self, _):


### PR DESCRIPTION
## Issue
This PR addresses [DPE-7545](https://warthogs.atlassian.net/browse/DPE-7545) / https://github.com/canonical/opensearch-operator/issues/651. Namely this PR:
- fixes the incorrect mapping between the `s3-uri-style` string property sent by the `s3` relation to the `path_style_access` boolean property expected by opensearch.
- fixes wrong conditions on the handling of missing s3/azure cloud credentials


[DPE-7545]: https://warthogs.atlassian.net/browse/DPE-7545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ