### PR TITLE
[DPE-7565] Add tiobe runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+self-hosted-runner:
+  labels:
+    - self-hosted
+    - linux
+    - amd64
+    - tiobe
+    - noble

--- a/.github/workflows/tics_run_sh_ghaction_test.yml
+++ b/.github/workflows/tics_run_sh_ghaction_test.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: [self-hosted, linux, X64]
+    runs-on: [self-hosted, linux, amd64, tiobe, noble]
 
     steps:
       - name: Checkout the project


### PR DESCRIPTION
## Issue
This PR addresses [DPE-7565](https://warthogs.atlassian.net/browse/DPE-7565) / https://github.com/canonical/opensearch-operator/issues/659. Specifically, this PR:
- Switches from self-hosted-runners to Tiobe runners which come with a set of pre-installed tools useful for code scanning.


[DPE-7565]: https://warthogs.atlassian.net/browse/DPE-7565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ