### PR TITLE
[DPE-8405] Restrict relation with OAuth provider to main-orchestrator

### DIFF
--- a/lib/charms/opensearch/v0/constants_charm.py
+++ b/lib/charms/opensearch/v0/constants_charm.py
@@ -76,6 +76,7 @@ JWTAuthConfigInvalid = (
     "Configuration for JWT authentication is invalid. Check and correct parameters."
 )
 JWTRelationInvalid = "JWT relation must be created with Main-cluster-orchestrator"
+OAuthRelationInvalid = "OAuth relation must be created with Main-cluster-orchestrator"
 SecurityIndexUpdateError = "Failed to update security configuration, check logs for details."
 
 # Wait status

--- a/lib/charms/opensearch/v0/opensearch_oauth.py
+++ b/lib/charms/opensearch/v0/opensearch_oauth.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 from charms.hydra.v0.oauth import ClientConfig, OAuthRequirer
 from charms.opensearch.v0.constants_charm import OAUTH_RELATION, OAuthRelationInvalid
 from charms.opensearch.v0.constants_tls import CertType
-from charms.opensearch.v0.models import DeploymentType, StartMode
+from charms.opensearch.v0.models import DeploymentType
 from charms.opensearch.v0.opensearch_exceptions import OpenSearchCmdError
 from charms.opensearch.v0.opensearch_internal_data import Scope
 from ops import (
@@ -158,13 +158,3 @@ class OAuthHandler(Object):
         return bool(self.charm.opensearch_peer_cm.deployment_desc()) and bool(
             self.charm.peers_data.get(Scope.APP, "security_index_initialised")
         )
-
-    def _is_admin_script_eligible(self) -> bool:
-        deployment_desc = self.charm.opensearch_peer_cm.deployment_desc()
-        return (
-            deployment_desc.typ == DeploymentType.MAIN_ORCHESTRATOR
-            and (
-                "data" in deployment_desc.config.roles
-                or deployment_desc.start == StartMode.WITH_GENERATED_ROLES
-            )
-        ) or self.charm.opensearch_peer_cm.is_provider(typ="main")

--- a/lib/charms/opensearch/v0/opensearch_oauth.py
+++ b/lib/charms/opensearch/v0/opensearch_oauth.py
@@ -7,12 +7,19 @@ import logging
 from typing import TYPE_CHECKING
 
 from charms.hydra.v0.oauth import ClientConfig, OAuthRequirer
-from charms.opensearch.v0.constants_charm import OAUTH_RELATION
+from charms.opensearch.v0.constants_charm import OAUTH_RELATION, OAuthRelationInvalid
 from charms.opensearch.v0.constants_tls import CertType
 from charms.opensearch.v0.models import DeploymentType, StartMode
 from charms.opensearch.v0.opensearch_exceptions import OpenSearchCmdError
 from charms.opensearch.v0.opensearch_internal_data import Scope
-from ops import EventBase, Object, RelationBrokenEvent, RelationDepartedEvent
+from ops import (
+    BlockedStatus,
+    EventBase,
+    Object,
+    RelationBrokenEvent,
+    RelationCreatedEvent,
+    RelationDepartedEvent,
+)
 
 if TYPE_CHECKING:
     from charms.opensearch.v0.opensearch_base_charm import OpenSearchBaseCharm
@@ -46,6 +53,10 @@ class OAuthHandler(Object):
         )
         self.oauth = OAuthRequirer(self.charm, client_config, relation_name=OAUTH_RELATION)
         self.framework.observe(
+            self.charm.on[OAUTH_RELATION].relation_created,
+            self._on_oauth_relation_created,
+        )
+        self.framework.observe(
             self.charm.on[OAUTH_RELATION].relation_changed,
             self._on_oauth_relation_changed,
         )
@@ -58,11 +69,26 @@ class OAuthHandler(Object):
             self._on_oauth_relation_broken,
         )
 
+    def _on_oauth_relation_created(self, event: RelationCreatedEvent) -> None:
+        """Handler for `relation_created` event."""
+        if self.charm.opensearch_peer_cm.deployment_desc().typ != DeploymentType.MAIN_ORCHESTRATOR:
+            # in large deployments, OAuth config must only be handled by the main orchestrator
+            # this is a safeguard to avoid different sources for applying security configuration
+            if self.charm.unit.is_leader():
+                self.charm.status.set(BlockedStatus(OAuthRelationInvalid), app=True)
+
     def _on_oauth_relation_changed(self, event: EventBase) -> None:
         """Handler for `_on_oauth_relation_changed` event.
 
         Updates the security config.yml with the OIDC info and update the cluster.
         """
+        if self.charm.opensearch_peer_cm.deployment_desc().typ != DeploymentType.MAIN_ORCHESTRATOR:
+            # in large deployments, OAuth config must only be handled by the main orchestrator
+            # this is a safeguard to avoid different sources for applying security configuration
+            if self.charm.unit.is_leader():
+                self.charm.status.set(BlockedStatus(OAuthRelationInvalid), app=True)
+            return
+
         relation = self.model.get_relation(OAUTH_RELATION)
         if not relation.data[relation.app]:
             logger.debug("Oauth relation not yet set up")
@@ -77,7 +103,7 @@ class OAuthHandler(Object):
             openid_connect_url=f"{relation.data[relation.app].get('issuer_url')}/.well-known/openid-configuration"
         )
 
-        if not self.charm.unit.is_leader() or not self._is_admin_script_eligible():
+        if not self.charm.unit.is_leader():
             return
 
         if not (admin_secrets := self.charm.secrets.get_object(Scope.APP, CertType.APP_ADMIN.val)):
@@ -93,10 +119,17 @@ class OAuthHandler(Object):
             return
 
     def _on_oauth_relation_departed(self, event: RelationDepartedEvent) -> None:
+        """Handler for `relation_departed` event."""
         if event.departing_unit == self.charm.unit and self.charm.peers_data is not None:
             self.charm.peers_data.put(Scope.UNIT, "departing_oauth", True)
 
     def _on_oauth_relation_broken(self, event: RelationBrokenEvent) -> None:
+        """Handler for `relation_broken` event."""
+        if self.charm.opensearch_peer_cm.deployment_desc().typ != DeploymentType.MAIN_ORCHESTRATOR:
+            if self.charm.unit.is_leader():
+                self.charm.status.clear(OAuthRelationInvalid, app=True)
+            return
+
         if (
             self.charm.peers_data is None
             or self.charm.peers_data.get(Scope.UNIT, "departing_oauth")
@@ -106,7 +139,7 @@ class OAuthHandler(Object):
 
         self.charm.opensearch_config.remove_oidc_auth()
 
-        if not self.charm.unit.is_leader() or not self._is_admin_script_eligible():
+        if not self.charm.unit.is_leader():
             return
 
         if not (admin_secrets := self.charm.secrets.get_object(Scope.APP, CertType.APP_ADMIN.val)):

--- a/tests/integration/relations/test_oauth.py
+++ b/tests/integration/relations/test_oauth.py
@@ -1,13 +1,16 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import asyncio
 import json
 import logging
 from asyncio import gather
 
 import pytest
 import requests
+from charms.opensearch.v0.constants_charm import OAuthRelationInvalid
 from integration.helpers import CONFIG_OPTS, get_leader_unit_ip
+from integration.helpers_deployments import wait_until
 from juju.client.client import Action
 from juju.model import Model
 from pytest_operator.plugin import OpsTest
@@ -23,6 +26,13 @@ DATA_INTEGRATOR_CONFIG = {
 SECOND_DATA_INTEGRATOR_CONFIG = {
     "index-name": "dev-index",
 }
+MAIN_APP = "opensearch-main"
+FAILOVER_APP = "opensearch-failover"
+DATA_APP = "opensearch-data"
+CLUSTER_NAME = "log-app"
+REL_ORCHESTRATOR = "peer-cluster-orchestrator"
+REL_PEER = "peer-cluster"
+APP_UNITS = {MAIN_APP: 1, FAILOVER_APP: 1, DATA_APP: 3}
 
 logger = logging.getLogger(__name__)
 
@@ -230,3 +240,139 @@ async def test_oauth_access_cleanup(ops_test: OpsTest, microk8s_model: Model):
     )
     assert result.status_code == 200, "request for authinfo should success"
     assert result.json().get("roles") == ["own_index"], "all the mapped roles should be removed"
+
+
+@pytest.mark.abort_on_fail
+async def test_setup_large_cluster(ops_test: OpsTest, charm, series, microk8s_model: Model):
+    """Replace the Opensearch application with a large deployment cluster."""
+    logger.info("Remove Opensearch application")
+    await ops_test.model.remove_application("opensearch", block_until_done=True)
+
+    logger.info("Create large deployment cluster of Opensearch")
+    await asyncio.gather(
+        ops_test.model.deploy(
+            charm,
+            application_name=MAIN_APP,
+            num_units=APP_UNITS[MAIN_APP],
+            series=series,
+            config={"cluster_name": CLUSTER_NAME, "roles": "cluster_manager"} | CONFIG_OPTS,
+        ),
+        ops_test.model.deploy(
+            charm,
+            application_name=FAILOVER_APP,
+            num_units=APP_UNITS[FAILOVER_APP],
+            series=series,
+            config={"cluster_name": CLUSTER_NAME, "init_hold": True, "roles": "cluster_manager"}
+            | CONFIG_OPTS,
+        ),
+        ops_test.model.deploy(
+            charm,
+            application_name=DATA_APP,
+            num_units=APP_UNITS[DATA_APP],
+            series=series,
+            config={"cluster_name": CLUSTER_NAME, "init_hold": True, "roles": "data"}
+            | CONFIG_OPTS,
+        ),
+    )
+
+    # integrate TLS to all applications
+    for app in [MAIN_APP, FAILOVER_APP, DATA_APP]:
+        await ops_test.model.integrate(app, "certificates")
+
+    # integrate large deployment cluster
+    await ops_test.model.integrate(f"{DATA_APP}:{REL_PEER}", f"{MAIN_APP}:{REL_ORCHESTRATOR}")
+    await ops_test.model.integrate(f"{FAILOVER_APP}:{REL_PEER}", f"{MAIN_APP}:{REL_ORCHESTRATOR}")
+    await ops_test.model.integrate(f"{DATA_APP}:{REL_PEER}", f"{FAILOVER_APP}:{REL_ORCHESTRATOR}")
+
+    # integrate with Data integrator
+    await ops_test.model.integrate(
+        f"{DATA_APP}:opensearch-client", f"{DATA_INTEGRATOR_NAME}:opensearch"
+    )
+
+    await wait_until(
+        ops_test,
+        apps=[MAIN_APP, DATA_APP, FAILOVER_APP],
+        apps_full_statuses={
+            MAIN_APP: {"active": []},
+            DATA_APP: {"active": []},
+            FAILOVER_APP: {"active": []},
+        },
+        units_statuses=["active"],
+        wait_for_exact_units={app: units for app, units in APP_UNITS.items()},
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_oauth_relation_restricted(ops_test: OpsTest, charm, series, microk8s_model: Model):
+    """Ensure OAuth cannot be enabled if related to non-main-orchestrator."""
+    logger.info(f"Integrating {DATA_APP} with OAuth - this will result in blocked status")
+    await ops_test.model.integrate(f"{DATA_APP}:oauth", "oauth")
+    await wait_until(
+        ops_test,
+        apps=[DATA_APP],
+        apps_full_statuses={
+            DATA_APP: {"blocked": [OAuthRelationInvalid]},
+        },
+        wait_for_exact_units={DATA_APP: 3},
+    )
+
+    logger.info("Verifying access is not possible")
+    opensearch_address = await get_leader_unit_ip(ops_test, DATA_APP)
+    opensearch_url = f"https://{opensearch_address}:9200/_cat/indices"
+    result = requests.get(
+        opensearch_url, headers={"Authorization": f"Bearer {oauth_access_token}"}, verify=False
+    )
+    assert result.json().get("status") == 401, "`Unauthorized` error expected"
+    logger.info("Access with OAuth Token failed as expected")
+
+    logger.info(f"Remove relation with {DATA_APP}")
+    remove_relation_cmd = f"remove-relation {DATA_APP}:oauth oauth"
+    await ops_test.juju(*remove_relation_cmd.split(), check=True)
+
+    await wait_until(
+        ops_test,
+        apps=[DATA_APP],
+        apps_full_statuses={DATA_APP: {"active": []}},
+        units_statuses=["active"],
+        wait_for_exact_units={DATA_APP: 3},
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_oauth_access_large_cluster(ops_test: OpsTest, charm, series, microk8s_model: Model):
+    """Relate to main orchestrator and verify access with OAuth."""
+    logger.info(f"Integrating {MAIN_APP} with oauth")
+    await ops_test.model.integrate(f"{MAIN_APP}:oauth", "oauth")
+    await wait_until(
+        ops_test,
+        apps=[MAIN_APP, DATA_APP, FAILOVER_APP],
+        apps_full_statuses={
+            MAIN_APP: {"active": []},
+            DATA_APP: {"active": []},
+            FAILOVER_APP: {"active": []},
+        },
+        units_statuses=["active"],
+        wait_for_exact_units={app: units for app, units in APP_UNITS.items()},
+    )
+
+    action = (
+        await ops_test.model.applications[DATA_INTEGRATOR_NAME]
+        .units[0]
+        .run_action("get-credentials")
+    )
+    await action.wait()
+    data_integrator_user = action.results.get("opensearch", {}).get("username")
+    assert data_integrator_user, "failed to retrieve data integrator user"
+
+    original_opensearch_config = await ops_test.model.applications[DATA_APP].get_config()
+    config_with_roles = original_opensearch_config.copy()
+    config_with_roles["roles_mapping"] = json.dumps({oauth_client_id: data_integrator_user})
+    await ops_test.model.applications[DATA_APP].set_config(config_with_roles)
+    await ops_test.model.wait_for_idle(status="active")
+
+    opensearch_address = await get_leader_unit_ip(ops_test, DATA_APP)
+    opensearch_url = f"https://{opensearch_address}:9200/_cat/indices"
+    result = requests.get(
+        opensearch_url, headers={"Authorization": f"Bearer {oauth_access_token}"}, verify=False
+    )
+    assert result.status_code == 200, "request expected to succeed with roles mapping"

--- a/tests/integration/relations/test_oauth.py
+++ b/tests/integration/relations/test_oauth.py
@@ -322,7 +322,7 @@ async def test_oauth_relation_restricted(ops_test: OpsTest, charm, series, micro
     result = requests.get(
         opensearch_url, headers={"Authorization": f"Bearer {oauth_access_token}"}, verify=False
     )
-    assert result.json().get("status") == 401, "`Unauthorized` error expected"
+    assert result.status_code == 401, "`Unauthorized` error expected"
     logger.info("Access with OAuth Token failed as expected")
 
     logger.info(f"Remove relation with {DATA_APP}")

--- a/tests/integration/relations/test_oauth.py
+++ b/tests/integration/relations/test_oauth.py
@@ -32,7 +32,7 @@ DATA_APP = "opensearch-data"
 CLUSTER_NAME = "log-app"
 REL_ORCHESTRATOR = "peer-cluster-orchestrator"
 REL_PEER = "peer-cluster"
-APP_UNITS = {MAIN_APP: 1, FAILOVER_APP: 1, DATA_APP: 3}
+APP_UNITS = {MAIN_APP: 1, FAILOVER_APP: 1, DATA_APP: 1}
 
 logger = logging.getLogger(__name__)
 
@@ -313,7 +313,7 @@ async def test_oauth_relation_restricted(ops_test: OpsTest, charm, series, micro
         apps_full_statuses={
             DATA_APP: {"blocked": [OAuthRelationInvalid]},
         },
-        wait_for_exact_units={DATA_APP: 3},
+        wait_for_exact_units={DATA_APP: 1},
     )
 
     logger.info("Verifying access is not possible")
@@ -334,7 +334,7 @@ async def test_oauth_relation_restricted(ops_test: OpsTest, charm, series, micro
         apps=[DATA_APP],
         apps_full_statuses={DATA_APP: {"active": []}},
         units_statuses=["active"],
-        wait_for_exact_units={DATA_APP: 3},
+        wait_for_exact_units={DATA_APP: 1},
     )
 
 

--- a/tests/integration/relations/test_oauth.py
+++ b/tests/integration/relations/test_oauth.py
@@ -32,7 +32,7 @@ DATA_APP = "opensearch-data"
 CLUSTER_NAME = "log-app"
 REL_ORCHESTRATOR = "peer-cluster-orchestrator"
 REL_PEER = "peer-cluster"
-APP_UNITS = {MAIN_APP: 1, FAILOVER_APP: 1, DATA_APP: 1}
+APP_UNITS = {MAIN_APP: 1, FAILOVER_APP: 1, DATA_APP: 3}
 
 logger = logging.getLogger(__name__)
 
@@ -313,7 +313,7 @@ async def test_oauth_relation_restricted(ops_test: OpsTest, charm, series, micro
         apps_full_statuses={
             DATA_APP: {"blocked": [OAuthRelationInvalid]},
         },
-        wait_for_exact_units={DATA_APP: 1},
+        wait_for_exact_units={DATA_APP: 3},
     )
 
     logger.info("Verifying access is not possible")
@@ -334,7 +334,7 @@ async def test_oauth_relation_restricted(ops_test: OpsTest, charm, series, micro
         apps=[DATA_APP],
         apps_full_statuses={DATA_APP: {"active": []}},
         units_statuses=["active"],
-        wait_for_exact_units={DATA_APP: 1},
+        wait_for_exact_units={DATA_APP: 3},
     )
 
 

--- a/tests/integration/relations/test_oauth.py
+++ b/tests/integration/relations/test_oauth.py
@@ -247,6 +247,7 @@ async def test_setup_large_cluster(ops_test: OpsTest, charm, series, microk8s_mo
     """Replace the Opensearch application with a large deployment cluster."""
     logger.info("Remove Opensearch application")
     await ops_test.model.remove_application("opensearch", block_until_done=True)
+    await ops_test.model.remove_application(SECOND_DATA_INTEGRATOR_NAME, block_until_done=True)
 
     logger.info("Create large deployment cluster of Opensearch")
     await asyncio.gather(


### PR DESCRIPTION
## Description of issue or feature:
Fixes https://github.com/canonical/opensearch-operator/issues/699.

## Solution:
This PR restricts the OAuth relation in large deployments of Opensearch to only be created with the main-orchestrator application of the cluster. Otherwise the OAuth configuration will not be applied to Opensearch and a `blocked` status will be displayed.

The solution is in line with the one for JWT authentication (implementation and UX are the same).

## How was this change tested?
- [X] Manually
- [ ] Unit tests
- [X] Integration tests

The PR also adds integration test coverage for this use case:
- creating a large deployment consisting of cluster-manager-only and data-only nodes
- verifying `blocked` status and OAuth access not possible if relation is created with `Data` application
- when the relation is established with the `Main` application, OAuth access is possible on the `Data` nodes.

Furthermore, manual tests for both small and large deployments have been conducted, ensuring that OAuth and JWT authentication can be used in parallel and both work.