### PR TITLE
[DPE-7059] - detect error while starting os

### DIFF
--- a/lib/charms/opensearch/v0/helper_cluster.py
+++ b/lib/charms/opensearch/v0/helper_cluster.py
@@ -148,13 +148,10 @@ class ClusterTopology:
     @staticmethod
     def data_role_in_cluster_fleet_apps(charm: "OpenSearchBaseCharm") -> bool:
         """Look for data-role through all the roles of all the nodes in all applications"""
-        if cluster_apps := charm.peers_data.get_object(Scope.APP, "cluster_fleet_apps"):
-            for app in cluster_apps.values():
-                p_cluster_app = PeerClusterApp.from_dict(app)
-                if "data" in p_cluster_app.roles:
-                    return True
-
-        return False
+        data_apps_in_fleet = [
+            app for app in charm.opensearch_peer_cm.apps_in_fleet() if "data" in app.roles
+        ]
+        return data_apps_in_fleet and any(app.planned_units > 0 for app in data_apps_in_fleet)
 
     @staticmethod
     def nodes(

--- a/lib/charms/opensearch/v0/helper_cluster.py
+++ b/lib/charms/opensearch/v0/helper_cluster.py
@@ -145,7 +145,7 @@ class ClusterTopology:
         return result
 
     @staticmethod
-    def data_role_in_cluster_fleet_apps(charm: "OpenSearchBaseCharm") -> bool:
+    def is_data_role_in_cluster_fleet_apps(charm: "OpenSearchBaseCharm") -> bool:
         """Look for data-role through all the roles of all the nodes in all applications"""
         data_apps_in_fleet = [
             app for app in charm.opensearch_peer_cm.apps_in_fleet() if "data" in app.roles

--- a/lib/charms/opensearch/v0/helper_cluster.py
+++ b/lib/charms/opensearch/v0/helper_cluster.py
@@ -7,9 +7,8 @@ from typing import TYPE_CHECKING, Dict, List, Optional
 
 from charms.opensearch.v0.constants_charm import GeneratedRoles
 from charms.opensearch.v0.helper_enums import BaseStrEnum
-from charms.opensearch.v0.models import App, Node, PeerClusterApp
+from charms.opensearch.v0.models import App, Node
 from charms.opensearch.v0.opensearch_distro import OpenSearchDistribution
-from charms.opensearch.v0.opensearch_internal_data import Scope
 from tenacity import retry, stop_after_attempt, wait_exponential
 
 # The unique Charmhub library identifier, never change it

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -608,7 +608,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
                     self.peers_data.delete(Scope.APP, "nodes_config")
                     # we delete the security index initialised and bootstrapped flags
                     # if there are no data units left in all cluster
-                    if not ClusterTopology.data_role_in_cluster_fleet_apps(self):
+                    if not ClusterTopology.is_data_role_in_cluster_fleet_apps(self):
                         self.peers_data.delete(Scope.APP, "security_index_initialised")
                         self.peers_data.delete(Scope.APP, "bootstrapped")
                 if self.opensearch_peer_cm.is_provider():
@@ -1041,7 +1041,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
                 # check if cluster should have started but is blocked
                 logger.debug("OpenSearch already started, but post-start init failed.")
                 if (
-                    ClusterTopology.data_role_in_cluster_fleet_apps(self)
+                    ClusterTopology.is_data_role_in_cluster_fleet_apps(self)
                     and self.peers_data.get(Scope.APP, "bootstrapped", False)
                     and self.opensearch_peer_cm.is_provider(typ="main")
                 ):
@@ -1112,21 +1112,11 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             OpenSearchNotFullyReadyError,
         ) as e:
             self.node_lock.release()
-            if (
-                ClusterTopology.data_role_in_cluster_fleet_apps(self)
-                and self.peers_data.get(Scope.APP, "bootstrapped", False)
-                # In large deployments with cluster-manager-only-nodes, the startup might fail
-                # for the cluster-manager if a joining data node did not yet initialize the
-                # security index. We still want to update and broadcast the latest relation data.
-                and self.opensearch_peer_cm.is_provider(typ="main")
-            ):
-                # In large deployments with cluster-manager-only-nodes,
-                # the startup might fail if the cluster was bootstrapped already
-                # and the cluster-manager node lost its data
-                logger.warning(
-                    "Node is not ready to start, but data node exists and the cluster was previously bootstrapped."
-                )
-                self.status.set(BlockedStatus(ServiceStartError))
+            self.status.set(BlockedStatus(ServiceStartError))
+            
+            # In large deployments with cluster-manager-only-nodes, the startup might fail
+            # for the cluster-manager if a joining data node did not yet initialize the
+            # security index. We still want to update and broadcast the latest relation data.
             if self.opensearch_peer_cm.is_provider(typ="main"):
                 self.peer_cluster_provider.refresh_relation_data(event, can_defer=False)
             event.defer()

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -1045,9 +1045,9 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
                     and self.peers_data.get(Scope.APP, "bootstrapped", False)
                     and self.opensearch_peer_cm.is_provider(typ="main")
                 ):
-                    # In large deployments with cluster-manager-only-nodes, 
-                    # the startup might fail if the cluster was bootstrapped earlier and the cluster-manager node
-                    # lost its data
+                    # In large deployments with cluster-manager-only-nodes,
+                    # the startup might fail if the cluster was bootstrapped earlier
+                    # and the cluster-manager node lost its data
                     logger.warning(
                         "Node is not ready to start, but data node exists and the cluster was previously bootstrapped."
                     )
@@ -1120,9 +1120,9 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
                 and self.peers_data.get(Scope.APP, "bootstrapped", False)
                 and self.opensearch_peer_cm.is_provider(typ="main")
             ):
-                # In large deployments with cluster-manager-only-nodes, 
-                    # the startup might fail if the cluster was bootstrapped already and the cluster-manager node
-                    # lost its data
+                # In large deployments with cluster-manager-only-nodes,
+                # the startup might fail if the cluster was bootstrapped already
+                # and the cluster-manager node lost its data
                 logger.warning(
                     "Node is not ready to start, but data node exists and the cluster was previously bootstrapped."
                 )
@@ -1278,14 +1278,15 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         logger.debug("Set upgrade unit state to healthy")
         self._reconcile_upgrade()
 
-        # get cluster uuid and save it to the peer relation data
-        try:
-            cluster_uuid = self.opensearch.request("GET", "/")["cluster_uuid"]
-            self.peers_data.put(Scope.APP, "cluster_uuid", cluster_uuid)
-        except OpenSearchHttpError as e:
-            logger.error(f"Failed to get cluster uuid, cluster might not be up: {e}")
-            event.defer()
-            return
+        # get cluster uuid and save it to the peer relation data if leader unit
+        if self.unit.is_leader():
+            try:
+                cluster_uuid = self.opensearch.request("GET", "/")["cluster_uuid"]
+                self.peers_data.put(Scope.APP, "cluster_uuid", cluster_uuid)
+            except OpenSearchHttpError as e:
+                logger.error(f"Failed to get cluster uuid, cluster might not be up: {e}")
+                event.defer()
+                return
 
         # update the peer cluster rel data with new IP in case of main cluster manager
         if self.opensearch_peer_cm.is_provider():

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -1113,7 +1113,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         ) as e:
             self.node_lock.release()
             self.status.set(BlockedStatus(ServiceStartError))
-            
+
             # In large deployments with cluster-manager-only-nodes, the startup might fail
             # for the cluster-manager if a joining data node did not yet initialize the
             # security index. We still want to update and broadcast the latest relation data.

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -420,6 +420,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             deployment_desc.typ == DeploymentType.MAIN_ORCHESTRATOR
             and not deployment_desc.start == StartMode.WITH_GENERATED_ROLES
             and "data" not in deployment_desc.config.roles
+            and not self.is_data_app_in_fleet()
         ):
             self.status.set(BlockedStatus(PClusterNoDataNode))
             event.defer()
@@ -607,14 +608,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
                     self.peers_data.delete(Scope.APP, "nodes_config")
                     # we delete the security index initialised and bootstrapped flags
                     # if there are no data units left in all cluster
-                    data_apps_in_fleet = [
-                        app
-                        for app in self.opensearch_peer_cm.apps_in_fleet()
-                        if "data" in app.roles
-                    ]
-                    if not data_apps_in_fleet or all(
-                        app.planned_units == 0 for app in data_apps_in_fleet
-                    ):
+                    if self.is_data_app_in_fleet():
                         self.peers_data.delete(Scope.APP, "security_index_initialised")
                         self.peers_data.delete(Scope.APP, "bootstrapped")
                 if self.opensearch_peer_cm.is_provider():
@@ -1044,6 +1038,15 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
                 OpenSearchHttpError,
                 OpenSearchNotFullyReadyError,
             ):
+                # check if cluster should have started but is blocked
+                logger.debug("OpenSearch already started, but post-start init failed.")
+                if self.is_data_app_in_fleet() and self.peers_data.get(Scope.APP, "bootstrapped", False) and self.opensearch_peer_cm.is_provider(typ="main"):
+                    # if data node exists and cluster was previously bootstrapped and the unit is a provider and cannot start
+                    logger.warning(
+                        "Node is not ready to start, but data node exists and the cluster was previously bootstrapped."
+                    )
+                    self.status.set(BlockedStatus(ServiceStartError))
+
                 event.defer()
             except OpenSearchUserMgmtError as e:
                 # Either generic start failure or cluster is not read to create the internal users
@@ -1106,6 +1109,12 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             # In large deployments with cluster-manager-only-nodes, the startup might fail
             # for the cluster-manager if a joining data node did not yet initialize the
             # security index. We still want to update and broadcast the latest relation data.
+            if self.is_data_app_in_fleet() and self.peers_data.get(Scope.APP, "bootstrapped", False) and self.opensearch_peer_cm.is_provider(typ="main"):
+                    # if data node exists and cluster was previously bootstrapped and the unit is a provider and cannot start
+                    logger.warning(
+                        "Node is not ready to start, but data node exists and the cluster was previously bootstrapped."
+                    )
+                    self.status.set(BlockedStatus(ServiceStartError))
             if self.opensearch_peer_cm.is_provider(typ="main"):
                 self.peer_cluster_provider.refresh_relation_data(event, can_defer=False)
             event.defer()
@@ -1256,6 +1265,15 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         self._upgrade.unit_state = upgrade.UnitState.HEALTHY
         logger.debug("Set upgrade unit state to healthy")
         self._reconcile_upgrade()
+
+        # get cluster uuid and save it to the peer relation data
+        try:
+            cluster_uuid = self.opensearch.request("GET", "/")["cluster_uuid"]
+            self.peers_data.put(Scope.APP, "cluster_uuid", cluster_uuid)
+        except OpenSearchHttpError as e:
+            logger.error(f"Failed to get cluster uuid, cluster might not be up: {e}")
+            event.defer()
+            return
 
         # update the peer cluster rel data with new IP in case of main cluster manager
         if self.opensearch_peer_cm.is_provider():
@@ -1853,3 +1871,14 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         return [
             host for host in all_hosts if host != self.unit_ip and self.opensearch.is_node_up(host)
         ]
+
+    def is_data_app_in_fleet(self) -> bool:
+        """Check if the data app is in the fleet."""
+        data_apps_in_fleet = [
+                        app
+                        for app in self.opensearch_peer_cm.apps_in_fleet()
+                        if "data" in app.roles
+                    ]
+        return data_apps_in_fleet and any(
+            app.planned_units > 0 for app in data_apps_in_fleet
+        )

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -608,7 +608,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
                     self.peers_data.delete(Scope.APP, "nodes_config")
                     # we delete the security index initialised and bootstrapped flags
                     # if there are no data units left in all cluster
-                    if self.is_data_app_in_fleet():
+                    if not self.is_data_app_in_fleet():
                         self.peers_data.delete(Scope.APP, "security_index_initialised")
                         self.peers_data.delete(Scope.APP, "bootstrapped")
                 if self.opensearch_peer_cm.is_provider():
@@ -1040,8 +1040,14 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             ):
                 # check if cluster should have started but is blocked
                 logger.debug("OpenSearch already started, but post-start init failed.")
-                if self.is_data_app_in_fleet() and self.peers_data.get(Scope.APP, "bootstrapped", False) and self.opensearch_peer_cm.is_provider(typ="main"):
-                    # if data node exists and cluster was previously bootstrapped and the unit is a provider and cannot start
+                if (
+                    self.is_data_app_in_fleet()
+                    and self.peers_data.get(Scope.APP, "bootstrapped", False)
+                    and self.opensearch_peer_cm.is_provider(typ="main")
+                ):
+                    # In large deployments with cluster-manager-only-nodes, 
+                    # the startup might fail if the cluster was bootstrapped earlier and the cluster-manager node
+                    # lost its data
                     logger.warning(
                         "Node is not ready to start, but data node exists and the cluster was previously bootstrapped."
                     )
@@ -1109,12 +1115,18 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             # In large deployments with cluster-manager-only-nodes, the startup might fail
             # for the cluster-manager if a joining data node did not yet initialize the
             # security index. We still want to update and broadcast the latest relation data.
-            if self.is_data_app_in_fleet() and self.peers_data.get(Scope.APP, "bootstrapped", False) and self.opensearch_peer_cm.is_provider(typ="main"):
-                    # if data node exists and cluster was previously bootstrapped and the unit is a provider and cannot start
-                    logger.warning(
-                        "Node is not ready to start, but data node exists and the cluster was previously bootstrapped."
-                    )
-                    self.status.set(BlockedStatus(ServiceStartError))
+            if (
+                self.is_data_app_in_fleet()
+                and self.peers_data.get(Scope.APP, "bootstrapped", False)
+                and self.opensearch_peer_cm.is_provider(typ="main")
+            ):
+                # In large deployments with cluster-manager-only-nodes, 
+                    # the startup might fail if the cluster was bootstrapped already and the cluster-manager node
+                    # lost its data
+                logger.warning(
+                    "Node is not ready to start, but data node exists and the cluster was previously bootstrapped."
+                )
+                self.status.set(BlockedStatus(ServiceStartError))
             if self.opensearch_peer_cm.is_provider(typ="main"):
                 self.peer_cluster_provider.refresh_relation_data(event, can_defer=False)
             event.defer()
@@ -1875,10 +1887,6 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
     def is_data_app_in_fleet(self) -> bool:
         """Check if the data app is in the fleet."""
         data_apps_in_fleet = [
-                        app
-                        for app in self.opensearch_peer_cm.apps_in_fleet()
-                        if "data" in app.roles
-                    ]
-        return data_apps_in_fleet and any(
-            app.planned_units > 0 for app in data_apps_in_fleet
-        )
+            app for app in self.opensearch_peer_cm.apps_in_fleet() if "data" in app.roles
+        ]
+        return data_apps_in_fleet and any(app.planned_units > 0 for app in data_apps_in_fleet)

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -1278,16 +1278,6 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         logger.debug("Set upgrade unit state to healthy")
         self._reconcile_upgrade()
 
-        # get cluster uuid and save it to the peer relation data if leader unit
-        if self.unit.is_leader():
-            try:
-                cluster_uuid = self.opensearch.request("GET", "/")["cluster_uuid"]
-                self.peers_data.put(Scope.APP, "cluster_uuid", cluster_uuid)
-            except OpenSearchHttpError as e:
-                logger.error(f"Failed to get cluster uuid, cluster might not be up: {e}")
-                event.defer()
-                return
-
         # update the peer cluster rel data with new IP in case of main cluster manager
         if self.opensearch_peer_cm.is_provider():
             self.peer_cluster_provider.refresh_relation_data(event, can_defer=False)

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -420,7 +420,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             deployment_desc.typ == DeploymentType.MAIN_ORCHESTRATOR
             and not deployment_desc.start == StartMode.WITH_GENERATED_ROLES
             and "data" not in deployment_desc.config.roles
-            and not self.is_data_app_in_fleet()
+            and not ClusterTopology.data_role_in_cluster_fleet_apps(self)
         ):
             self.status.set(BlockedStatus(PClusterNoDataNode))
             event.defer()
@@ -608,7 +608,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
                     self.peers_data.delete(Scope.APP, "nodes_config")
                     # we delete the security index initialised and bootstrapped flags
                     # if there are no data units left in all cluster
-                    if not self.is_data_app_in_fleet():
+                    if not ClusterTopology.data_role_in_cluster_fleet_apps(self):
                         self.peers_data.delete(Scope.APP, "security_index_initialised")
                         self.peers_data.delete(Scope.APP, "bootstrapped")
                 if self.opensearch_peer_cm.is_provider():
@@ -1041,7 +1041,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
                 # check if cluster should have started but is blocked
                 logger.debug("OpenSearch already started, but post-start init failed.")
                 if (
-                    self.is_data_app_in_fleet()
+                    ClusterTopology.data_role_in_cluster_fleet_apps(self)
                     and self.peers_data.get(Scope.APP, "bootstrapped", False)
                     and self.opensearch_peer_cm.is_provider(typ="main")
                 ):
@@ -1112,12 +1112,12 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             OpenSearchNotFullyReadyError,
         ) as e:
             self.node_lock.release()
-            # In large deployments with cluster-manager-only-nodes, the startup might fail
-            # for the cluster-manager if a joining data node did not yet initialize the
-            # security index. We still want to update and broadcast the latest relation data.
             if (
-                self.is_data_app_in_fleet()
+                ClusterTopology.data_role_in_cluster_fleet_apps(self)
                 and self.peers_data.get(Scope.APP, "bootstrapped", False)
+                # In large deployments with cluster-manager-only-nodes, the startup might fail
+                # for the cluster-manager if a joining data node did not yet initialize the
+                # security index. We still want to update and broadcast the latest relation data.
                 and self.opensearch_peer_cm.is_provider(typ="main")
             ):
                 # In large deployments with cluster-manager-only-nodes,
@@ -1874,10 +1874,3 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         return [
             host for host in all_hosts if host != self.unit_ip and self.opensearch.is_node_up(host)
         ]
-
-    def is_data_app_in_fleet(self) -> bool:
-        """Check if the data app is in the fleet."""
-        data_apps_in_fleet = [
-            app for app in self.opensearch_peer_cm.apps_in_fleet() if "data" in app.roles
-        ]
-        return data_apps_in_fleet and any(app.planned_units > 0 for app in data_apps_in_fleet)

--- a/lib/charms/opensearch/v0/opensearch_health.py
+++ b/lib/charms/opensearch/v0/opensearch_health.py
@@ -93,7 +93,7 @@ class OpenSearchHealth:
         # compute health only in clusters where data nodes exist
         compute_health = (
             deployment_desc.start == StartMode.WITH_GENERATED_ROLES
-            or ClusterTopology.data_role_in_cluster_fleet_apps(self._charm)
+            or ClusterTopology.is_data_role_in_cluster_fleet_apps(self._charm)
             or not local_app_only
         )
         if not compute_health:

--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -679,7 +679,7 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
         ):
             if not self.charm.peers_data.get(Scope.APP, "security_index_initialised", False):
                 blocked_msg = f"Security index not initialized {message_suffix}."
-        elif ClusterTopology.data_role_in_cluster_fleet_apps(
+        elif ClusterTopology.is_data_role_in_cluster_fleet_apps(
             self.charm
         ) and self.charm.peers_data.get(Scope.APP, "security_index_initialised", False):
             # Requirer units should start after all provider units have started,


### PR DESCRIPTION
This pull request introduces a new helper method, `is_data_app_in_fleet`, to streamline checks for the presence of data apps in the fleet and integrates this method across multiple functions in the `opensearch_base_charm.py` file. The changes enhance code readability and reduce redundancy, while also adding more robust handling for edge cases in large deployments.

### Code Simplification and Reusability:

* **Addition of `is_data_app_in_fleet` helper method**: A new method was added to encapsulate the logic for checking if data apps are present in the fleet, improving code reuse and readability. (`lib/charms/opensearch/v0/opensearch_base_charm.py`, [lib/charms/opensearch/v0/opensearch_base_charm.pyR1877-R1883](diffhunk://#diff-5c0d89f838ffd5a9ecf2288b3698320fda2d2b2b737361b6e10adb55d1929f43R1877-R1883))

* **Refactoring of `_on_opensearch_data_storage_detaching`**: Replaced inline logic for checking data apps in the fleet with the newly added `is_data_app_in_fleet` method, reducing code duplication. (`lib/charms/opensearch/v0/opensearch_base_charm.py`, [lib/charms/opensearch/v0/opensearch_base_charm.pyL610-R611](diffhunk://#diff-5c0d89f838ffd5a9ecf2288b3698320fda2d2b2b737361b6e10adb55d1929f43L610-R611))

### Improved Error Handling:

* **Enhanced error handling in `_start_opensearch`**: Added checks using `is_data_app_in_fleet` to detect scenarios where the cluster-manager node loses its data after bootstrapping, and logs warnings while setting the status to `BlockedStatus`. This ensures better handling of edge cases in large deployments. (`lib/charms/opensearch/v0/opensearch_base_charm.py`, [[1]](diffhunk://#diff-5c0d89f838ffd5a9ecf2288b3698320fda2d2b2b737361b6e10adb55d1929f43R1041-R1055) [[2]](diffhunk://#diff-5c0d89f838ffd5a9ecf2288b3698320fda2d2b2b737361b6e10adb55d1929f43R1118-R1129)

### Logical Adjustments:

* **Update to `_on_start` method**: Incorporated `is_data_app_in_fleet` to refine the conditions for blocking the charm when no data nodes are detected. (`lib/charms/opensearch/v0/opensearch_base_charm.py`, [lib/charms/opensearch/v0/opensearch_base_charm.pyR423](diffhunk://#diff-5c0d89f838ffd5a9ecf2288b3698320fda2d2b2b737361b6e10adb55d1929f43R423))