### PR TITLE
[DPE-7351] - Check for security index initialized before waiting for data app

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -420,6 +420,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             deployment_desc.typ == DeploymentType.MAIN_ORCHESTRATOR
             and not deployment_desc.start == StartMode.WITH_GENERATED_ROLES
             and "data" not in deployment_desc.config.roles
+            and not self.peers_data.get(Scope.APP, "security_index_initialised", False)
         ):
             self.status.set(BlockedStatus(PClusterNoDataNode))
             event.defer()


### PR DESCRIPTION
Enhance the data node waiting checks by adding a check to ensure the security index is not initialised.