### PR TITLE
Fixing failing unit tests on TiCs workflows

### DIFF
--- a/.github/workflows/tics_run_sh_ghaction_test.yml
+++ b/.github/workflows/tics_run_sh_ghaction_test.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: "0 2 * * 6" # Every Saturday 2:00 AM UTC
   workflow_dispatch: # Allows manual triggering
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/tics_run_sh_ghaction_test.yml
+++ b/.github/workflows/tics_run_sh_ghaction_test.yml
@@ -33,7 +33,7 @@ jobs:
       # to the aproxy configuration that is excluding only a range of ip's
       - name: Exclude the opensearch test host from proxy
         run: |
-          sudo nft add element ip aproxy exclude { 1.1.1.1 }
+          sudo nft add element ip aproxy exclude "{ 1.1.1.1 }"
 
       - name: Run tox tests to create coverage.xml
         run: tox run -e unit

--- a/.github/workflows/tics_run_sh_ghaction_test.yml
+++ b/.github/workflows/tics_run_sh_ghaction_test.yml
@@ -27,6 +27,13 @@ jobs:
           pipx install tox
           pipx install poetry
 
+      # This step is required since the configuration of aproxy on the self-hosted runner
+      # Makes the socket connections to several ip's give false positive results. This is due
+      # to the aproxy configuration that is excluding only a range of ip's
+      - name: Exclude the opensearch test host from proxy
+        run: |
+          sudo nft add element ip aproxy exclude { 1.1.1.1 }
+
       - name: Run tox tests to create coverage.xml
         run: tox run -e unit
 


### PR DESCRIPTION
## Description of issue or feature:
This PR addresses issue #716 . The tics workflows was failing due to unit tests that were not passing on self-hosted runners [[1]](https://github.com/canonical/opensearch-operator/actions/workflows/tics_run_sh_ghaction_test.yml). After an investigation of the failing unit tests, we found that the function`is_reachable` in the`helpers_networking`[ [2] ](https://github.com/canonical/opensearch-operator/blob/387544298dfd447c2ae8a62bc811365a6f673c2d/lib/charms/opensearch/v0/helper_networking.py#L87C48-L88C1)is giving some weird false-positive results. This means that it was giving a success result when using IPs that don't exist or don't work when creating a socket connection to. After tracking this issue, we found that the issue was due to the tight configuration of self-hosted runners, they have an aproxy configuration that allow only a certain range of IPs. 

## Solution:
The Self-Hosted runners team proposed to add the unit test IP to the excluded IPs using this command `sudo nft add element ip aproxy exclude { 1.1.1.1 }`.  As a result we have added this workaround to the github actions workflow. 

# Note:
I have temporary updated the workflow to run on pull request making sure to validate the PR and then remove the trigger. 

## How was this change tested?
- [ ] Manually
- [X] Unit tests
- [ ] Integration tests

[1] https://github.com/canonical/opensearch-operator/actions/workflows/tics_run_sh_ghaction_test.yml
[2] https://github.com/canonical/opensearch-operator/blob/387544298dfd447c2ae8a62bc811365a6f673c2d/lib/charms/opensearch/v0/helper_networking.py#L87C48-L88C1
