### PR TITLE
opensearch_oauth: add LIBID, LIBAPI, LIBPATCH

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_oauth.py
+++ b/lib/charms/opensearch/v0/opensearch_oauth.py
@@ -17,6 +17,16 @@ from ops import EventBase, Object, RelationBrokenEvent, RelationDepartedEvent
 if TYPE_CHECKING:
     from charms.opensearch.v0.opensearch_base_charm import OpenSearchBaseCharm
 
+# The unique Charmhub library identifier, never change it
+LIBID = "c761774d45d8494fb3601addc7676d0e"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Issue
The charm release workflow complains that the opensearch_oauth lib is missing mandatory metadata fields.

## Solution
Generate LIBID, LIBAPI and LIBPATCH for opensearch_oauth.py

