### PR TITLE
[DPE-6808] Fix channel name for 'data-integrator' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ juju deploy opensearch --channel=2/edge
 
 The relevant provided [relations](https://juju.is/docs/olm/relations) of Charmed OpenSearch are:
 
-### Client interface:
+### Client interface
 
 To connect to the Charmed OpenSearch Operator and exchange data, relate to the `opensearch-client` endpoint:
 
@@ -72,7 +72,7 @@ juju deploy data-integrator --channel=stable
 juju integrate opensearch data-integrator
 ```
 
-### Large deployments:
+### Large deployments
 Charmed OpenSearch also allows to form large clusters or join an existing deployment, through the relations:
 - `peer-cluster`
 - `peer-cluster-orchestrator`
@@ -80,14 +80,14 @@ Charmed OpenSearch also allows to form large clusters or join an existing deploy
 juju integrate main:peer-cluster-orchestrator data-hot:peer-cluster
 ```
 
-## TLS:
+## TLS
 
 The Charmed OpenSearch Operator also supports TLS encryption as a first class citizen, on both the HTTP and Transport layers. 
 TLS is enabled by default and is a requirement for the charm to start.
 
 The charm relies on the `tls-certificates` interface.
 
-#### 1. Self-signed certificates:
+#### Example with Self-signed certificates
 ```shell
 # Deploy the self-signed TLS Certificates Operator.
 juju deploy self-signed-certificates --channel=latest/stable

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The relevant provided [relations](https://juju.is/docs/olm/relations) of Charmed
 To connect to the Charmed OpenSearch Operator and exchange data, relate to the `opensearch-client` endpoint:
 
 ```shell
-juju deploy data-integrator --channel=stable
+juju deploy data-integrator --channel=latest/stable
 juju integrate opensearch data-integrator
 ```
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The relevant provided [relations](https://juju.is/docs/olm/relations) of Charmed
 To connect to the Charmed OpenSearch Operator and exchange data, relate to the `opensearch-client` endpoint:
 
 ```shell
-juju deploy data-integrator --channel=2/edge
+juju deploy data-integrator --channel=stable
 juju integrate opensearch data-integrator
 ```
 


### PR DESCRIPTION
## Description of issue or feature:
This PR updates the channel name for 'data-integrator' charm in the README.md. In the README.md we show how to integrate the opensearch charm with the data-integrator charm. However the charm channel is not valid as reported in #590.  
fix #590 

## Solution:
Updated channel name to 'stable' following the docs [here](https://charmhub.io/opensearch/docs/t-integrate?channel=2/edge).  

I also made some quick fixes that I think will improve the quality and clarity of the docs.


## How was this change tested?
- [ ] Manually
- [ ] Unit tests
- [ ] Integration tests




## Checklist
- [X] I have updated README.md
