### PR TITLE
Change track of grafana-agent in test-plugins

### DIFF
--- a/tests/integration/plugins/test_plugins.py
+++ b/tests/integration/plugins/test_plugins.py
@@ -246,7 +246,7 @@ async def test_prometheus_exporter_enabled_by_default(ops_test, deploy_type: str
 async def test_small_deployments_prometheus_exporter_cos_relation(
     ops_test, series, deploy_type: str
 ):
-    await ops_test.model.deploy(COS_APP_NAME, channel="edge", series=series),
+    await ops_test.model.deploy(COS_APP_NAME, channel="1/edge", series=series),
     await ops_test.model.integrate(APP_NAME, COS_APP_NAME)
     await _wait_for_units(ops_test, deploy_type, wait_for_cos=True)
 


### PR DESCRIPTION
## Issue
The grafana-agent has deprecated the `latest/` track, in favor of `1/`. We need to change it in the integration tests.