### PR TITLE
[DPE-7559] Fix leader-elected hook for non-leader units (post deferral)

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -281,7 +281,8 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
     def _on_leader_elected(self, event: LeaderElectedEvent):
         """Handle leader election event."""
         # We check if the current unit is the leader, in case where the leader elected event
-        # was deferred, then juju proceeded with a new leader election
+        # was deferred, then juju proceeded with a new leader election, and this now deferred-event
+        # was emitted in a non-juju leader unit (previous leader)
         if not self.unit.is_leader():
             return
 

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -280,6 +280,11 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
 
     def _on_leader_elected(self, event: LeaderElectedEvent):
         """Handle leader election event."""
+        # We check if the current unit is the leader, in case where the leader elected event
+        # was deferred, then juju proceeded with a new leader election
+        if not self.unit.is_leader():
+            return
+
         if self.peers_data.get(Scope.APP, "security_index_initialised", False):
             # Leader election event happening after a previous leader got killed
             if not self.opensearch.is_node_up():


### PR DESCRIPTION
## Issue
This PR addresses an edge case described in: [DPE-7559](https://warthogs.atlassian.net/browse/DPE-7559) / https://github.com/canonical/opensearch-operator/issues/656. Specifically, this PR:
- safeguards against a change in the juju-leadership **right after a leader-elected deferral** 

[DPE-7559]: https://warthogs.atlassian.net/browse/DPE-7559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ