### PR TITLE
[DPE-8601] - Deactivate jammy integration tests

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -117,7 +117,7 @@ environment:
   PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
   CONCIERGE_JUJU_CHANNEL: 3.6/stable
   CHARM_UBUNTU_BASE/ubuntu24: 24.04
-  CHARM_UBUNTU_BASE/ubuntu22: 22.04
+  # CHARM_UBUNTU_BASE/ubuntu22: 22.04
 prepare: |
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"

--- a/spread.yaml
+++ b/spread.yaml
@@ -117,6 +117,7 @@ environment:
   PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
   CONCIERGE_JUJU_CHANNEL: 3.6/stable
   CHARM_UBUNTU_BASE/ubuntu24: 24.04
+  # TODO Add back when snapd problem is resolved on jammy
   # CHARM_UBUNTU_BASE/ubuntu22: 22.04
 prepare: |
   snap refresh --hold


### PR DESCRIPTION
## Description of issue or feature:
Integration tests failing on Jammy due to a bug with snapd on jammy
## Solution:
* Commented out the `CHARM_UBUNTU_BASE/ubuntu22` environment variable in `spread.yaml`, removing Ubuntu 22.04 as a configured base.

## How was this change tested?
- [ ] Manually
- [ ] Unit tests
- [ ] Integration tests

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
