### PR TITLE
docs: Add missing landing pages

### DIFF
--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -1,8 +1,19 @@
 (explanation-index)=
 # Explanation
 
+The pages in this section aim to provide additional context and deeper understanding
+of foundational topics and concepts relevant to OpenSearch.
+
+## Security
+
+Secure deployments of Charmed OpenSearch can be achieved through using recommended configurations,
+including setting up encryption and authentication.
+For more details, see the [Security](explanation-security-index) topic overview and
+[Cryptography](explanation-security-cryptography) usage explanation pages.
+
 ```{toctree}
 :titlesonly:
+:hidden:
 
 security/index
 ```

--- a/docs/how-to/back-up-and-restore/index.md
+++ b/docs/how-to/back-up-and-restore/index.md
@@ -1,6 +1,8 @@
 (how-to-guides-back-up-and-restore-index)=
 # Back up and restore
 
+For guidance on how to manage backups, see the following pages:
+
 ```{toctree}
 :titlesonly:
 

--- a/docs/how-to/deploy/index.md
+++ b/docs/how-to/deploy/index.md
@@ -1,6 +1,9 @@
 (how-to-guides-deploy-index)=
 # Deploy
 
+For guidance on how to set up environment and deploy OpenSearch with Juju charms,
+see the [Tutorial](tutorial-index) and the following guides:
+
 ```{toctree}
 :titlesonly:
 

--- a/docs/how-to/tls-encryption/index.md
+++ b/docs/how-to/tls-encryption/index.md
@@ -1,6 +1,9 @@
 (how-to-guides-tls-encryption-index)=
 # TLS encryption
 
+For guidance on how to enable TLS encryption,
+see the [Tutorial](tutorial-3-enable-encryption) and the following guides:
+
 ```{toctree}
 :titlesonly:
 

--- a/docs/how-to/upgrade/index.md
+++ b/docs/how-to/upgrade/index.md
@@ -1,6 +1,8 @@
 (how-to-guides-upgrade-index)=
 # Upgrade
 
+For instructions on performing version upgrades, see the following guides:
+
 ```{toctree}
 :titlesonly:
 


### PR DESCRIPTION
## Description of issue or feature:

A few landing pages were missing in the content migrated from Discourse. This is to be expected due to poor support of landing pages in Discourse Gatekeeper.

## Solution:

I've added the missing landing pages.

## How was this change tested?

- [x] Manually
- [ ] Unit tests
- [x] Integration tests


## Checklist

- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
