### PR TITLE
[DPE-8405] Fix JWT integration test

### DIFF
--- a/tests/integration/relations/test_jwt_auth.py
+++ b/tests/integration/relations/test_jwt_auth.py
@@ -76,9 +76,11 @@ async def test_configure_and_use_jwt(charm, series, ops_test: OpsTest) -> None:
 
     logger.info("Creating signing-key secret")
     secret_name = "jwt-signing-key"
-    secret_id = await ops_test.model.add_secret(
-        name=secret_name, data_args=[f"signing-key={generated_jwt['signing-key']}"]
-    )
+    secret_id = (
+        await ops_test.juju(
+            "add-secret", secret_name, f"signing-key={generated_jwt['signing-key']}"
+        )
+    )[1].strip()
     await ops_test.model.grant_secret(secret_name=secret_name, application=JWT_APP_NAME)
 
     logger.info(f"Configuring {JWT_APP_NAME}")


### PR DESCRIPTION
## Description of issue or feature:
The integration test for JWT authentication is not stable, as can be seen [here](https://github.com/canonical/opensearch-operator/actions/runs/18654821240/job/53182127862?pr=724).

## Solution:
The test fails because the JWT signing key is not fully added to the user secret used for configuration. To work around this issue, the secret is created with a different command.

## How was this change tested?
- [X] Manually
- [ ] Unit tests
- [X] Integration tests

For investigation, the workflow has been executed manually, and everything worked well. When trying to reproduce the failed integration test, I found in the Opensearch server logfile that the JWT signing key was not accepted by Opensearch. This could be seen in the user secret created while testing, too.

## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
