### PR TITLE
[DPE-7076] Data node fails to start

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -42,8 +42,6 @@ jobs:
               _, runner, task, variant = job.split(":")
               # Example: "test_charm.py"
               task = task.removeprefix("tests/spread/")
-              if "remove_orchestrators" in task:
-                continue
               # For IS-hosted runners
               if "arm64" in runner:
                   architecture = "arm64"

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -1189,6 +1189,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         self.unit.open_port("tcp", 9200)
 
         # clear waiting to start status
+        self.status.clear(RequestUnitServiceOps.format("start"))
         self.status.clear(WaitingToStart)
         self.status.clear(ServiceStartError)
         self.status.clear(PClusterNoDataNode)

--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -675,7 +675,7 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
                 blocked_msg = f"Security index not initialized {message_suffix}."
         elif (
             ClusterTopology.data_role_in_cluster_fleet_apps(self.charm)
-            or deployment_desc.start == StartMode.WITH_GENERATED_ROLES
+            and self.charm.peers_data.get(Scope.APP, "security_index_initialised", False)
         ):
             if not self.charm.is_every_unit_marked_as_started():
                 blocked_msg = f"Waiting for every unit {message_suffix} to start."

--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -676,6 +676,10 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
         elif ClusterTopology.data_role_in_cluster_fleet_apps(
             self.charm
         ) and self.charm.peers_data.get(Scope.APP, "security_index_initialised", False):
+            # Requirer units should start after all provider units have started,
+            # and only if the security index has already been initialized by a data node.
+            # This avoids a potential deadlock where both orchestrator and data units
+            # wait on each other to proceed.
             if not self.charm.is_every_unit_marked_as_started():
                 blocked_msg = f"Waiting for every unit {message_suffix} to start."
             elif not self.charm.secrets.get(Scope.APP, self.charm.secrets.password_key(COSUser)):

--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -673,10 +673,9 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
         ):
             if not self.charm.peers_data.get(Scope.APP, "security_index_initialised", False):
                 blocked_msg = f"Security index not initialized {message_suffix}."
-        elif (
-            ClusterTopology.data_role_in_cluster_fleet_apps(self.charm)
-            and self.charm.peers_data.get(Scope.APP, "security_index_initialised", False)
-        ):
+        elif ClusterTopology.data_role_in_cluster_fleet_apps(
+            self.charm
+        ) and self.charm.peers_data.get(Scope.APP, "security_index_initialised", False):
             if not self.charm.is_every_unit_marked_as_started():
                 blocked_msg = f"Waiting for every unit {message_suffix} to start."
             elif not self.charm.secrets.get(Scope.APP, self.charm.secrets.password_key(COSUser)):


### PR DESCRIPTION
## Issue
If the presence of the data node is detected during the first call to `refresh_relation_data`, a `'Waiting for every unit in <main-orchestrator> to start'` error state is set in the peer-cluster relation data, blocking the data node from starting and from initializing the security index, which in turn blocks the units from other applications from starting and results in a deadlock.

## Solution
Only set the error if the main orchestrator detects a data node in the cluster and the security index has been initialized.

This PR also re-ables the remove-orchestrators tests and clears the `Requesting lock on operation start` status in post-start-init for the cases where opensearch takes longer than expected to start and `is_started` is detected at a later event

Fixes #631 / [DPE-7076] and [DPE-7527]


[DPE-7076]: https://warthogs.atlassian.net/browse/DPE-7076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DPE-7527]: https://warthogs.atlassian.net/browse/DPE-7527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ