### PR TITLE
[DPE-8527] - extract certificates key/trust stores openssl logic into helpers

### DIFF
--- a/lib/charms/opensearch/v0/helper_security.py
+++ b/lib/charms/opensearch/v0/helper_security.py
@@ -212,8 +212,8 @@ def list_cas(store_pwd: str, store_path: str) -> Optional[dict[str, str]]:
 
     certs = {}
     for cert in certificates:
-        alias = [line for line in cert if line.startswith("friendlyName:")][0]
-        alias = alias.split("friendlyName:")[-1]
+        alias = [line for line in cert.split("\n") if line.strip().startswith("friendlyName:")][0]
+        alias = alias.split("friendlyName:")[-1].strip()
 
         certs[alias] = f"{start_cert_marker}{cert.split(start_cert_marker)[1]}{end_cert_marker}"
 

--- a/lib/charms/opensearch/v0/helper_security.py
+++ b/lib/charms/opensearch/v0/helper_security.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 
 """Helpers for security related operations, such as password generation etc."""
+import logging
 import math
 import os
 import secrets
@@ -9,9 +10,12 @@ import string
 import subprocess
 import tempfile
 from datetime import datetime
+from os.path import exists
 from typing import Optional, Tuple
 
 import bcrypt
+from charms.opensearch.v0.helper_charm import run_cmd
+from charms.opensearch.v0.opensearch_exceptions import OpenSearchCmdError
 from cryptography import x509
 
 # The unique Charmhub library identifier, never change it
@@ -23,6 +27,8 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 LIBPATCH = 1
+
+logger = logging.getLogger(__name__)
 
 
 def hash_string(string: str) -> str:
@@ -117,3 +123,213 @@ def to_pkcs8(private_key: str, password: Optional[str] = None) -> str:
     finally:
         os.unlink(tmp_key.name)
         os.unlink(tmp_pkcs8_key.name)
+
+
+def store_ca(
+    alias: str, store_pwd: str, store_path: str, ca: str, keep_previous: bool = True
+) -> bool:
+    """Add new CA cert to trust store."""
+    keytool = "opensearch.keytool"
+
+    if keep_previous:
+        cmd = f"{keytool} -changealias -alias {alias} -destalias old-{alias} -keystore {store_path} -storetype PKCS12"
+        args = f"-storepass {store_pwd}"
+        try:
+            run_cmd(cmd, args)
+            logger.info(f"Current CA {alias} was renamed to old-{alias}.")
+        except OpenSearchCmdError as e:
+            # This message means there was no "ca" alias or store before, if it happens ignore
+            if not (
+                f"Alias <{alias}> does not exist" in e.out
+                or "Keystore file does not exist" in e.out
+            ):
+                return False
+
+    with tempfile.NamedTemporaryFile(mode="w+t", dir=os.path.dirname(store_path)) as ca_tmp_file:
+        ca_tmp_file.write(ca)
+        ca_tmp_file.flush()
+        try:
+            run_cmd(
+                f"""{keytool} -importcert \
+                -trustcacerts \
+                -noprompt \
+                -alias {alias} \
+                -keystore {store_path} \
+                -file {ca_tmp_file.name} \
+                -storetype PKCS12
+                """,
+                f"-storepass {store_pwd}",
+            )
+            run_cmd(f"sudo chmod +r {store_path}")
+            logger.info("New CA was added to truststore.")
+        except OpenSearchCmdError as e:
+            logging.error(f"Error storing the ca-cert: {e}")
+            return False
+
+    return True
+
+
+def list_aliases(store_pwd: str, store_path: str) -> Optional[list[str]]:
+    """Fetch the aliases stored in a store."""
+    if not exists(store_path):
+        return None
+
+    keytool = "opensearch.keytool"
+
+    # we fetch the list of stored aliases
+    cmd = f"{keytool} -list -keystore {store_path} -storetype PKCS12"
+    args = f"-storepass {store_pwd}"
+
+    try:
+        resp = run_cmd(cmd, args).out.split()
+        return [
+            line.split("Alias name:")[-1].strip()
+            for line in resp
+            if line.startswith("Alias name:")
+        ]
+    except OpenSearchCmdError as e:
+        logging.error(f"Error reading the current truststore: {e}")
+        return None
+
+
+def list_cas(store_pwd: str, store_path: str) -> Optional[dict[str, str]]:
+    """List the CAs current stored in a trust store."""
+    if not exists(store_path):
+        return None
+
+    cmd = f"openssl pkcs12 -in {store_path}"
+    args = f"-passin pass:{store_pwd}"
+    try:
+        stored_certs = run_cmd(cmd, args).out
+    except OpenSearchCmdError as e:
+        logging.error(f"Error reading the current truststore: {e}")
+        return None
+
+    # parse output to retrieve the current CA (in case there are many)
+    start_cert_marker = "-----BEGIN CERTIFICATE-----"
+    end_cert_marker = "-----END CERTIFICATE-----"
+    certificates = stored_certs.split(end_cert_marker)
+
+    certs = {}
+    for cert in certificates:
+        alias = [line for line in cert if line.startswith("friendlyName:")][0]
+        alias = alias.split("friendlyName:")[-1]
+
+        certs[alias] = f"{start_cert_marker}{cert.split(start_cert_marker)[1]}{end_cert_marker}"
+
+    return certs
+
+
+def read_ca(alias: str, store_pwd: str, store_path: str) -> Optional[str]:
+    """Load stored CA cert."""
+    return (list_cas(store_pwd, store_path) or {}).get(alias)
+
+
+def remove_ca(alias: str, store_pwd: str, store_path: str) -> None:
+    """Remove old CA cert from trust store."""
+    if not exists(store_path):
+        return
+
+    keytool = "opensearch.keytool"
+
+    list_cmd = f"{keytool} -list -keystore {store_path} -alias {alias} -storetype PKCS12"
+    list_args = f"-storepass {store_pwd}"
+    try:
+        run_cmd(list_cmd, list_args)
+    except OpenSearchCmdError as e:
+        # This message means there was no "ca" alias or store before, if it happens ignore
+        if f"Alias <{alias}> does not exist" in e.out:
+            return
+
+    del_cmd = f"{keytool} -delete -keystore {store_path} -alias {alias} -storetype PKCS12"
+    del_args = f"-storepass {store_pwd}"
+    run_cmd(del_cmd, del_args)
+    logger.info(f"Removed {alias} from truststore.")
+
+
+def store_key_pair(
+    name: str, store_pwd: str, store_path: str, cert: str, key: str, key_pwd: str | None
+) -> None:
+    """Store cert in keystore."""
+    try:
+        os.remove(store_path)
+    except OSError:
+        pass
+
+    tmp_key = tempfile.NamedTemporaryFile(
+        mode="w+t", suffix=".pem", dir=os.path.dirname(store_path)
+    )
+    tmp_key.write(key)
+    tmp_key.flush()
+    tmp_key.seek(0)
+
+    tmp_cert = tempfile.NamedTemporaryFile(
+        mode="w+t", suffix=".cert", dir=os.path.dirname(store_path)
+    )
+    tmp_cert.write(cert)
+    tmp_cert.flush()
+    tmp_cert.seek(0)
+
+    cmd = f"openssl pkcs12 -export -in {tmp_cert.name} -inkey {tmp_key.name} -out {store_path} -name {name}"
+    args = f"-passout pass:{store_pwd}"
+    if key_pwd:
+        args = f"{args} -passin pass:{key_pwd}"
+
+    try:
+        run_cmd(cmd, args)
+        run_cmd(f"sudo chmod +r {store_path}")
+    except OpenSearchCmdError as e:
+        logging.error(f"Error storing the TLS certificates for {name}: {e}")
+    finally:
+        tmp_key.close()
+        tmp_cert.close()
+        logger.info(f"TLS certificate for {name} stored.")
+
+
+def get_cert_issuer(cert: str) -> Optional[str]:
+    """Retrieve the certificate issuer from a string certificate."""
+    # to make sure the content is processed correctly by openssl, temporary store it in a file
+    tmp_ca_file = tempfile.NamedTemporaryFile(mode="w+t", dir="/tmp")
+    tmp_ca_file.write(cert)
+    tmp_ca_file.flush()
+    tmp_ca_file.seek(0)
+
+    try:
+        return run_cmd(f"openssl x509 -in {tmp_ca_file.name} -noout -issuer").out
+    except OpenSearchCmdError as e:
+        logger.error(f"Error reading the current truststore: {e}")
+        return None
+    finally:
+        tmp_ca_file.close()
+
+
+def get_cert_issuer_from_path(store_pwd: str, store_path: str) -> Optional[str]:
+    """Retrieve the certificate issuer from a string certificate."""
+    try:
+        return run_cmd(
+            f"openssl pkcs12 -in {store_path}.p12",
+            f"""-nodes \
+            -passin pass:{store_pwd} \
+            | openssl x509 -noout -issuer
+            """,
+        ).out
+    except OpenSearchCmdError as e:
+        logger.error(f"Error reading the current certificate: {e}")
+        return None
+
+
+def get_cert_issuer_from_keystore(store_pwd: str, store_path: str) -> Optional[str]:
+    """Fetch the certificate issuer of a PKCS12 certificate."""
+    if not exists(store_path):
+        return None
+
+    cmd = f"openssl pkcs12 -in {store_path}.p12 -nodes"
+    args = f"-passin pass:{store_pwd} | openssl x509 -noout -issuer"
+    try:
+        return run_cmd(command=cmd, args=args).out
+    except OpenSearchCmdError as e:
+        logger.error(f"Error reading the current certificate: {e}")
+        return None
+    except AttributeError as e:
+        logger.error(f"Error reading secret: {e}")
+        return None

--- a/lib/charms/opensearch/v0/helper_security.py
+++ b/lib/charms/opensearch/v0/helper_security.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 
 
 KEYTOOL = "opensearch.keytool"
+OLD_CA_PREFIX = "old-"
 
 
 def hash_string(string: str) -> str:
@@ -144,11 +145,11 @@ def store_ca(
 
     for index in range(len(certs)):
         if keep_previous:
-            cmd = f"{KEYTOOL} -changealias -alias {alias}-{index} -destalias old-{alias}-{index} -keystore {store_path} -storetype PKCS12"
+            cmd = f"{KEYTOOL} -changealias -alias {alias}-{index} -destalias {OLD_CA_PREFIX}{alias}-{index} -keystore {store_path} -storetype PKCS12"
             args = f"-storepass {store_pwd}"
             try:
                 run_cmd(cmd, args)
-                logger.info(f"Current CA {alias}-{index} was renamed to old-{alias}-{index}.")
+                logger.info(f"Current CA {alias}-{index} was renamed to {OLD_CA_PREFIX}{alias}-{index}.")
             except OpenSearchCmdError as e:
                 # This message means there was no "ca" alias or store before, if it happens ignore
                 if not (
@@ -207,7 +208,7 @@ def list_aliases(store_pwd: str, store_path: str) -> Optional[list[str]]:
 
 
 def list_cas(store_pwd: str, store_path: str) -> Optional[dict[str, str]]:
-    """List the CAs current stored in a trust store."""
+    """List the CAs currently stored in a trust store."""
     if not exists(store_path):
         return None
 

--- a/lib/charms/opensearch/v0/helper_security.py
+++ b/lib/charms/opensearch/v0/helper_security.py
@@ -31,6 +31,9 @@ LIBPATCH = 1
 logger = logging.getLogger(__name__)
 
 
+KEYTOOL = "opensearch.keytool"
+
+
 def hash_string(string: str) -> str:
     """Hashes the given string."""
     salt = bcrypt.gensalt()
@@ -125,46 +128,64 @@ def to_pkcs8(private_key: str, password: Optional[str] = None) -> str:
         os.unlink(tmp_pkcs8_key.name)
 
 
+def split_ca_chain(pem_content: str) -> list[str]:
+    """Split PEM chain into individual certificates."""
+    certs = []
+    current_cert = ""
+
+    for line in pem_content.split("\n"):
+        current_cert += line + "\n"
+        if "-----END CERTIFICATE-----" in line:
+            certs.append(current_cert.strip())
+            current_cert = ""
+
+    return certs
+
+
 def store_ca(
     alias: str, store_pwd: str, store_path: str, ca: str, keep_previous: bool = True
 ) -> bool:
     """Add new CA cert to trust store."""
-    keytool = "opensearch.keytool"
 
-    if keep_previous:
-        cmd = f"{keytool} -changealias -alias {alias} -destalias old-{alias} -keystore {store_path} -storetype PKCS12"
-        args = f"-storepass {store_pwd}"
-        try:
-            run_cmd(cmd, args)
-            logger.info(f"Current CA {alias} was renamed to old-{alias}.")
-        except OpenSearchCmdError as e:
-            # This message means there was no "ca" alias or store before, if it happens ignore
-            if not (
-                f"Alias <{alias}> does not exist" in e.out
-                or "Keystore file does not exist" in e.out
-            ):
+    # This loop and split are to handle when the CA is a chain with intermediate certs
+    certs = list(reversed(split_ca_chain(ca)))
+
+    for index in range(len(certs)):
+        if keep_previous:
+            cmd = f"{KEYTOOL} -changealias -alias {alias}-{index} -destalias old-{alias}-{index} -keystore {store_path} -storetype PKCS12"
+            args = f"-storepass {store_pwd}"
+            try:
+                run_cmd(cmd, args)
+                logger.info(f"Current CA {alias}-{index} was renamed to old-{alias}-{index}.")
+            except OpenSearchCmdError as e:
+                # This message means there was no "ca" alias or store before, if it happens ignore
+                if not (
+                    f"Alias <{alias}-{index}> does not exist" in e.out
+                    or "Keystore file does not exist" in e.out
+                ):
+                    raise
+
+        with tempfile.NamedTemporaryFile(
+            mode="w+t", dir=os.path.dirname(store_path)
+        ) as ca_tmp_file:
+            ca_tmp_file.write(certs[index])
+            ca_tmp_file.flush()
+            try:
+                run_cmd(
+                    f"""{KEYTOOL} -importcert \
+                    -noprompt \
+                    -alias {alias}-{index} \
+                    -keystore {store_path} \
+                    -file {ca_tmp_file.name} \
+                    -storetype PKCS12
+                    """,
+                    f"-storepass {store_pwd}",
+                )
+                run_cmd(f"sudo chmod +r {store_path}")
+                logger.info("New CA was added to truststore.")
+            except OpenSearchCmdError as e:
+                logging.error(f"Error storing the ca-cert: {e}")
                 return False
-
-    with tempfile.NamedTemporaryFile(mode="w+t", dir=os.path.dirname(store_path)) as ca_tmp_file:
-        ca_tmp_file.write(ca)
-        ca_tmp_file.flush()
-        try:
-            run_cmd(
-                f"""{keytool} -importcert \
-                -trustcacerts \
-                -noprompt \
-                -alias {alias} \
-                -keystore {store_path} \
-                -file {ca_tmp_file.name} \
-                -storetype PKCS12
-                """,
-                f"-storepass {store_pwd}",
-            )
-            run_cmd(f"sudo chmod +r {store_path}")
-            logger.info("New CA was added to truststore.")
-        except OpenSearchCmdError as e:
-            logging.error(f"Error storing the ca-cert: {e}")
-            return False
 
     return True
 
@@ -174,14 +195,12 @@ def list_aliases(store_pwd: str, store_path: str) -> Optional[list[str]]:
     if not exists(store_path):
         return None
 
-    keytool = "opensearch.keytool"
-
     # we fetch the list of stored aliases
-    cmd = f"{keytool} -list -keystore {store_path} -storetype PKCS12"
+    cmd = f"{KEYTOOL} -v -list -keystore {store_path} -storetype PKCS12"
     args = f"-storepass {store_pwd}"
 
     try:
-        resp = run_cmd(cmd, args).out.split()
+        resp = run_cmd(cmd, args).out.split("\n")
         return [
             line.split("Alias name:")[-1].strip()
             for line in resp
@@ -206,18 +225,28 @@ def list_cas(store_pwd: str, store_path: str) -> Optional[dict[str, str]]:
         return None
 
     # parse output to retrieve the current CA (in case there are many)
+    certificates = split_ca_chain(stored_certs)
+
     start_cert_marker = "-----BEGIN CERTIFICATE-----"
-    end_cert_marker = "-----END CERTIFICATE-----"
-    certificates = stored_certs.split(end_cert_marker)
 
     certs = {}
     for cert in certificates:
         alias = [line for line in cert.split("\n") if line.strip().startswith("friendlyName:")][0]
         alias = alias.split("friendlyName:")[-1].strip()
 
-        certs[alias] = f"{start_cert_marker}{cert.split(start_cert_marker)[1]}{end_cert_marker}"
+        alias_split = alias.split("-")  # support for CA chains with multiple intermediate CAs
+        ca_index = int(alias_split[-1])
+        ca_alias = "-".join(alias_split[:-1])
+        certs.setdefault(ca_alias, []).insert(
+            ca_index, f"{start_cert_marker}{cert.split(start_cert_marker)[1]}"
+        )
 
-    return certs
+    # since we add a suffix for the index of the CA chain content, we need to re-arrange the output
+    cas = {}
+    for alias, certs_list in certs.items():
+        cas[alias] = "\n".join(certs_list)
+
+    return cas
 
 
 def read_ca(alias: str, store_pwd: str, store_path: str) -> Optional[str]:
@@ -230,9 +259,7 @@ def remove_ca(alias: str, store_pwd: str, store_path: str) -> None:
     if not exists(store_path):
         return
 
-    keytool = "opensearch.keytool"
-
-    list_cmd = f"{keytool} -list -keystore {store_path} -alias {alias} -storetype PKCS12"
+    list_cmd = f"{KEYTOOL} -list -keystore {store_path} -alias {alias} -storetype PKCS12"
     list_args = f"-storepass {store_pwd}"
     try:
         run_cmd(list_cmd, list_args)
@@ -241,7 +268,7 @@ def remove_ca(alias: str, store_pwd: str, store_path: str) -> None:
         if f"Alias <{alias}> does not exist" in e.out:
             return
 
-    del_cmd = f"{keytool} -delete -keystore {store_path} -alias {alias} -storetype PKCS12"
+    del_cmd = f"{KEYTOOL} -delete -keystore {store_path} -alias {alias} -storetype PKCS12"
     del_args = f"-storepass {store_pwd}"
     run_cmd(del_cmd, del_args)
     logger.info(f"Removed {alias} from truststore.")

--- a/lib/charms/opensearch/v0/helper_security.py
+++ b/lib/charms/opensearch/v0/helper_security.py
@@ -266,7 +266,7 @@ def remove_ca(alias: str, store_pwd: str, store_path: str) -> None:
     del_cmd = f"{KEYTOOL} -delete -keystore {store_path} -alias {alias} -storetype PKCS12"
     del_args = f"-storepass {store_pwd}"
     run_cmd(del_cmd, del_args)
-    logger.info(f"Removed %s from truststore.", alias)
+    logger.info("Removed %s from truststore.", alias)
 
 
 def store_key_pair(

--- a/lib/charms/opensearch/v0/helper_security.py
+++ b/lib/charms/opensearch/v0/helper_security.py
@@ -149,7 +149,9 @@ def store_ca(
             args = f"-storepass {store_pwd}"
             try:
                 run_cmd(cmd, args)
-                logger.info(f"Current CA {alias}-{index} was renamed to {OLD_CA_PREFIX}{alias}-{index}.")
+                logger.info(
+                    f"Current CA {alias}-{index} was renamed to {OLD_CA_PREFIX}{alias}-{index}."
+                )
             except OpenSearchCmdError as e:
                 # This message means there was no "ca" alias or store before, if it happens ignore
                 if not (

--- a/lib/charms/opensearch/v0/helper_security.py
+++ b/lib/charms/opensearch/v0/helper_security.py
@@ -146,7 +146,6 @@ def store_ca(
     alias: str, store_pwd: str, store_path: str, ca: str, keep_previous: bool = True
 ) -> bool:
     """Add new CA cert to trust store."""
-
     # This loop and split are to handle when the CA is a chain with intermediate certs
     certs = list(reversed(split_ca_chain(ca)))
 

--- a/lib/charms/opensearch/v0/helper_security.py
+++ b/lib/charms/opensearch/v0/helper_security.py
@@ -307,7 +307,7 @@ def get_cert_issuer_from_path(store_pwd: str, store_path: str) -> Optional[str]:
     """Retrieve the certificate issuer from a string certificate."""
     try:
         return run_cmd(
-            f"openssl pkcs12 -in {store_path}.p12",
+            f"openssl pkcs12 -in {store_path}",
             f"""-nodes \
             -passin pass:{store_pwd} \
             | openssl x509 -noout -issuer
@@ -323,7 +323,7 @@ def get_cert_issuer_from_keystore(store_pwd: str, store_path: str) -> Optional[s
     if not exists(store_path):
         return None
 
-    cmd = f"openssl pkcs12 -in {store_path}.p12 -nodes"
+    cmd = f"openssl pkcs12 -in {store_path} -nodes"
     args = f"-passin pass:{store_pwd} | openssl x509 -noout -issuer"
     try:
         return run_cmd(command=cmd, args=args).out

--- a/lib/charms/opensearch/v0/helper_security.py
+++ b/lib/charms/opensearch/v0/helper_security.py
@@ -130,16 +130,9 @@ def to_pkcs8(private_key: str, password: Optional[str] = None) -> str:
 
 def split_ca_chain(pem_content: str) -> list[str]:
     """Split PEM chain into individual certificates."""
-    certs = []
-    current_cert = ""
-
-    for line in pem_content.split("\n"):
-        current_cert += line + "\n"
-        if "-----END CERTIFICATE-----" in line:
-            certs.append(current_cert.strip())
-            current_cert = ""
-
-    return certs
+    end_cert_marker = "-----END CERTIFICATE-----"
+    parts = [part.strip() for part in pem_content.split(end_cert_marker) if part.strip()]
+    return [f"{part}\n{end_cert_marker}" for part in parts]
 
 
 def store_ca(
@@ -159,8 +152,11 @@ def store_ca(
             except OpenSearchCmdError as e:
                 # This message means there was no "ca" alias or store before, if it happens ignore
                 if not (
-                    f"Alias <{alias}-{index}> does not exist" in e.out
-                    or "Keystore file does not exist" in e.out
+                    e.out is not None
+                    and (
+                        f"Alias <{alias}-{index}> does not exist" in e.out
+                        or "Keystore file does not exist" in e.out
+                    )
                 ):
                     raise
 
@@ -183,7 +179,7 @@ def store_ca(
                 run_cmd(f"sudo chmod +r {store_path}")
                 logger.info("New CA was added to truststore.")
             except OpenSearchCmdError as e:
-                logging.error(f"Error storing the ca-cert: {e}")
+                logger.error("Error storing the ca-cert: %s", e)
                 return False
 
     return True
@@ -206,7 +202,7 @@ def list_aliases(store_pwd: str, store_path: str) -> Optional[list[str]]:
             if line.startswith("Alias name:")
         ]
     except OpenSearchCmdError as e:
-        logging.error(f"Error reading the current truststore: {e}")
+        logger.error("Error reading the current truststore: %s", e)
         return None
 
 
@@ -220,7 +216,7 @@ def list_cas(store_pwd: str, store_path: str) -> Optional[dict[str, str]]:
     try:
         stored_certs = run_cmd(cmd, args).out
     except OpenSearchCmdError as e:
-        logging.error(f"Error reading the current truststore: {e}")
+        logging.error("Error reading the current truststore: %s", e)
         return None
 
     # parse output to retrieve the current CA (in case there are many)
@@ -264,13 +260,13 @@ def remove_ca(alias: str, store_pwd: str, store_path: str) -> None:
         run_cmd(list_cmd, list_args)
     except OpenSearchCmdError as e:
         # This message means there was no "ca" alias or store before, if it happens ignore
-        if f"Alias <{alias}> does not exist" in e.out:
+        if e.out and f"Alias <{alias}> does not exist" in e.out:
             return
 
     del_cmd = f"{KEYTOOL} -delete -keystore {store_path} -alias {alias} -storetype PKCS12"
     del_args = f"-storepass {store_pwd}"
     run_cmd(del_cmd, del_args)
-    logger.info(f"Removed {alias} from truststore.")
+    logger.info(f"Removed %s from truststore.", alias)
 
 
 def store_key_pair(
@@ -305,11 +301,11 @@ def store_key_pair(
         run_cmd(cmd, args)
         run_cmd(f"sudo chmod +r {store_path}")
     except OpenSearchCmdError as e:
-        logging.error(f"Error storing the TLS certificates for {name}: {e}")
+        logger.error("Error storing the TLS certificates for %s: %s", name, e)
     finally:
         tmp_key.close()
         tmp_cert.close()
-        logger.info(f"TLS certificate for {name} stored.")
+        logger.info("TLS certificate for %s stored.", name)
 
 
 def get_cert_issuer(cert: str) -> Optional[str]:
@@ -323,7 +319,7 @@ def get_cert_issuer(cert: str) -> Optional[str]:
     try:
         return run_cmd(f"openssl x509 -in {tmp_ca_file.name} -noout -issuer").out
     except OpenSearchCmdError as e:
-        logger.error(f"Error reading the current truststore: {e}")
+        logger.error("Error reading the current truststore: %s", e)
         return None
     finally:
         tmp_ca_file.close()
@@ -340,7 +336,7 @@ def get_cert_issuer_from_path(store_pwd: str, store_path: str) -> Optional[str]:
             """,
         ).out
     except OpenSearchCmdError as e:
-        logger.error(f"Error reading the current certificate: {e}")
+        logger.error("Error reading the current certificate: %s", e)
         return None
 
 
@@ -354,8 +350,8 @@ def get_cert_issuer_from_keystore(store_pwd: str, store_path: str) -> Optional[s
     try:
         return run_cmd(command=cmd, args=args).out
     except OpenSearchCmdError as e:
-        logger.error(f"Error reading the current certificate: {e}")
+        logger.error("Error reading the current certificate: %s", e)
         return None
     except AttributeError as e:
-        logger.error(f"Error reading secret: {e}")
+        logger.error("Error reading secret: %s", e)
         return None

--- a/lib/charms/opensearch/v0/opensearch_keystore.py
+++ b/lib/charms/opensearch/v0/opensearch_keystore.py
@@ -8,9 +8,9 @@ This module manages OpenSearch keystore access and lifecycle.
 import functools
 import logging
 import os
-from abc import ABC, abstractmethod
 from typing import Any, Dict, List
 
+from charms.opensearch.v0.opensearch_distro import OpenSearchDistribution
 from charms.opensearch.v0.opensearch_exceptions import (
     OpenSearchCmdError,
     OpenSearchError,
@@ -38,54 +38,62 @@ class OpenSearchKeystoreNotReadyError(OpenSearchKeystoreError):
     """Exception thrown when the keystore is not ready yet."""
 
 
-class Keystore(ABC):
-    """Abstract class that represents the keystore."""
-
-    def __init__(self, charm, password: str = None):
-        """Creates the keystore manager class."""
-        self._charm = charm
-        self._opensearch = charm.opensearch
-        self._keystore = "keystore"
-        self._keystore_path = ""
-
-    @abstractmethod
-    def update(self, entries: Dict[str, Any]) -> None:
-        """Updates the keystore value (adding or removing) and reload.
-
-        Raises:
-            OpenSearchHttpError: If the reload fails.
-        """
-        ...
-
-    @functools.cached_property
-    @abstractmethod
-    def list(self) -> List[str]:
-        """Lists the keys available in opensearch's keystore."""
-        ...
-
-    def _clean_cache_if_needed(self):
-        if self.list:
-            del self.list
-
-    @abstractmethod
-    def reload_keystore(self) -> None:
-        """Updates the keystore value (adding or removing) and reload.
-
-        Raises:
-            OpenSearchHttpError: If the reload fails.
-        """
-        ...
-
-
-class OpenSearchKeystore(Keystore):
+class OpenSearchKeystore:
     """Manages keystore."""
 
-    def __init__(self, charm):
+    def __init__(self, opensearch: "OpenSearchDistribution"):
         """Creates the keystore manager class."""
-        super().__init__(charm)
+        self._opensearch = opensearch
         self._keystore = "keystore"
-        self._keystore_path = f"{charm.opensearch.paths.conf}/opensearch.keystore"
+        self._keystore_path = f"{opensearch.paths.conf}/opensearch.keystore"
 
+    def _create_if_needed(self) -> None:
+        """Creates the keystore if not already present."""
+        if os.path.exists(self._keystore_path):
+            return
+
+        self._opensearch.run_bin("keystore", "create")
+
+    def put_entries(self, entries: dict[str, str]) -> None:
+        """Add new key/val entries on the keystore."""
+        for key, val in entries.items():
+            # adding the '--force' flag will create the keystore if not present
+            self._opensearch.run_bin("keystore", f"add {key} --force", stdin=val)
+
+    def put_file_entry(self, key: str, filename: str) -> None:
+        """Add a new file entry in the keystore."""
+        self._opensearch.run_bin("keystore", f"add-file {key} {filename} --force")
+
+    def remove_entries(self, keys: list[str]) -> None:
+        """Remove entries from the keystore."""
+        self._create_if_needed()
+
+        for key in keys:
+            if key == "keystore.seed":
+                continue
+
+            try:
+                self._opensearch.run_bin("keystore", f"remove {key}")
+            except OpenSearchCmdError as e:
+                if e.err and "does not exist in the keystore" in e.err:
+                    continue
+                raise
+
+    def list_keys(self) -> list[str]:
+        """List all keys in the keystore."""
+        self._create_if_needed()
+        return self._opensearch.run_bin("keystore", "list").splitlines()
+
+    def reload(self) -> None:
+        """Reload the keystore."""
+        self._create_if_needed()
+        self._opensearch.run_bin("keystore", "upgrade")
+
+        if self._opensearch.is_node_up():
+            self._opensearch.request("POST", "_nodes/reload_secure_settings")
+            logger.debug("keystore reloaded.")
+
+    # TODO delete once backups rework fully merged
     def update(self, entries: Dict[str, Any]) -> None:
         """Updates the keystore value (adding or removing) and reload.
 
@@ -104,6 +112,7 @@ class OpenSearchKeystore(Keystore):
             else:
                 self._delete(key)
 
+    # TODO delete once backups rework fully merged
     @functools.cached_property
     def list(self) -> List[str]:
         """Lists the keys available in opensearch's keystore."""
@@ -114,6 +123,7 @@ class OpenSearchKeystore(Keystore):
         except OpenSearchCmdError as e:
             raise OpenSearchKeystoreError(str(e))
 
+    # TODO delete once backups rework fully merged
     def _add(self, key: str, value: str):
         try:
             # Add newline to the end of the key, if missing
@@ -124,6 +134,7 @@ class OpenSearchKeystore(Keystore):
         except OpenSearchCmdError as e:
             raise OpenSearchKeystoreError(str(e))
 
+    # TODO delete once backups rework fully merged
     def _delete(self, key: str) -> None:
         try:
             self._opensearch.run_bin(self._keystore, f"remove {key}")
@@ -138,6 +149,7 @@ class OpenSearchKeystore(Keystore):
                 return
             raise OpenSearchKeystoreError(str(e))
 
+    # TODO delete once backups rework fully merged
     def reload_keystore(self) -> None:
         """Updates the keystore value (adding or removing) and reload.
 
@@ -148,3 +160,9 @@ class OpenSearchKeystore(Keystore):
         """
         response = self._opensearch.request("POST", "_nodes/reload_secure_settings")
         logger.debug(f"_update_keystore_and_reload: response received {response}")
+
+    # TODO delete once backups rework fully merged
+    def _clean_cache_if_needed(self):
+        """Delete keystore content cached property."""
+        if self.list:
+            del self.list

--- a/lib/charms/opensearch/v0/opensearch_plugin_manager.py
+++ b/lib/charms/opensearch/v0/opensearch_plugin_manager.py
@@ -76,7 +76,7 @@ class OpenSearchPluginManager:
         self._opensearch = charm.opensearch
         self._opensearch_config = charm.opensearch_config
         self._charm_config = self._charm.model.config
-        self._keystore = OpenSearchKeystore(self._charm)
+        self._keystore = OpenSearchKeystore(charm.opensearch)
 
     @functools.cached_property
     def cluster_config(self):

--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -30,12 +30,19 @@ from charms.opensearch.v0.constants_charm import (
     PeerRelationName,
 )
 from charms.opensearch.v0.constants_tls import TLS_RELATION, CertType
-from charms.opensearch.v0.helper_charm import all_units, run_cmd
+from charms.opensearch.v0.helper_charm import all_units
 from charms.opensearch.v0.helper_networking import get_host_public_ip
-from charms.opensearch.v0.helper_security import generate_password
+from charms.opensearch.v0.helper_security import (
+    generate_password,
+    get_cert_issuer,
+    get_cert_issuer_from_path,
+    read_ca,
+    remove_ca,
+    store_ca,
+    store_key_pair,
+)
 from charms.opensearch.v0.models import DeploymentType
 from charms.opensearch.v0.opensearch_exceptions import (
-    OpenSearchCmdError,
     OpenSearchError,
     OpenSearchHttpError,
 )
@@ -84,7 +91,6 @@ class OpenSearchTLS(Object):
         self.peer_relation = peer_relation
         self.jdk_path = jdk_path
         self.certs_path = certs_path
-        self.keytool = "opensearch.keytool"
         self.certs = TLSCertificatesRequiresV3(charm, TLS_RELATION, expiry_notification_time=23)
 
         self.framework.observe(
@@ -552,50 +558,15 @@ class OpenSearchTLS(Object):
             logging.error("CA cert  or truststore-password not found, quitting.")
             return False
 
-        store_path = f"{self.certs_path}/{CA_ALIAS}.p12"
-
-        try:
-            run_cmd(
-                f"""{self.keytool} -changealias \
-                -alias {CA_ALIAS} \
-                -destalias {OLD_CA_ALIAS} \
-                -keystore {store_path} \
-                -storetype PKCS12
-            """,
-                f"-storepass {admin_secrets.get('truststore-password')}",
-            )
-            logger.info(f"Current CA {CA_ALIAS} was renamed to old-{CA_ALIAS}.")
-        except OpenSearchCmdError as e:
-            # This message means there was no "ca" alias or store before, if it happens ignore
-            if not (
-                f"Alias <{CA_ALIAS}> does not exist" in e.out
-                or "Keystore file does not exist" in e.out
-            ):
-                raise
-
-        with tempfile.NamedTemporaryFile(
-            mode="w+t", dir=self.charm.opensearch.paths.conf
-        ) as ca_tmp_file:
-            ca_tmp_file.write(secrets.get("ca-cert"))
-            ca_tmp_file.flush()
-
-            try:
-                run_cmd(
-                    f"""{self.keytool} -importcert \
-                    -trustcacerts \
-                    -noprompt \
-                    -alias {CA_ALIAS} \
-                    -keystore {store_path} \
-                    -file {ca_tmp_file.name} \
-                    -storetype PKCS12
-                """,
-                    f"-storepass {admin_secrets.get('truststore-password')}",
-                )
-                run_cmd(f"sudo chmod +r {store_path}")
-                logger.info("New CA was added to truststore.")
-            except OpenSearchCmdError as e:
-                logging.error(f"Error storing the ca-cert: {e}")
-                return False
+        is_ca_stored = store_ca(
+            alias=CA_ALIAS,
+            store_pwd=admin_secrets.get("truststore-password"),
+            store_path=f"{self.certs_path}/{CA_ALIAS}.p12",
+            ca=secrets.get("ca-cert"),
+            keep_previous=True,
+        )
+        if not is_ca_stored:
+            return False
 
         self._add_ca_to_request_bundle(secrets.get("chain"))
 
@@ -605,63 +576,30 @@ class OpenSearchTLS(Object):
         """Load stored CA cert."""
         secrets = self.charm.secrets.get_object(Scope.APP, CertType.APP_ADMIN.val, peek=True)
 
-        ca_trust_store = f"{self.certs_path}/ca.p12"
-        if not (exists(ca_trust_store) and secrets):
-            return None
-
-        try:
-            stored_certs = run_cmd(
-                f"openssl pkcs12 -in {ca_trust_store}",
-                f"-passin pass:{secrets.get('truststore-password')}",
-            ).out
-        except OpenSearchCmdError as e:
-            logging.error(f"Error reading the current truststore: {e}")
-            return
-
-        # parse output to retrieve the current CA (in case there are many)
-        start_cert_marker = "-----BEGIN CERTIFICATE-----"
-        end_cert_marker = "-----END CERTIFICATE-----"
-        certificates = stored_certs.split(end_cert_marker)
-        for cert in certificates:
-            if f"friendlyName: {alias}" in cert:
-                return f"{start_cert_marker}{cert.split(start_cert_marker)[1]}{end_cert_marker}"
-
-        return None
+        return read_ca(
+            alias=alias,
+            store_pwd=secrets.get("truststore-password"),
+            store_path=f"{self.certs_path}/{CA_ALIAS}.p12",
+        )
 
     def remove_old_ca(self) -> None:
         """Remove old CA cert from trust store."""
-        ca_trust_store = f"{self.certs_path}/ca.p12"
-
         secrets = self.charm.secrets.get_object(Scope.APP, CertType.APP_ADMIN.val, peek=True)
-        store_pwd = secrets.get("truststore-password")
+        trust_store_pwd = secrets.get("truststore-password")
+        trust_store_path = f"{self.certs_path}/{CA_ALIAS}.p12"
 
-        try:
-            run_cmd(
-                f"""{self.keytool} \
-                -list \
-                -keystore {ca_trust_store} \
-                -storepass {store_pwd} \
-                -alias {OLD_CA_ALIAS} \
-                -storetype PKCS12"""
-            )
-        except OpenSearchCmdError as e:
-            # This message means there was no "ca" alias or store before, if it happens ignore
-            if f"Alias <{OLD_CA_ALIAS}> does not exist" in e.out:
-                return
-
-        old_ca_content = self.read_stored_ca(alias=OLD_CA_ALIAS)
-
-        run_cmd(
-            f"""{self.keytool} \
-            -delete \
-            -keystore {ca_trust_store} \
-            -storepass {store_pwd} \
-            -alias {OLD_CA_ALIAS} \
-            -storetype PKCS12"""
+        old_ca = read_ca(
+            alias=OLD_CA_ALIAS,
+            store_pwd=trust_store_pwd,
+            store_path=trust_store_path,
         )
-        logger.info(f"Removed {OLD_CA_ALIAS} from truststore.")
+        remove_ca(
+            alias=OLD_CA_ALIAS,
+            store_pwd=trust_store_pwd,
+            store_path=trust_store_path,
+        )
         # remove it from the request bundle
-        self._remove_ca_from_request_bundle(old_ca_content)
+        self._remove_ca_from_request_bundle(old_ca)
 
     def update_request_ca_bundle(self) -> None:
         """Create a new chain.pem file for requests module"""
@@ -679,9 +617,6 @@ class OpenSearchTLS(Object):
         if not self.ca_rotation_complete_in_cluster():
             return
 
-        cert_name = cert_type.val
-        store_path = f"{self.certs_path}/{cert_type}.p12"
-
         # if the TLS certificate is available before the keystore-password, create it anyway
         if cert_type == CertType.APP_ADMIN:
             self._create_keystore_pwd_if_not_exists(Scope.APP, cert_type, cert_type.val)
@@ -692,44 +627,14 @@ class OpenSearchTLS(Object):
             logging.error("TLS key not found, quitting.")
             return
 
-        try:
-            os.remove(store_path)
-        except OSError:
-            pass
-
-        tmp_key = tempfile.NamedTemporaryFile(
-            mode="w+t", suffix=".pem", dir=self.charm.opensearch.paths.conf
+        store_key_pair(
+            name=cert_type.val,
+            store_pwd=secrets.get("keystore-password"),
+            store_path=f"{self.certs_path}/{cert_type}.p12",
+            cert=secrets.get("cert"),
+            key=secrets.get("key"),
+            key_pwd=secrets.get("key-password"),
         )
-        tmp_key.write(secrets.get("key"))
-        tmp_key.flush()
-        tmp_key.seek(0)
-
-        tmp_cert = tempfile.NamedTemporaryFile(
-            mode="w+t", suffix=".cert", dir=self.charm.opensearch.paths.conf
-        )
-        tmp_cert.write(secrets.get("cert"))
-        tmp_cert.flush()
-        tmp_cert.seek(0)
-
-        try:
-            cmd = f"""openssl pkcs12 -export \
-                -in {tmp_cert.name} \
-                -inkey {tmp_key.name} \
-                -out {store_path} \
-                -name {cert_name}
-            """
-            args = f"-passout pass:{secrets.get('keystore-password')}"
-            if secrets.get("key-password"):
-                args = f"{args} -passin pass:{secrets.get('key-password')}"
-
-            run_cmd(cmd, args)
-            run_cmd(f"sudo chmod +r {store_path}")
-        except OpenSearchCmdError as e:
-            logging.error(f"Error storing the TLS certificates for {cert_name}: {e}")
-        finally:
-            tmp_key.close()
-            tmp_cert.close()
-            logger.info(f"TLS certificate for {cert_name} stored.")
 
     def all_tls_resources_stored(self, only_unit_resources: bool = False) -> bool:  # noqa: C901
         """Check if all TLS resources are stored on disk."""
@@ -742,19 +647,7 @@ class OpenSearchTLS(Object):
         if not (current_ca := self.read_stored_ca()):
             return False
 
-        # to make sure the content is processed correctly by openssl, temporary store it in a file
-        tmp_ca_file = tempfile.NamedTemporaryFile(mode="w+t", dir=self.charm.opensearch.paths.conf)
-        tmp_ca_file.write(current_ca)
-        tmp_ca_file.flush()
-        tmp_ca_file.seek(0)
-
-        try:
-            ca_issuer = run_cmd(f"openssl x509 -in {tmp_ca_file.name} -noout -issuer").out
-        except OpenSearchCmdError as e:
-            logger.error(f"Error reading the current truststore: {e}")
-            return False
-        finally:
-            tmp_ca_file.close()
+        ca_issuer = get_cert_issuer(cert=current_ca)
 
         for cert_type in cert_types:
             if not exists(f"{self.certs_path}/{cert_type}.p12"):
@@ -763,19 +656,11 @@ class OpenSearchTLS(Object):
             scope = Scope.APP if cert_type == CertType.APP_ADMIN else Scope.UNIT
             secret = self.charm.secrets.get_object(scope, cert_type.val, peek=True)
 
-            try:
-                cert_issuer = run_cmd(
-                    f"openssl pkcs12 -in {self.certs_path}/{cert_type}.p12",
-                    f"""-nodes \
-                    -passin pass:{secret.get('keystore-password')} \
-                    | openssl x509 -noout -issuer
-                    """,
-                ).out
-            except OpenSearchCmdError as e:
-                logger.error(f"Error reading the current certificate: {e}")
-                return False
-            except AttributeError as e:
-                logger.error(f"Error reading secret: {e}")
+            cert_issuer = get_cert_issuer_from_path(
+                store_pwd=secret.get("keystore-password"),
+                store_path=f"{self.certs_path}/{cert_type}.p12",
+            )
+            if not cert_issuer:
                 return False
 
             if cert_issuer != ca_issuer:

--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -575,6 +575,9 @@ class OpenSearchTLS(Object):
     def read_stored_ca(self, alias: str = CA_ALIAS) -> Optional[str]:
         """Load stored CA cert."""
         secrets = self.charm.secrets.get_object(Scope.APP, CertType.APP_ADMIN.val, peek=True)
+        ca_trust_store = f"{self.certs_path}/ca.p12"
+        if not (exists(ca_trust_store) and secrets):
+            return None
 
         return read_ca(
             alias=alias,
@@ -588,11 +591,7 @@ class OpenSearchTLS(Object):
         trust_store_pwd = secrets.get("truststore-password")
         trust_store_path = f"{self.certs_path}/{CA_ALIAS}.p12"
 
-        old_ca = read_ca(
-            alias=OLD_CA_ALIAS,
-            store_pwd=trust_store_pwd,
-            store_path=trust_store_path,
-        )
+        old_ca = self.read_stored_ca(alias=OLD_CA_ALIAS)
         remove_ca(
             alias=OLD_CA_ALIAS,
             store_pwd=trust_store_pwd,

--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -558,14 +558,13 @@ class OpenSearchTLS(Object):
             logging.error("CA cert  or truststore-password not found, quitting.")
             return False
 
-        is_ca_stored = store_ca(
+        if not store_ca(
             alias=CA_ALIAS,
             store_pwd=admin_secrets.get("truststore-password"),
             store_path=f"{self.certs_path}/{CA_ALIAS}.p12",
             ca=secrets.get("ca-cert"),
             keep_previous=True,
-        )
-        if not is_ca_stored:
+        ):
             return False
 
         self._add_ca_to_request_bundle(secrets.get("chain"))

--- a/tests/unit/lib/test_opensearch_tls.py
+++ b/tests/unit/lib/test_opensearch_tls.py
@@ -744,6 +744,7 @@ class TestOpenSearchTLS(unittest.TestCase):
     @patch("charms.opensearch.v0.opensearch_tls.tempfile.NamedTemporaryFile")
     @patch("charms.opensearch.v0.helper_security.run_cmd")
     @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS.read_stored_ca")
+    @patch("charms.opensearch.v0.helper_security.split_ca_chain")
     @patch(f"{PEER_CLUSTERS_MANAGER}.deployment_desc")
     # Mocks to avoid I/O
     @patch("builtins.open", side_effect=unittest.mock.mock_open())
@@ -753,6 +754,7 @@ class TestOpenSearchTLS(unittest.TestCase):
         deployment_type,
         _,
         deployment_desc,
+        split_ca_chain,
         read_stored_ca,
         run_cmd,
         named_temporary_file,
@@ -827,17 +829,20 @@ class TestOpenSearchTLS(unittest.TestCase):
         self.harness.set_leader(is_leader=True)
         original_status = self.harness.model.unit.status
 
+        split_ca_chain.return_value = ["new_ca"]
         self.charm.tls._on_certificate_available(event_mock)
 
         mock_add_ca_to_request_bundle.assert_called_once()
 
-        # Old CA cert is saved with corresponding alias, new new CA cert added to keystore
+        # Old CA cert is saved with corresponding alias, new CA cert added to keystore
         assert run_cmd.call_count == 3
         assert re.search(
-            "keytool *-changealias *-alias ca *-destalias old-ca",
+            "opensearch.keytool -changealias -alias ca-0 -destalias old-ca-0",
             run_cmd.call_args_list[0].args[0],
         )
-        assert re.search("keytool *-importcert.* *-alias ca", run_cmd.call_args_list[1].args[0])
+        assert re.search(
+            "opensearch.keytool -importcert.* *-alias ca-0", run_cmd.call_args_list[1].args[0]
+        )
         assert (
             "chmod +r /var/snap/opensearch/current/etc/opensearch/certificates/ca.p12"
             in run_cmd.call_args_list[2].args[0]
@@ -1611,6 +1616,7 @@ class TestOpenSearchTLS(unittest.TestCase):
     @patch("charms.opensearch.v0.helper_security.run_cmd")
     @patch(f"{PEER_CLUSTERS_MANAGER}.deployment_desc")
     # Mock to avoid I/O
+    @patch("charms.opensearch.v0.helper_security.split_ca_chain")
     @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS.read_stored_ca")
     @patch("builtins.open", side_effect=unittest.mock.mock_open())
     def test_on_certificate_available_rotation_ongoing_on_this_unit(
@@ -1620,6 +1626,7 @@ class TestOpenSearchTLS(unittest.TestCase):
         leader,
         _,
         read_stored_ca,
+        split_ca_chain,
         deployment_desc,
         run_cmd,
         named_temporary_file,
@@ -1682,6 +1689,7 @@ class TestOpenSearchTLS(unittest.TestCase):
                 self.rel_id, f"{self.charm.unit.name}", {"tls_ca_renewing": "True"}
             )
 
+        split_ca_chain.return_value = ["new_ca"]
         self.charm.tls._on_certificate_available(self.charm.on.certificate_available)
 
         # exactly three run_cmd commands to be executed: checking the current CA for the
@@ -1729,6 +1737,7 @@ class TestOpenSearchTLS(unittest.TestCase):
     @patch("charms.opensearch.v0.helper_security.run_cmd")
     @patch(f"{PEER_CLUSTERS_MANAGER}.deployment_desc")
     # Mock to avoid I/O
+    @patch("charms.opensearch.v0.helper_security.split_ca_chain")
     @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS.read_stored_ca")
     @patch("builtins.open", side_effect=unittest.mock.mock_open())
     def test_on_certificate_available_rotation_ongoing_on_another_unit(
@@ -1738,6 +1747,7 @@ class TestOpenSearchTLS(unittest.TestCase):
         leader,
         _,
         read_stored_ca,
+        split_ca_chain,
         deployment_desc,
         run_cmd,
         __,
@@ -1802,6 +1812,7 @@ class TestOpenSearchTLS(unittest.TestCase):
                 self.rel_id, f"{self.charm.app.name}/1", {"tls_ca_renewing": "True"}
             )
 
+        split_ca_chain.return_value = ["new_ca"]
         self.charm.tls._on_certificate_available(self.charm.on.certificate_available)
 
         # exactly three run_cmd commands to be executed: checking the current CA for the

--- a/tests/unit/lib/test_opensearch_tls.py
+++ b/tests/unit/lib/test_opensearch_tls.py
@@ -474,7 +474,7 @@ class TestOpenSearchTLS(unittest.TestCase):
         ]
     )
     @patch("charms.opensearch.v0.opensearch_tls.tempfile.NamedTemporaryFile")
-    @patch("charms.opensearch.v0.opensearch_tls.run_cmd")
+    @patch("charms.opensearch.v0.helper_security.run_cmd")
     @patch(f"{PEER_CLUSTERS_MANAGER}.deployment_desc")
     # Mocks to avoid I/O
     @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS.read_stored_ca")
@@ -594,7 +594,7 @@ class TestOpenSearchTLS(unittest.TestCase):
         )
     )
     @patch("charms.opensearch.v0.opensearch_tls.tempfile.NamedTemporaryFile")
-    @patch("charms.opensearch.v0.opensearch_tls.run_cmd")
+    @patch("charms.opensearch.v0.helper_security.run_cmd")
     @patch(f"{PEER_CLUSTERS_MANAGER}.deployment_desc")
     # Mocks to avoid I/O
     @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS.read_stored_ca")
@@ -742,7 +742,7 @@ class TestOpenSearchTLS(unittest.TestCase):
     )
     @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS._add_ca_to_request_bundle")
     @patch("charms.opensearch.v0.opensearch_tls.tempfile.NamedTemporaryFile")
-    @patch("charms.opensearch.v0.opensearch_tls.run_cmd")
+    @patch("charms.opensearch.v0.helper_security.run_cmd")
     @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS.read_stored_ca")
     @patch(f"{PEER_CLUSTERS_MANAGER}.deployment_desc")
     # Mocks to avoid I/O
@@ -876,7 +876,7 @@ class TestOpenSearchTLS(unittest.TestCase):
             (DeploymentType.FAILOVER_ORCHESTRATOR),
         ]
     )
-    @patch("charms.opensearch.v0.opensearch_tls.run_cmd")
+    @patch("charms.opensearch.v0.helper_security.run_cmd")
     @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS.read_stored_ca")
     @patch(f"{PEER_CLUSTERS_MANAGER}.deployment_desc")
     def test_on_certificate_available_ca_rotation_first_stage_any_cluster_non_leader(
@@ -1281,8 +1281,8 @@ class TestOpenSearchTLS(unittest.TestCase):
             (DeploymentType.FAILOVER_ORCHESTRATOR),
         ]
     )
-    @patch("charms.opensearch.v0.opensearch_tls.tempfile.NamedTemporaryFile")
-    @patch("charms.opensearch.v0.opensearch_tls.run_cmd")
+    @patch("charms.opensearch.v0.helper_security.tempfile.NamedTemporaryFile")
+    @patch("charms.opensearch.v0.helper_security.run_cmd")
     @patch(f"{PEER_CLUSTERS_MANAGER}.deployment_desc")
     # Mocks to avoid I/O
     @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS.read_stored_ca")
@@ -1371,7 +1371,7 @@ class TestOpenSearchTLS(unittest.TestCase):
         # Exporting new certs
         assert re.search(
             "openssl pkcs12 -export .* -out "
-            "/var/snap/opensearch/current/etc/opensearch/certificates/app-admin.p12 .* -name app-admin",
+            "/var/snap/opensearch/current/etc/opensearch/certificates/app-admin.p12 -name app-admin",
             run_cmd.call_args_list[0].args[0],
         )
         assert (
@@ -1421,8 +1421,8 @@ class TestOpenSearchTLS(unittest.TestCase):
     )
     @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS._remove_ca_from_request_bundle")
     @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS.reload_tls_certificates")
-    @patch("charms.opensearch.v0.opensearch_tls.tempfile.NamedTemporaryFile")
-    @patch("charms.opensearch.v0.opensearch_tls.run_cmd")
+    @patch("charms.opensearch.v0.helper_security.tempfile.NamedTemporaryFile")
+    @patch("charms.opensearch.v0.helper_security.run_cmd")
     @patch(f"{PEER_CLUSTERS_MANAGER}.deployment_desc")
     # Mocks to avoid I/O
     @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS.read_stored_ca")
@@ -1561,13 +1561,13 @@ class TestOpenSearchTLS(unittest.TestCase):
         # Note: the high number of operations come from the fact that on each certificate received
         # the 'issuer' is checked on each certificate that is saved on the disk.
         if self.charm.unit.is_leader():
-            assert run_cmd.call_count == 14
+            assert run_cmd.call_count == 12
         else:
-            assert run_cmd.call_count == 16
+            assert run_cmd.call_count == 14
 
         assert re.search(
             "openssl pkcs12 -export .* -out "
-            rf"/var/snap/opensearch/current/etc/opensearch/certificates/{cert_type}.p12 .* -name {cert_type}",
+            rf"/var/snap/opensearch/current/etc/opensearch/certificates/{cert_type}.p12 -name {cert_type}",
             run_cmd.call_args_list[0].args[0],
         )
         assert (
@@ -1603,7 +1603,7 @@ class TestOpenSearchTLS(unittest.TestCase):
     )
     @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS._add_ca_to_request_bundle")
     @patch("charms.opensearch.v0.opensearch_tls.tempfile.NamedTemporaryFile")
-    @patch("charms.opensearch.v0.opensearch_tls.run_cmd")
+    @patch("charms.opensearch.v0.helper_security.run_cmd")
     @patch(f"{PEER_CLUSTERS_MANAGER}.deployment_desc")
     # Mock to avoid I/O
     @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS.read_stored_ca")
@@ -1721,7 +1721,7 @@ class TestOpenSearchTLS(unittest.TestCase):
     )
     @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS._add_ca_to_request_bundle")
     @patch("charms.opensearch.v0.opensearch_tls.tempfile.NamedTemporaryFile")
-    @patch("charms.opensearch.v0.opensearch_tls.run_cmd")
+    @patch("charms.opensearch.v0.helper_security.run_cmd")
     @patch(f"{PEER_CLUSTERS_MANAGER}.deployment_desc")
     # Mock to avoid I/O
     @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS.read_stored_ca")

--- a/tests/unit/lib/test_opensearch_tls.py
+++ b/tests/unit/lib/test_opensearch_tls.py
@@ -1423,6 +1423,7 @@ class TestOpenSearchTLS(unittest.TestCase):
     @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS.reload_tls_certificates")
     @patch("charms.opensearch.v0.helper_security.tempfile.NamedTemporaryFile")
     @patch("charms.opensearch.v0.helper_security.run_cmd")
+    @patch("charms.opensearch.v0.helper_security.exists")
     @patch(f"{PEER_CLUSTERS_MANAGER}.deployment_desc")
     # Mocks to avoid I/O
     @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS.read_stored_ca")
@@ -1443,6 +1444,7 @@ class TestOpenSearchTLS(unittest.TestCase):
         _____,
         read_stored_ca,
         deployment_desc,
+        os_path_exists,
         run_cmd,
         named_temporary_file,
         reload_tls_certificates,
@@ -1553,6 +1555,8 @@ class TestOpenSearchTLS(unittest.TestCase):
         mock_response_put_http_cert("1.1.1.1")
         original_status = self.harness.model.unit.status
 
+        os_path_exists.return_value = True
+
         self.charm.tls._on_certificate_available(event_mock)
 
         mock_remove_ca_from_request_bundle.assert_called_once()
@@ -1561,9 +1565,9 @@ class TestOpenSearchTLS(unittest.TestCase):
         # Note: the high number of operations come from the fact that on each certificate received
         # the 'issuer' is checked on each certificate that is saved on the disk.
         if self.charm.unit.is_leader():
-            assert run_cmd.call_count == 12
-        else:
             assert run_cmd.call_count == 14
+        else:
+            assert run_cmd.call_count == 16
 
         assert re.search(
             "openssl pkcs12 -export .* -out "
@@ -1574,6 +1578,7 @@ class TestOpenSearchTLS(unittest.TestCase):
             f"chmod +r /var/snap/opensearch/current/etc/opensearch/certificates/{cert_type}.p12"
             in run_cmd.call_args_list[1].args[0]
         )
+
         assert re.search("keytool .*-delete .*-alias old-ca", run_cmd.call_args_list[-1].args[0])
         assert (
             "/var/snap/opensearch/current/etc/opensearch"


### PR DESCRIPTION
## Description of issue or feature:
The openssl operations on PKCS12 certificates and trust stores related operations currently in the TLS module will be reused by the backups modules. 

There was a bug in the previous TLS implementation that lost the whole cert chain when storing in the trust store with the exception of the leaf certificate.  

## Solution:
- Extract those into helpers
- Fix the bug described above by breaking down CA chains into individual entries in the trust store 

## How was this change tested?
- [ ] Manually
- [x] Unit tests
- [x] Integration tests

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
