### PR TITLE
Block if invalid smtp relation

### DIFF
--- a/lib/charms/opensearch/v0/constants_charm.py
+++ b/lib/charms/opensearch/v0/constants_charm.py
@@ -72,6 +72,7 @@ BackupRelShouldNotExist = "This unit should not be related to backup relation"
 BackupRelDataIncomplete = "Backup relation data missing or incomplete."
 BackupRelUneligible = "Only orchestrator clusters should relate to backup relation."
 SecretAccessError = "Failed to access secret, please check permissions."
+SmtpRelationInvalid = "SMTP relation must be created with the main cluster-orchestrator."
 JWTAuthConfigInvalid = (
     "Configuration for JWT authentication is invalid. Check and correct parameters."
 )

--- a/lib/charms/opensearch/v0/opensearch_plugin_manager.py
+++ b/lib/charms/opensearch/v0/opensearch_plugin_manager.py
@@ -13,14 +13,14 @@ config-changed, upgrade, s3-credentials-changed, etc.
 import logging
 from typing import TYPE_CHECKING, Dict, List, Optional
 
-from charms.opensearch.v0.constants_charm import PeerRelationName
+from charms.opensearch.v0.constants_charm import PeerRelationName, SmtpRelationInvalid
 from charms.opensearch.v0.helper_charm import Status, diff
 from charms.opensearch.v0.helper_plugins import (
     decode_plugin_secret_content,
     remove_plugin_secret,
     store_plugin_secret,
 )
-from charms.opensearch.v0.models import PluginConfigInfo
+from charms.opensearch.v0.models import DeploymentType, PluginConfigInfo
 from charms.opensearch.v0.opensearch_internal_data import Scope
 from charms.smtp_integrator.v0.smtp import DEFAULT_RELATION_NAME as SMTP_RELATION
 from charms.smtp_integrator.v0.smtp import SmtpRequires
@@ -66,6 +66,16 @@ class SmtpEvents(Object):
 
     def _on_smtp_credentials_changed(self, event) -> None:
         """Creates secret containing key, value pairs for keystore"""
+        if not (deployment_desc := self.charm.opensearch_peer_cm.deployment_desc()):
+            logger.debug("Node not up yet. Deferring event.")
+            event.defer()
+            return
+
+        if deployment_desc.typ != DeploymentType.MAIN_ORCHESTRATOR:
+            if self.charm.unit.is_leader():
+                self.charm.status.set(BlockedStatus(SmtpRelationInvalid), app=True)
+            return
+
         if not self.charm.opensearch.is_started():
             # node must be reachable to reload settings after adding keys
             event.defer()
@@ -126,6 +136,16 @@ class SmtpEvents(Object):
 
     def _on_smtp_credentials_gone(self, event) -> None:
         """Removes secret when credentials are gone"""
+        if not (deployment_desc := self.charm.opensearch_peer_cm.deployment_desc()):
+            logger.debug("Node not up yet. Deferring event.")
+            event.defer()
+            return
+
+        if deployment_desc.typ != DeploymentType.MAIN_ORCHESTRATOR:
+            if self.charm.unit.is_leader():
+                self.charm.status.clear(SmtpRelationInvalid, app=True)
+            return
+
         plugin_config = self.charm.state.unit.plugin_config_info.get(self.secret_label)
         keys = plugin_config.cleanup.get("keys")
 


### PR DESCRIPTION
## Description of issue or feature:
The smtp integrator should be related with the main orchestrator

## Solution:
Set a blocked status and message when the smtp integrator is related to an application that isn't the main orchestrator

## How was this change tested?
- [x] Manually
- [ ] Unit tests
- [ ] Integration tests
