### PR TITLE
change s3-integrator channel

### DIFF
--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -89,7 +89,7 @@ LARGE_DEPLOYMENTS_ALL_CLOUDS = [
 
 
 S3_INTEGRATOR = "s3-integrator"
-S3_INTEGRATOR_CHANNEL = "latest/edge"
+S3_INTEGRATOR_CHANNEL = "2/edge"
 S3_RELATION = "s3-credentials"
 AZURE_INTEGRATOR = "azure-storage-integrator"
 AZURE_INTEGRATOR_CHANNEL = "latest/edge"

--- a/tests/integration/ha/test_backups.py
+++ b/tests/integration/ha/test_backups.py
@@ -89,7 +89,7 @@ LARGE_DEPLOYMENTS_ALL_CLOUDS = [
 
 
 S3_INTEGRATOR = "s3-integrator"
-S3_INTEGRATOR_CHANNEL = "2/edge"
+S3_INTEGRATOR_CHANNEL = "1/stable"
 S3_RELATION = "s3-credentials"
 AZURE_INTEGRATOR = "azure-storage-integrator"
 AZURE_INTEGRATOR_CHANNEL = "latest/edge"


### PR DESCRIPTION
## Issue
Backups-aws/microceph tests are failing on `s3-integratror --channel=latest/edge`

## Solution
Use channel `1/stable`
