### PR TITLE
[DPE-7560] Remove wrong default base path for snapshots repositories

### DIFF
--- a/lib/charms/opensearch/v0/constants_charm.py
+++ b/lib/charms/opensearch/v0/constants_charm.py
@@ -124,9 +124,7 @@ OPENSEARCH_SNAP_REVISION = 70  # Keep in sync with `workload_version` file
 # User-face Backup ID format
 OPENSEARCH_BACKUP_ID_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
-S3_REPO_BASE_PATH = "/"
 S3_RELATION = "s3-credentials"
-AZURE_REPO_BASE_PATH = "/"
 AZURE_RELATION = "azure-credentials"
 
 OAUTH_RELATION = "oauth"

--- a/lib/charms/opensearch/v0/models.py
+++ b/lib/charms/opensearch/v0/models.py
@@ -429,6 +429,11 @@ class AzureRelData(Model):
         ):
             raise ValueError("Missing fields: storage_account, secret_key")
 
+        # remove any duplicate, prefix or trailing "/" characters
+        if base_path := values.get("base_path"):
+            base_path = re.sub(r"/+", "/", base_path).strip().strip("/")
+        values["base_path"] = base_path or None
+
         return values
 
     @validator(AZURE_CREDENTIALS, check_fields=False)

--- a/lib/charms/opensearch/v0/models.py
+++ b/lib/charms/opensearch/v0/models.py
@@ -9,7 +9,6 @@ from datetime import datetime
 from hashlib import md5
 from typing import Any, Dict, List, Literal, Optional
 
-from charms.opensearch.v0.constants_charm import AZURE_REPO_BASE_PATH, S3_REPO_BASE_PATH
 from charms.opensearch.v0.constants_secrets import AZURE_CREDENTIALS, S3_CREDENTIALS
 from charms.opensearch.v0.helper_enums import BaseStrEnum
 from pydantic import BaseModel, Field, root_validator, validator
@@ -299,7 +298,7 @@ class S3RelData(Model):
     bucket: str = Field(default="")
     endpoint: str = Field(default="")
     region: str = Field(default="")
-    base_path: Optional[str] = Field(alias="path", default=S3_REPO_BASE_PATH)
+    base_path: Optional[str] = Field(alias="path", default=None)
     protocol: Optional[str] = None
     storage_class: Optional[str] = Field(alias="storage-class", default=None)
     tls_ca_chain: Optional[str] = Field(alias="tls-ca-chain", default=None)
@@ -403,7 +402,7 @@ class AzureRelData(Model):
     storage_account: str = Field(alias="storage-account", default="")
     container: str = Field(default="")
     endpoint: Optional[str] = Field(default="")
-    base_path: Optional[str] = Field(alias="path", default=AZURE_REPO_BASE_PATH)
+    base_path: Optional[str] = Field(alias="path", default=None)
     connection_protocol: Optional[str] = Field(alias="connection-protocol", default=None)
     credentials: AzureRelDataCredentials = Field(
         alias=AZURE_CREDENTIALS, default=AzureRelDataCredentials()

--- a/lib/charms/opensearch/v0/models.py
+++ b/lib/charms/opensearch/v0/models.py
@@ -4,6 +4,7 @@
 """Cluster-related data structures / model classes."""
 import json
 import logging
+import re
 from abc import ABC
 from datetime import datetime
 from hashlib import md5
@@ -329,6 +330,11 @@ class S3RelData(Model):
             raise ValueError("Missing field: bucket")
         if not values.get("region"):
             raise ValueError("Missing field: region")
+
+        # remove any duplicate, prefix or trailing "/" characters
+        if base_path := values.get("base_path"):
+            base_path = re.sub(r"/+", "/", base_path).strip().strip("/")
+        values["base_path"] = base_path or None
 
         return values
 


### PR DESCRIPTION
## Issue
This PR addresses [DPE-7560](https://warthogs.atlassian.net/browse/DPE-7560) / https://github.com/canonical/opensearch-operator/issues/657, namely this PR:
- fixes the wrong default value on the snapshot repositories' path
- adds sanitation of input on the `base_path` field 


[DPE-7560]: https://warthogs.atlassian.net/browse/DPE-7560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ