### PR TITLE
[DPE-7574] Fix interpolated pattern match

### DIFF
--- a/lib/charms/opensearch/v0/helper_charm.py
+++ b/lib/charms/opensearch/v0/helper_charm.py
@@ -65,7 +65,8 @@ class Status:
             condition = context.status.message.endswith(status_message)
         elif pattern == Status.CheckPattern.Interpolated:
             condition = (
-                re.fullmatch(status_message.replace("{}", "(?s:.*?)"), status_message) is not None
+                re.fullmatch(status_message.replace("{}", "(?s:.*?)"), context.status.message)
+                is not None
             )
         else:
             condition = status_message in context.status.message

--- a/tests/unit/lib/test_helper_charm.py
+++ b/tests/unit/lib/test_helper_charm.py
@@ -46,6 +46,10 @@ class TestHelperDatabag(unittest.TestCase):
         self.status.clear(message_template, pattern=Status.CheckPattern.Interpolated)
         self.assertEqual(self.charm.unit.status.name, "active")
 
+        self.charm.unit.status = BlockedStatus("Should not be cleared")
+        self.status.clear(message_template, pattern=Status.CheckPattern.Interpolated)
+        self.assertEqual(self.charm.unit.status.name, "blocked")
+
     def test_mask_sensitive_information(self):
         """Verify the pattern to remove sensitive information from the logs."""
         command_to_test = """-tspass mypasswd \


### PR DESCRIPTION
## Issue
The `charm.status.clear` regex check is matching the template message against itself rather than the status message for the case of `Status.CheckPattern.Interpolated`

## Solution
Match against `context.status.message`
