### PR TITLE
Group Common Code of `get_application_units` and `get_application_subordinate_units`

### DIFF
--- a/tests/integration/helpers_deployments.py
+++ b/tests/integration/helpers_deployments.py
@@ -185,9 +185,7 @@ async def get_application_subordinate_units(
     # `get_unit_ip` should be replaced with `.public_address`
     raw_app = get_raw_application(ops_test, app)
     units = []
-    for principal_unit in get_raw_application(ops_test, principal_app)[
-        "units"
-    ].values():
+    for principal_unit in get_raw_application(ops_test, principal_app)["units"].values():
         u_name, raw_unit = None, None
         for u_name, raw_unit in principal_unit["subordinates"].items():
             if u_name.startswith(f"${app}/"):
@@ -199,9 +197,7 @@ async def get_application_subordinate_units(
             # unit not ready yet...
             continue
 
-        units.append(
-            _get_unit(ops_test, app, raw_app, u_name, raw_unit, subordinate=True)
-        )
+        units.append(_get_unit(ops_test, app, raw_app, u_name, raw_unit, subordinate=True))
     return await asyncio.gather(*units) if units else []
 
 
@@ -230,8 +226,7 @@ def _is_every_condition_on_app_met(
         any_match = False
         for status_val, messages in apps_full_statuses[app].items():
             any_match = any_match or (
-                app_status.value == status_val
-                and app_status.message in (messages or ["", None])
+                app_status.value == status_val and app_status.message in (messages or ["", None])
             )
         if not any_match:
             return False
@@ -300,9 +295,7 @@ async def _is_every_condition_met(
             units = await get_application_units(ops_test, app)
 
         if -1 < expected_units != len(units):
-            logger.info(
-                f"{app} -- expected units: {expected_units} -- current: {len(units)}"
-            )
+            logger.info(f"{app} -- expected units: {expected_units} -- current: {len(units)}")
             return False
 
         if (apps_statuses or apps_full_statuses) and not _is_every_condition_on_app_met(
@@ -368,9 +361,7 @@ async def wait_until(  # noqa: C901
     """
     if not apps:
         raise ValueError("apps must be specified.")
-    if not (
-        apps_statuses or apps_full_statuses or units_statuses or units_full_statuses
-    ):
+    if not (apps_statuses or apps_full_statuses or units_statuses or units_full_statuses):
         apps_statuses = ["active"]
         units_statuses = ["active"]
     if isinstance(wait_for_exact_units, int):

--- a/tests/integration/helpers_deployments.py
+++ b/tests/integration/helpers_deployments.py
@@ -188,7 +188,7 @@ async def get_application_subordinate_units(
     for principal_unit in get_raw_application(ops_test, principal_app)["units"].values():
         u_name, raw_unit = None, None
         for u_name, raw_unit in principal_unit["subordinates"].items():
-            if u_name.startswith(f"${app}/"):
+            if u_name.startswith(f"{app}/"):
                 break
         else:
             raise ValueError(f"Subordinate unit for {app} not found in {principal_app}")

--- a/tests/integration/helpers_deployments.py
+++ b/tests/integration/helpers_deployments.py
@@ -188,9 +188,7 @@ async def get_application_subordinate_units(
     # `get_unit_ip` should be replaced with `.public_address`
     raw_app = get_raw_application(ops_test, app)
     units = []
-    for principal_unit in get_raw_application(ops_test, principal_app)[
-        "units"
-    ].values():
+    for principal_unit in get_raw_application(ops_test, principal_app)["units"].values():
         u_name, raw_unit = None, None
         for u_name, raw_unit in principal_unit["subordinates"].items():
             if app in u_name:
@@ -201,9 +199,7 @@ async def get_application_subordinate_units(
         if not raw_unit.get("public-address"):
             # unit not ready yet...
             continue
-        unit = await unit_from_raw(
-            ops_test, u_name, raw_unit, app, raw_app, subordinate=True
-        )
+        unit = await unit_from_raw(ops_test, u_name, raw_unit, app, raw_app, subordinate=True)
         units.append(unit)
 
     return units
@@ -234,8 +230,7 @@ def _is_every_condition_on_app_met(
         any_match = False
         for status_val, messages in apps_full_statuses[app].items():
             any_match = any_match or (
-                app_status.value == status_val
-                and app_status.message in (messages or ["", None])
+                app_status.value == status_val and app_status.message in (messages or ["", None])
             )
         if not any_match:
             return False
@@ -304,9 +299,7 @@ async def _is_every_condition_met(
             units = await get_application_units(ops_test, app)
 
         if -1 < expected_units != len(units):
-            logger.info(
-                f"{app} -- expected units: {expected_units} -- current: {len(units)}"
-            )
+            logger.info(f"{app} -- expected units: {expected_units} -- current: {len(units)}")
             return False
 
         if (apps_statuses or apps_full_statuses) and not _is_every_condition_on_app_met(
@@ -372,9 +365,7 @@ async def wait_until(  # noqa: C901
     """
     if not apps:
         raise ValueError("apps must be specified.")
-    if not (
-        apps_statuses or apps_full_statuses or units_statuses or units_full_statuses
-    ):
+    if not (apps_statuses or apps_full_statuses or units_statuses or units_full_statuses):
         apps_statuses = ["active"]
         units_statuses = ["active"]
     if isinstance(wait_for_exact_units, int):

--- a/tests/integration/helpers_deployments.py
+++ b/tests/integration/helpers_deployments.py
@@ -119,30 +119,27 @@ async def get_unit_hostname(ops_test: OpsTest, unit_id: int, app: str) -> str:
     return hostname.strip()
 
 
-async def unit_from_raw(
+async def _get_unit(
     ops_test: OpsTest,
+    app: str,
+    raw_app: dict[str, Any],
     unit_name: str,
-    raw_unit: Dict[str, Any],
-    app_name: str,
-    raw_app: Dict[str, Any],
+    raw_unit: dict[str, Any],
     subordinate: bool = False,
 ) -> Unit:
     """Create a Unit object from raw unit data."""
     unit_id = int(unit_name.split("/")[-1])
 
-    app_id = f"{ops_test.model.uuid}/{app_name}"
+    app_id = f"{ops_test.model.uuid}/{app}"
     app_short_id = md5(app_id.encode()).hexdigest()[:3]
-    if subordinate:
-        machine_id = -1
-    else:
-        machine_id = int(raw_unit["machine"])
+    machine_id = -1 if subordinate else int(raw_unit["machine"])
 
     return Unit(
         id=unit_id,
         short_name=unit_name.replace("/", "-"),
         name=f"{unit_name.replace('/', '-')}.{app_short_id}",
         ip=raw_unit["public-address"],
-        hostname=await get_unit_hostname(ops_test, unit_id, app_name),
+        hostname=await get_unit_hostname(ops_test, unit_id, app),
         is_leader=raw_unit.get("leader", False),
         machine_id=machine_id,
         workload_status=Status(
@@ -173,7 +170,7 @@ async def get_application_units(ops_test: OpsTest, app: str) -> List[Unit]:
         if not raw_unit.get("public-address"):
             # unit not ready yet...
             continue
-        unit = await unit_from_raw(ops_test, u_name, raw_unit, app, raw_app)
+        unit = await _get_unit(ops_test, app, raw_app, u_name, raw_unit)
         units.append(unit)
 
     return units
@@ -199,7 +196,7 @@ async def get_application_subordinate_units(
         if not raw_unit.get("public-address"):
             # unit not ready yet...
             continue
-        unit = await unit_from_raw(ops_test, u_name, raw_unit, app, raw_app, subordinate=True)
+        unit = await _get_unit(ops_test, app, raw_app, u_name, raw_unit, subordinate=True)
         units.append(unit)
 
     return units

--- a/tests/integration/helpers_deployments.py
+++ b/tests/integration/helpers_deployments.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
+import asyncio
 import json
 import logging
 import subprocess
@@ -170,10 +171,9 @@ async def get_application_units(ops_test: OpsTest, app: str) -> List[Unit]:
         if not raw_unit.get("public-address"):
             # unit not ready yet...
             continue
-        unit = await _get_unit(ops_test, app, raw_app, u_name, raw_unit)
-        units.append(unit)
+        units.append(_get_unit(ops_test, app, raw_app, u_name, raw_unit))
 
-    return units
+    return await asyncio.gather(*units) if units else []
 
 
 async def get_application_subordinate_units(
@@ -185,10 +185,12 @@ async def get_application_subordinate_units(
     # `get_unit_ip` should be replaced with `.public_address`
     raw_app = get_raw_application(ops_test, app)
     units = []
-    for principal_unit in get_raw_application(ops_test, principal_app)["units"].values():
+    for principal_unit in get_raw_application(ops_test, principal_app)[
+        "units"
+    ].values():
         u_name, raw_unit = None, None
         for u_name, raw_unit in principal_unit["subordinates"].items():
-            if app in u_name:
+            if u_name.startswith(f"${app}/"):
                 break
         else:
             raise ValueError(f"Subordinate unit for {app} not found in {principal_app}")
@@ -196,10 +198,11 @@ async def get_application_subordinate_units(
         if not raw_unit.get("public-address"):
             # unit not ready yet...
             continue
-        unit = await _get_unit(ops_test, app, raw_app, u_name, raw_unit, subordinate=True)
-        units.append(unit)
 
-    return units
+        units.append(
+            _get_unit(ops_test, app, raw_app, u_name, raw_unit, subordinate=True)
+        )
+    return await asyncio.gather(*units) if units else []
 
 
 def _is_every_condition_on_app_met(
@@ -227,7 +230,8 @@ def _is_every_condition_on_app_met(
         any_match = False
         for status_val, messages in apps_full_statuses[app].items():
             any_match = any_match or (
-                app_status.value == status_val and app_status.message in (messages or ["", None])
+                app_status.value == status_val
+                and app_status.message in (messages or ["", None])
             )
         if not any_match:
             return False
@@ -296,7 +300,9 @@ async def _is_every_condition_met(
             units = await get_application_units(ops_test, app)
 
         if -1 < expected_units != len(units):
-            logger.info(f"{app} -- expected units: {expected_units} -- current: {len(units)}")
+            logger.info(
+                f"{app} -- expected units: {expected_units} -- current: {len(units)}"
+            )
             return False
 
         if (apps_statuses or apps_full_statuses) and not _is_every_condition_on_app_met(
@@ -362,7 +368,9 @@ async def wait_until(  # noqa: C901
     """
     if not apps:
         raise ValueError("apps must be specified.")
-    if not (apps_statuses or apps_full_statuses or units_statuses or units_full_statuses):
+    if not (
+        apps_statuses or apps_full_statuses or units_statuses or units_full_statuses
+    ):
         apps_statuses = ["active"]
         units_statuses = ["active"]
     if isinstance(wait_for_exact_units, int):

--- a/tests/integration/helpers_deployments.py
+++ b/tests/integration/helpers_deployments.py
@@ -85,7 +85,7 @@ def _dump_juju_logs(model: str, unit: Optional[str] = None, lines: int = 500) ->
     if unit:
         pos = unit.rfind("-")
         if pos != -1:
-            unit = f"{unit[:pos]}/{unit[pos+1:]}"  # noqa
+            unit = f"{unit[:pos]}/{unit[pos + 1 :]}"  # noqa
         cmd = f"{cmd} --include={unit}"
 
     cmd = f"{cmd} --model={model} --limit {lines} > {target_file}; cat {target_file}"
@@ -173,7 +173,7 @@ async def get_application_units(ops_test: OpsTest, app: str) -> List[Unit]:
         if not raw_unit.get("public-address"):
             # unit not ready yet...
             continue
-        unit = unit_from_raw(ops_test, u_name, raw_unit, app, raw_app)
+        unit = await unit_from_raw(ops_test, u_name, raw_unit, app, raw_app)
         units.append(unit)
 
     return units
@@ -188,7 +188,9 @@ async def get_application_subordinate_units(
     # `get_unit_ip` should be replaced with `.public_address`
     raw_app = get_raw_application(ops_test, app)
     units = []
-    for principal_unit in get_raw_application(ops_test, principal_app)["units"].values():
+    for principal_unit in get_raw_application(ops_test, principal_app)[
+        "units"
+    ].values():
         u_name, raw_unit = None, None
         for u_name, raw_unit in principal_unit["subordinates"].items():
             if app in u_name:
@@ -199,7 +201,9 @@ async def get_application_subordinate_units(
         if not raw_unit.get("public-address"):
             # unit not ready yet...
             continue
-        unit = unit_from_raw(ops_test, u_name, raw_unit, app, raw_app, subordinate=True)
+        unit = await unit_from_raw(
+            ops_test, u_name, raw_unit, app, raw_app, subordinate=True
+        )
         units.append(unit)
 
     return units
@@ -230,7 +234,8 @@ def _is_every_condition_on_app_met(
         any_match = False
         for status_val, messages in apps_full_statuses[app].items():
             any_match = any_match or (
-                app_status.value == status_val and app_status.message in (messages or ["", None])
+                app_status.value == status_val
+                and app_status.message in (messages or ["", None])
             )
         if not any_match:
             return False
@@ -299,7 +304,9 @@ async def _is_every_condition_met(
             units = await get_application_units(ops_test, app)
 
         if -1 < expected_units != len(units):
-            logger.info(f"{app} -- expected units: {expected_units} -- current: {len(units)}")
+            logger.info(
+                f"{app} -- expected units: {expected_units} -- current: {len(units)}"
+            )
             return False
 
         if (apps_statuses or apps_full_statuses) and not _is_every_condition_on_app_met(
@@ -365,7 +372,9 @@ async def wait_until(  # noqa: C901
     """
     if not apps:
         raise ValueError("apps must be specified.")
-    if not (apps_statuses or apps_full_statuses or units_statuses or units_full_statuses):
+    if not (
+        apps_statuses or apps_full_statuses or units_statuses or units_full_statuses
+    ):
         apps_statuses = ["active"]
         units_statuses = ["active"]
     if isinstance(wait_for_exact_units, int):

--- a/tests/integration/helpers_deployments.py
+++ b/tests/integration/helpers_deployments.py
@@ -119,6 +119,49 @@ async def get_unit_hostname(ops_test: OpsTest, unit_id: int, app: str) -> str:
     return hostname.strip()
 
 
+async def unit_from_raw(
+    ops_test: OpsTest,
+    unit_name: str,
+    raw_unit: Dict[str, Any],
+    app_name: str,
+    raw_app: Dict[str, Any],
+    subordinate: bool = False,
+) -> Unit:
+    """Create a Unit object from raw unit data."""
+    unit_id = int(unit_name.split("/")[-1])
+
+    app_id = f"{ops_test.model.uuid}/{app_name}"
+    app_short_id = md5(app_id.encode()).hexdigest()[:3]
+    if subordinate:
+        machine_id = -1
+    else:
+        machine_id = int(raw_unit["machine"])
+
+    return Unit(
+        id=unit_id,
+        short_name=unit_name.replace("/", "-"),
+        name=f"{unit_name.replace('/', '-')}.{app_short_id}",
+        ip=raw_unit["public-address"],
+        hostname=await get_unit_hostname(ops_test, unit_id, app_name),
+        is_leader=raw_unit.get("leader", False),
+        machine_id=machine_id,
+        workload_status=Status(
+            value=raw_unit["workload-status"]["current"],
+            since=raw_unit["workload-status"]["since"],
+            message=raw_unit["workload-status"].get("message"),
+        ),
+        agent_status=Status(
+            value=raw_unit["juju-status"]["current"],
+            since=raw_unit["juju-status"]["since"],
+        ),
+        app_status=Status(
+            value=raw_app["application-status"]["current"],
+            since=raw_app["application-status"]["since"],
+            message=raw_app["application-status"].get("message"),
+        ),
+    )
+
+
 async def get_application_units(ops_test: OpsTest, app: str) -> List[Unit]:
     """Get fully detailed units of an application."""
     # Juju incorrectly reports the IP addresses after the network is restored this is reported as a
@@ -126,39 +169,11 @@ async def get_application_units(ops_test: OpsTest, app: str) -> List[Unit]:
     # `get_unit_ip` should be replaced with `.public_address`
     raw_app = get_raw_application(ops_test, app)
     units = []
-    for u_name, unit in raw_app["units"].items():
-        unit_id = int(u_name.split("/")[-1])
-
-        if not unit.get("public-address"):
+    for u_name, raw_unit in raw_app["units"].items():
+        if not raw_unit.get("public-address"):
             # unit not ready yet...
             continue
-
-        app_id = f"{ops_test.model.uuid}/{app}"
-        app_short_id = md5(app_id.encode()).hexdigest()[:3]
-        unit = Unit(
-            id=unit_id,
-            short_name=u_name.replace("/", "-"),
-            name=f"{u_name.replace('/', '-')}.{app_short_id}",
-            ip=unit["public-address"],
-            hostname=await get_unit_hostname(ops_test, unit_id, app),
-            is_leader=unit.get("leader", False),
-            machine_id=int(unit["machine"]),
-            workload_status=Status(
-                value=unit["workload-status"]["current"],
-                since=unit["workload-status"]["since"],
-                message=unit["workload-status"].get("message"),
-            ),
-            agent_status=Status(
-                value=unit["juju-status"]["current"],
-                since=unit["juju-status"]["since"],
-            ),
-            app_status=Status(
-                value=raw_app["application-status"]["current"],
-                since=raw_app["application-status"]["since"],
-                message=raw_app["application-status"].get("message"),
-            ),
-        )
-
+        unit = unit_from_raw(ops_test, u_name, raw_unit, app, raw_app)
         units.append(unit)
 
     return units
@@ -174,45 +189,17 @@ async def get_application_subordinate_units(
     raw_app = get_raw_application(ops_test, app)
     units = []
     for principal_unit in get_raw_application(ops_test, principal_app)["units"].values():
-        u_name, unit = None, None
-        for u_name, unit in principal_unit["subordinates"].items():
+        u_name, raw_unit = None, None
+        for u_name, raw_unit in principal_unit["subordinates"].items():
             if app in u_name:
                 break
         else:
             raise ValueError(f"Subordinate unit for {app} not found in {principal_app}")
 
-        unit_id = int(u_name.split("/")[-1])
-
-        if not unit.get("public-address"):
+        if not raw_unit.get("public-address"):
             # unit not ready yet...
             continue
-
-        app_id = f"{ops_test.model.uuid}/{app}"
-        app_short_id = md5(app_id.encode()).hexdigest()[:3]
-        unit = Unit(
-            id=unit_id,
-            short_name=u_name.replace("/", "-"),
-            name=f"{u_name.replace('/', '-')}.{app_short_id}",
-            ip=unit["public-address"],
-            hostname=await get_unit_hostname(ops_test, unit_id, app),
-            is_leader=unit.get("leader", False),
-            machine_id=-1,
-            workload_status=Status(
-                value=unit["workload-status"]["current"],
-                since=unit["workload-status"]["since"],
-                message=unit["workload-status"].get("message"),
-            ),
-            agent_status=Status(
-                value=unit["juju-status"]["current"],
-                since=unit["juju-status"]["since"],
-            ),
-            app_status=Status(
-                value=raw_app["application-status"]["current"],
-                since=raw_app["application-status"]["since"],
-                message=raw_app["application-status"].get("message"),
-            ),
-        )
-
+        unit = unit_from_raw(ops_test, u_name, raw_unit, app, raw_app, subordinate=True)
         units.append(unit)
 
     return units


### PR DESCRIPTION
## Description of issue or feature:
This PR provides a fix #488. Function `get_application_units` had some shared logic with `get_application_subordinate_units`. I have moved the shared logic to a separate function that will be called by the two functions. This provides a cleaner way of handling that logic.


## How was this change tested?
- [ ] Manually
- [ ] Unit tests
- [X] Integration tests




## Checklist
- [ ] I have updated mainly integration tests helpers in `tests/integration/helpers_deployment`

