### PR TITLE
[DPE-8408]: Isolate OpenSearchNotFullyReadyError and add retry machanisme

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -114,6 +114,7 @@ from ops.charm import (
 )
 from ops.framework import EventBase, EventSource
 from ops.model import BlockedStatus, MaintenanceStatus, WaitingStatus
+from tenacity import Retrying, stop_after_attempt, wait_exponential
 
 import lifecycle
 import upgrade
@@ -1166,9 +1167,11 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         except (
             OpenSearchHttpError,
             OpenSearchStartTimeoutError,
-            OpenSearchNotFullyReadyError,
+            OpenSearchStartError,
+            OpenSearchUserMgmtError,
         ) as e:
             self.node_lock.release()
+            logger.warning(e)
             self.status.set(BlockedStatus(ServiceStartError))
 
             # In large deployments with cluster-manager-only-nodes, the startup might fail
@@ -1177,11 +1180,9 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             if self.opensearch_peer_cm.is_provider(typ="main"):
                 self.peer_cluster_provider.refresh_relation_data(event, can_defer=False)
             event.defer()
-            logger.warning(e)
-        except (OpenSearchStartError, OpenSearchUserMgmtError) as e:
-            logger.warning(e)
+        except OpenSearchNotFullyReadyError as e:
             self.node_lock.release()
-            self.status.set(BlockedStatus(ServiceStartError))
+            logger.debug(f"Node started but not fully ready: {e}")
             event.defer()
 
     def _post_start_init(self, event: _StartOpenSearch):  # noqa: C901
@@ -1210,8 +1211,14 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
         # it sometimes takes a few seconds before the node is fully "up" otherwise a 503 error
         # may be thrown when calling a node - we want to ensure this node is perfectly ready
         # before marking it as ready
-        if not self.opensearch.is_node_up():
-            raise OpenSearchNotFullyReadyError("Node started but not full ready yet.")
+        for attempt in Retrying(
+            stop=stop_after_attempt(5),
+            wait=wait_exponential(multiplier=2, min=2, max=10),
+            reraise=True,
+        ):
+            with attempt:
+                if not self.opensearch.is_node_up():
+                    raise OpenSearchNotFullyReadyError("Node started but not fully ready yet.")
 
         try:
             nodes = self._get_nodes(use_localhost=self.opensearch.is_node_up())

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -1173,17 +1173,17 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             self.node_lock.release()
             logger.warning(e)
             self.status.set(BlockedStatus(ServiceStartError))
-
-            # In large deployments with cluster-manager-only-nodes, the startup might fail
-            # for the cluster-manager if a joining data node did not yet initialize the
-            # security index. We still want to update and broadcast the latest relation data.
-            if self.opensearch_peer_cm.is_provider(typ="main"):
-                self.peer_cluster_provider.refresh_relation_data(event, can_defer=False)
             event.defer()
         except OpenSearchNotFullyReadyError as e:
             self.node_lock.release()
             logger.debug(f"Node started but not fully ready: {e}")
             event.defer()
+        finally:
+            # In large deployments with cluster-manager-only-nodes, the startup might fail
+            # for the cluster-manager if a joining data node did not yet initialize the
+            # security index. We still want to update and broadcast the latest relation data.
+            if self.opensearch_peer_cm.is_provider(typ="main"):
+                self.peer_cluster_provider.refresh_relation_data(event, can_defer=False)
 
     def _post_start_init(self, event: _StartOpenSearch):  # noqa: C901
         """Initialization post OpenSearch start."""

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -1176,7 +1176,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             event.defer()
         except OpenSearchNotFullyReadyError as e:
             self.node_lock.release()
-            logger.debug(f"Node started but not fully ready: {e}")
+            logger.debug("Node started but not fully ready: %s", e)
             event.defer()
         finally:
             # In large deployments with cluster-manager-only-nodes, the startup might fail


### PR DESCRIPTION
## Description of issue or feature:
The charm is blocked on deployment for slow cluster startups

## Solution:
Isolate OpenSearchNotFullyReadyError and add retry machanisme. Re-open the issue for the cluster ID mismatch.
* Added a retry loop using `tenacity.Retrying` in `_post_start_init` to repeatedly check if the node is up, with exponential backoff, before proceeding. This ensures the node is fully ready and avoids premature readiness signaling. [[1]](diffhunk://#diff-5c0d89f838ffd5a9ecf2288b3698320fda2d2b2b737361b6e10adb55d1929f43R117) [[2]](diffhunk://#diff-5c0d89f838ffd5a9ecf2288b3698320fda2d2b2b737361b6e10adb55d1929f43R1214-R1221)
* Refined the exception handling in `_start_opensearch` to catch `OpenSearchStartError` and `OpenSearchUserMgmtError` together, log warnings for these errors, and set the unit status to `BlockedStatus` with `ServiceStartError`. Logging for `OpenSearchNotFullyReadyError` was moved to a debug message, clarifying the node readiness state. [[1]](diffhunk://#diff-5c0d89f838ffd5a9ecf2288b3698320fda2d2b2b737361b6e10adb55d1929f43L1169-R1174) [[2]](diffhunk://#diff-5c0d89f838ffd5a9ecf2288b3698320fda2d2b2b737361b6e10adb55d1929f43L1180-R1185)

## How was this change tested?
- [x] Manually
- [x] Unit tests
- [x] Integration tests

Fixes #700 
