### PR TITLE
[DPE-7996] - Fix OpenSearchStartTimeoutError being raised all the time

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_distro.py
+++ b/lib/charms/opensearch/v0/opensearch_distro.py
@@ -120,9 +120,10 @@ class OpenSearchDistribution(ABC):
         self._start_service()
 
         start = datetime.now()
-        while not _is_connected() and (datetime.now() - start).seconds < 180:
+        while not (connected := _is_connected()) and (datetime.now() - start).seconds < 180:
             time.sleep(3)
-        else:
+        if not connected:
+            logger.debug(f"waited {datetime.now() - start} opensearch did not start")
             raise OpenSearchStartTimeoutError()
 
     def restart(self):


### PR DESCRIPTION
Refactor the logic for waiting for the OpenSearch service to start in `opensearch_distro.py`. Only raise a timeout error if the connection failed.

Service startup logic improvements:

* Changed the loop to use assignment expression (`connected := _is_connected()`).
* Replaced the `else` clause with an explicit `if not connected:` check after the loop, and added a debug log message when OpenSearch fails to start within the timeout period.