### PR TITLE
fix: spread job collection

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -19,19 +19,24 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up environment
         run: |
-          sudo snap install charmcraft --classic
+          sudo snap install go --classic
+          go install github.com/snapcore/spread/cmd/spread@latest
           pipx install tox poetry
       - name: Collect spread jobs
         id: collect-jobs
         shell: python
         run: |
           import json
+          import pathlib
           import os
           import subprocess
 
           spread_jobs = (
               subprocess.run(
-                  ["charmcraft", "test", "--list", "github-ci"], capture_output=True, check=True, text=True
+                  [pathlib.Path.home() / "go/bin/spread", "-list", "github-ci"],
+                  capture_output=True,
+                  check=True,
+                  text=True,
               )
               .stdout.strip()
               .split("\n")


### PR DESCRIPTION
## Description of issue or feature:
charmcraft test --list doesn't work anymore as charmcraft 4.0 removed --list from the charmcraft test command.
https://github.com/canonical/opensearch-operator/actions/runs/19344248602/job/55343765457

## Solution:
Install spread in the workflow and replace `charmcraft test --list` with `spread -list`. 

## How was this change tested?
- [ ] Manually
- [ ] Unit tests
- [ ] Integration tests


## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
