### PR TITLE
[DPE-7059] Raise on the last cluster manager unit

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -690,13 +690,17 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
                     self.peer_cluster_provider.clean_all_relation_data()
                 elif self.opensearch_peer_cm.is_consumer():
                     self.peer_cluster_requirer.refresh_requirer_relation_data()
-                
+
             # No cluster managers left in the cluster fleet
             # raise so we do not lose the cluster state
-            if len(self.opensearch_peer_cm.apps_in_fleet()) > 0 and not self.opensearch_peer_cm.does_cluster_have_cm_up():
-                logger.error("No cluster managers left in the cluster fleet. Please scale up your cluster manager units.")
+            if (
+                len(self.opensearch_peer_cm.apps_in_fleet()) > 0
+                and not self.opensearch_peer_cm.does_cluster_have_cm_up()
+            ):
+                logger.error(
+                    "No cluster managers left in the cluster fleet. Please scale up your cluster manager units."
+                )
                 raise OpenSearchNoClusterManagersError()
-                
 
         # we attempt to flush the translog to disk
         if self.opensearch.is_node_up():

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -702,7 +702,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
                     ]
                 )
                 > 0
-                and not self.opensearch_peer_cm.does_cluster_have_cm_up()
+                and not self.opensearch_peer_cm.is_any_cm_node_up_in_cluster()
             ):
                 logger.error(
                     "No cluster managers left in the cluster fleet. Please scale up your cluster manager units."

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -694,7 +694,14 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             # No cluster managers left in the cluster fleet
             # raise so we do not lose the cluster state
             if (
-                len(self.opensearch_peer_cm.apps_in_fleet()) > 0
+                len(
+                    [
+                        app
+                        for app in self.opensearch_peer_cm.apps_in_fleet()
+                        if app.app.id != self.state.app.deployment_description.app.id
+                    ]
+                )
+                > 0
                 and not self.opensearch_peer_cm.does_cluster_have_cm_up()
             ):
                 logger.error(

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -66,6 +66,7 @@ from charms.opensearch.v0.opensearch_exceptions import (
     OpenSearchHAError,
     OpenSearchHttpError,
     OpenSearchMissingError,
+    OpenSearchNoClusterManagersError,
     OpenSearchNotFullyReadyError,
     OpenSearchStartError,
     OpenSearchStartTimeoutError,
@@ -689,6 +690,13 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
                     self.peer_cluster_provider.clean_all_relation_data()
                 elif self.opensearch_peer_cm.is_consumer():
                     self.peer_cluster_requirer.refresh_requirer_relation_data()
+                
+            # No cluster managers left in the cluster fleet
+            # raise so we do not lose the cluster state
+            if len(self.opensearch_peer_cm.apps_in_fleet()) > 0 and not self.opensearch_peer_cm.does_cluster_have_cm_up():
+                logger.error("No cluster managers left in the cluster fleet. Please scale up your cluster manager units.")
+                raise OpenSearchNoClusterManagersError()
+                
 
         # we attempt to flush the translog to disk
         if self.opensearch.is_node_up():

--- a/lib/charms/opensearch/v0/opensearch_exceptions.py
+++ b/lib/charms/opensearch/v0/opensearch_exceptions.py
@@ -108,8 +108,10 @@ class OpenSearchSecretError(OpenSearchError):
 class OpenSearchSecretInsertionError(OpenSearchSecretError):
     """Exception thrown when a secret (group) was not found."""
 
+
 class OpenSearchNoClusterManagersError(OpenSearchError):
     """Exception thrown when there are no cluster managers in the cluster."""
+
     def __init__(self):
         message = "No cluster managers left in the cluster fleet. Please scale up your cluster manager units."
         super().__init__(message)

--- a/lib/charms/opensearch/v0/opensearch_exceptions.py
+++ b/lib/charms/opensearch/v0/opensearch_exceptions.py
@@ -107,3 +107,9 @@ class OpenSearchSecretError(OpenSearchError):
 
 class OpenSearchSecretInsertionError(OpenSearchSecretError):
     """Exception thrown when a secret (group) was not found."""
+
+class OpenSearchNoClusterManagersError(OpenSearchError):
+    """Exception thrown when there are no cluster managers in the cluster."""
+    def __init__(self):
+        message = "No cluster managers left in the cluster fleet. Please scale up your cluster manager units."
+        super().__init__(message)

--- a/lib/charms/opensearch/v0/opensearch_peer_clusters.py
+++ b/lib/charms/opensearch/v0/opensearch_peer_clusters.py
@@ -769,7 +769,7 @@ class OpenSearchPeerClustersManager:
 
         return PeerClusterRelData.from_dict(content)
 
-    def does_cluster_have_cm_up(self) -> bool:
+    def is_any_cm_node_up_in_cluster(self) -> bool:
         """Check whether there is at least one cluster manager unit up in the fleet."""
         nodes = ClusterTopology.nodes(self._charm.opensearch, True, self._charm.alt_hosts)
         for node in nodes:

--- a/lib/charms/opensearch/v0/opensearch_peer_clusters.py
+++ b/lib/charms/opensearch/v0/opensearch_peer_clusters.py
@@ -768,3 +768,14 @@ class OpenSearchPeerClustersManager:
             )
 
         return PeerClusterRelData.from_dict(content)
+
+    def does_cluster_have_cm_up(self) -> bool:
+        """Check whether there is at least one cluster manager unit up in the fleet."""
+        nodes = ClusterTopology.nodes(self._charm.opensearch, True, self._charm.alt_hosts)
+        for node in nodes:
+            # ignore current unit
+            if node.ip == self._charm.opensearch.host:
+                continue
+            if node.is_cm_eligible() and self._charm.opensearch.is_node_up(node.ip):
+                return True
+        return False


### PR DESCRIPTION
## Description of issue or feature:
<!--- Please describe in detail what this PR is about. And a reference link to a Github issue or Jira ticket.  -->

This pull request introduces a new error handling mechanism for the scenario where no cluster manager units are available in an OpenSearch cluster. The changes ensure that the system will raise a specific exception and log an error if all cluster managers are lost, helping to prevent cluster state loss and improve operational robustness.

## Solution:
<!--- Please describe in detail what the solution implemented in this PR is. The changes made etc. -->

**Error handling improvements:**

* Added a new exception class `OpenSearchNoClusterManagersError` to `opensearch_exceptions.py` for cases when there are no cluster managers in the cluster.
* Updated the imports in `opensearch_base_charm.py` to include `OpenSearchNoClusterManagersError`.
* In the `_on_opensearch_data_storage_detaching` method, added logic to check for the presence of cluster managers and raise `OpenSearchNoClusterManagersError` if none are up, with an appropriate error log message.

**Cluster manager status checks:**

* Added the method `does_cluster_have_cm_up` to `opensearch_peer_clusters.py` to determine if at least one cluster manager unit is up in the fleet.


## How was this change tested?
- [x] Manually
- [ ] Unit tests
- [ ] Integration tests


## Checklist
- [ ] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
