### PR TITLE
Pin lxc image for jammy

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -140,12 +140,6 @@ jobs:
       - timeout-minutes: 1
         if: ${{ success() || (failure() && steps.spread.outcome == 'failure') }}
         run: snap list
-      - name: lxc image list
-        timeout-minutes: 1
-        if: ${{ (success() || (failure() && steps.spread.outcome == 'failure')) && inputs.path-to-charm-directory == 'machines' }}
-        # sudo needed since spread runs scripts as root
-        run: |
-          sudo lxc image list
       - name: Select model
         timeout-minutes: 1
         # `!contains(matrix.job.spread_job, 'juju29')` workaround for juju 2 error:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -107,6 +107,10 @@ jobs:
         with:
           pattern: ${{ inputs.artifact-prefix }}-*
           merge-multiple: true
+      - name: Pin lxc image for jammy
+        run: |
+          sudo lxc image copy ubuntu:568f69ff1166 local:
+          sudo lxc image alias create "juju/ubuntu@22.04/amd64" 568f69ff1166
       - name: Run spread job
         timeout-minutes: 180
         id: spread
@@ -136,6 +140,12 @@ jobs:
       - timeout-minutes: 1
         if: ${{ success() || (failure() && steps.spread.outcome == 'failure') }}
         run: snap list
+      - name: lxc image list
+        timeout-minutes: 1
+        if: ${{ (success() || (failure() && steps.spread.outcome == 'failure')) && inputs.path-to-charm-directory == 'machines' }}
+        # sudo needed since spread runs scripts as root
+        run: |
+          sudo lxc image list
       - name: Select model
         timeout-minutes: 1
         # `!contains(matrix.job.spread_job, 'juju29')` workaround for juju 2 error:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -107,6 +107,7 @@ jobs:
         with:
           pattern: ${{ inputs.artifact-prefix }}-*
           merge-multiple: true
+      # TODO Remove pinned image when problem is resolved on jammy
       - name: Pin lxc image for jammy
         run: |
           sudo lxc image copy ubuntu:568f69ff1166 local:

--- a/spread.yaml
+++ b/spread.yaml
@@ -117,7 +117,8 @@ environment:
   PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
   CONCIERGE_JUJU_CHANNEL: 3.6/stable
   CHARM_UBUNTU_BASE/ubuntu24: 24.04
-  CHARM_UBUNTU_BASE/ubuntu22: 22.04
+  # TODO Add back when snapd problem is resolved on jammy
+  # CHARM_UBUNTU_BASE/ubuntu22: 22.04
 prepare: |
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"

--- a/spread.yaml
+++ b/spread.yaml
@@ -117,8 +117,7 @@ environment:
   PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
   CONCIERGE_JUJU_CHANNEL: 3.6/stable
   CHARM_UBUNTU_BASE/ubuntu24: 24.04
-  # TODO Add back when snapd problem is resolved on jammy
-  # CHARM_UBUNTU_BASE/ubuntu22: 22.04
+  CHARM_UBUNTU_BASE/ubuntu22: 22.04
 prepare: |
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"


### PR DESCRIPTION
## Description of issue or feature:
There is an issue with the jammy image used by lxd which is causing charms running on 22.04 (eg self-signed-certificates) to be stuck in "waiting for machine" state and breaking most tests.

## Solution:
Pin the image to a working one while the issue is being fixed

## How was this change tested?
- [ ] Manually
- [ ] Unit tests
- [x] Integration tests
