### PR TITLE
Re-enable opensearch_provider tests

### DIFF
--- a/tests/integration/relations/test_opensearch_provider.py
+++ b/tests/integration/relations/test_opensearch_provider.py
@@ -55,7 +55,6 @@ PROTECTED_INDICES = [
 ]
 
 
-@pytest.mark.skip(reason="Merge 2.19.2 change")
 @pytest.mark.abort_on_fail
 async def test_create_relation(ops_test: OpsTest, application_charm, charm, series):
     """Test basic functionality of relation interface."""
@@ -111,7 +110,6 @@ async def test_create_relation(ops_test: OpsTest, application_charm, charm, seri
     )
 
 
-@pytest.mark.skip(reason="Merge 2.19.2 change")
 @pytest.mark.abort_on_fail
 async def test_index_usage(ops_test: OpsTest):
     """Check we can update and delete things.
@@ -149,7 +147,6 @@ async def test_index_usage(ops_test: OpsTest):
     )
 
 
-@pytest.mark.skip(reason="Merge 2.19.2 change")
 @pytest.mark.abort_on_fail
 async def test_bulk_index_usage(ops_test: OpsTest):
     """Check we can update and delete things using bulk api."""
@@ -190,7 +187,6 @@ async def test_bulk_index_usage(ops_test: OpsTest):
     assert set(artists) == {"Herbie Hancock", "Lydian Collective", "Vulfpeck"}
 
 
-@pytest.mark.skip(reason="Merge 2.19.2 change")
 @pytest.mark.abort_on_fail
 async def test_version(ops_test: OpsTest):
     """Check version reported in the databag is consistent with the version on the charm."""
@@ -218,7 +214,6 @@ async def get_secret_data(ops_test, secret_uri):
     return json.loads(stdout)[secret_unique_id]["content"]["Data"]
 
 
-@pytest.mark.skip(reason="Merge 2.19.2 change")
 @pytest.mark.abort_on_fail
 async def test_dashboard_relation(ops_test: OpsTest):
     """Test we can create relations with admin permissions."""
@@ -250,7 +245,6 @@ async def test_dashboard_relation(ops_test: OpsTest):
     assert relation_user_pwd == result.response.get("password")
 
 
-@pytest.mark.skip(reason="Merge 2.19.2 change")
 @pytest.mark.abort_on_fail
 async def test_dashboard_relation_password_change(ops_test: OpsTest):
     """Test we can create relations with admin permissions."""
@@ -279,7 +273,6 @@ async def test_dashboard_relation_password_change(ops_test: OpsTest):
     assert relation_user_pwd == result.response.get("password")
 
 
-@pytest.mark.skip(reason="Merge 2.19.2 change")
 @pytest.mark.abort_on_fail
 async def test_scaling(ops_test: OpsTest):
     """Test that scaling correctly updates endpoints in databag.
@@ -343,7 +336,6 @@ async def test_scaling(ops_test: OpsTest):
     ), await rel_endpoints(CLIENT_APP_NAME, FIRST_RELATION_NAME)
 
 
-@pytest.mark.skip(reason="Merge 2.19.2 change")
 @pytest.mark.abort_on_fail
 async def test_multiple_relations(ops_test: OpsTest, application_charm):
     """Test that two different applications can connect to the database."""
@@ -408,7 +400,6 @@ async def test_multiple_relations(ops_test: OpsTest, application_charm):
     assert "403 Client Error: Forbidden for url:" in results[0], results
 
 
-@pytest.mark.skip(reason="Merge 2.19.2 change")
 @pytest.mark.abort_on_fail
 async def test_multiple_relations_accessing_same_index(ops_test: OpsTest):
     """Test that two different applications can connect to the database."""
@@ -445,7 +436,6 @@ async def test_multiple_relations_accessing_same_index(ops_test: OpsTest):
     assert set(artists) == {"Herbie Hancock", "Lydian Collective", "Vulfpeck"}
 
 
-@pytest.mark.skip(reason="Merge 2.19.2 change")
 @pytest.mark.abort_on_fail
 async def test_admin_relation(ops_test: OpsTest):
     """Test we can create relations with admin permissions."""
@@ -482,7 +472,6 @@ async def test_admin_relation(ops_test: OpsTest):
     assert set(artists) == {"Herbie Hancock", "Lydian Collective", "Vulfpeck"}
 
 
-@pytest.mark.skip(reason="Merge 2.19.2 change")
 @pytest.mark.abort_on_fail
 async def test_admin_permissions(ops_test: OpsTest):
     """Test admin permissions behave the way we want.
@@ -550,7 +539,6 @@ async def test_admin_permissions(ops_test: OpsTest):
         assert "Error:" in results[0], results
 
 
-@pytest.mark.skip(reason="Merge 2.19.2 change")
 @pytest.mark.abort_on_fail
 async def test_normal_user_permissions(ops_test: OpsTest):
     """Test normal user permissions behave the way we want.
@@ -611,7 +599,6 @@ async def test_normal_user_permissions(ops_test: OpsTest):
         assert "Error:" in results[0], results
 
 
-@pytest.mark.skip(reason="Merge 2.19.2 change")
 @pytest.mark.abort_on_fail
 async def test_relation_broken(ops_test: OpsTest):
     """Test that the user is removed when the relation is broken."""
@@ -666,7 +653,6 @@ async def test_relation_broken(ops_test: OpsTest):
     assert relation_user not in users.keys()
 
 
-@pytest.mark.skip(reason="Merge 2.19.2 change")
 @pytest.mark.abort_on_fail
 async def test_data_persists_on_relation_rejoin(ops_test: OpsTest):
     """Verify that if we recreate a relation, we can access the same index."""


### PR DESCRIPTION
This PR enables the skipped provider tests