### PR TITLE
Update list_cas and remove_ca to account for CA index

### DIFF
--- a/lib/charms/opensearch/v0/helper_security.py
+++ b/lib/charms/opensearch/v0/helper_security.py
@@ -259,7 +259,7 @@ def remove_ca(alias: str, store_pwd: str, store_path: str) -> None:
         return
 
     aliases = list_aliases(store_pwd, store_path) or []
-    to_remove = [a for a in aliases if a == alias or a.startswith(f"{alias}-")]
+    to_remove = [a for a in aliases if a.startswith(f"{alias}-")]
 
     for a in to_remove:
         del_cmd = f"{KEYTOOL} -delete -keystore {store_path} -alias {a} -storetype PKCS12"

--- a/lib/charms/opensearch/v0/helper_security.py
+++ b/lib/charms/opensearch/v0/helper_security.py
@@ -258,19 +258,14 @@ def remove_ca(alias: str, store_pwd: str, store_path: str) -> None:
     if not exists(store_path):
         return
 
-    list_cmd = f"{KEYTOOL} -list -keystore {store_path} -alias {alias} -storetype PKCS12"
-    list_args = f"-storepass {store_pwd}"
-    try:
-        run_cmd(list_cmd, list_args)
-    except OpenSearchCmdError as e:
-        # This message means there was no "ca" alias or store before, if it happens ignore
-        if e.out and f"Alias <{alias}> does not exist" in e.out:
-            return
+    aliases = list_aliases(store_pwd, store_path) or []
+    to_remove = [a for a in aliases if a == alias or a.startswith(f"{alias}-")]
 
-    del_cmd = f"{KEYTOOL} -delete -keystore {store_path} -alias {alias} -storetype PKCS12"
-    del_args = f"-storepass {store_pwd}"
-    run_cmd(del_cmd, del_args)
-    logger.info("Removed %s from truststore.", alias)
+    for a in to_remove:
+        del_cmd = f"{KEYTOOL} -delete -keystore {store_path} -alias {a} -storetype PKCS12"
+        del_args = f"-storepass {store_pwd}"
+        run_cmd(del_cmd, del_args)
+        logger.info("Removed %s from truststore.", a)
 
 
 def store_key_pair(

--- a/lib/charms/opensearch/v0/helper_security.py
+++ b/lib/charms/opensearch/v0/helper_security.py
@@ -259,7 +259,7 @@ def remove_ca(alias: str, store_pwd: str, store_path: str) -> None:
         return
 
     aliases = list_aliases(store_pwd, store_path) or []
-    to_remove = [a for a in aliases if a.startswith(f"{alias}")]
+    to_remove = [a for a in aliases if a.startswith(alias)]
 
     for a in to_remove:
         del_cmd = f"{KEYTOOL} -delete -keystore {store_path} -alias {a} -storetype PKCS12"

--- a/lib/charms/opensearch/v0/helper_security.py
+++ b/lib/charms/opensearch/v0/helper_security.py
@@ -233,8 +233,9 @@ def list_cas(store_pwd: str, store_path: str) -> Optional[dict[str, str]]:
         alias = alias.split("friendlyName:")[-1].strip()
 
         alias_split = alias.split("-")  # support for CA chains with multiple intermediate CAs
-        ca_index = int(alias_split[-1])
-        ca_alias = "-".join(alias_split[:-1])
+        last = alias_split[-1]
+        ca_index = int(last) if last.isdigit() else 0
+        ca_alias = "-".join(alias_split[:-1]) if last.isdigit() else alias
         certs.setdefault(ca_alias, []).insert(
             ca_index, f"{start_cert_marker}{cert.split(start_cert_marker)[1]}"
         )

--- a/lib/charms/opensearch/v0/helper_security.py
+++ b/lib/charms/opensearch/v0/helper_security.py
@@ -259,7 +259,7 @@ def remove_ca(alias: str, store_pwd: str, store_path: str) -> None:
         return
 
     aliases = list_aliases(store_pwd, store_path) or []
-    to_remove = [a for a in aliases if a.startswith(f"{alias}-")]
+    to_remove = [a for a in aliases if a.startswith(f"{alias}")]
 
     for a in to_remove:
         del_cmd = f"{KEYTOOL} -delete -keystore {store_path} -alias {a} -storetype PKCS12"

--- a/tests/unit/lib/test_opensearch_tls.py
+++ b/tests/unit/lib/test_opensearch_tls.py
@@ -1427,6 +1427,7 @@ class TestOpenSearchTLS(unittest.TestCase):
     @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS._remove_ca_from_request_bundle")
     @patch("charms.opensearch.v0.opensearch_tls.OpenSearchTLS.reload_tls_certificates")
     @patch("charms.opensearch.v0.helper_security.tempfile.NamedTemporaryFile")
+    @patch("charms.opensearch.v0.helper_security.list_aliases")
     @patch("charms.opensearch.v0.helper_security.run_cmd")
     @patch("charms.opensearch.v0.helper_security.exists")
     @patch(f"{PEER_CLUSTERS_MANAGER}.deployment_desc")
@@ -1451,6 +1452,7 @@ class TestOpenSearchTLS(unittest.TestCase):
         deployment_desc,
         os_path_exists,
         run_cmd,
+        list_aliases,
         named_temporary_file,
         reload_tls_certificates,
         mock_remove_ca_from_request_bundle,
@@ -1473,7 +1475,7 @@ class TestOpenSearchTLS(unittest.TestCase):
         ca = "new_ca"
         key = "key"
         keystore_password = "keystore_12345"
-
+        list_aliases.return_value = ["new_ca", "old-ca-0", "old-ca"]
         self.secret_store.put_object(
             Scope.APP,
             CertType.APP_ADMIN.val,
@@ -1584,7 +1586,10 @@ class TestOpenSearchTLS(unittest.TestCase):
             in run_cmd.call_args_list[1].args[0]
         )
 
-        assert re.search("keytool .*-delete .*-alias old-ca", run_cmd.call_args_list[-1].args[0])
+        assert re.search("keytool .*-delete .*-alias old-ca ", run_cmd.call_args_list[-1].args[0])
+        assert re.search(
+            "keytool .*-delete .*-alias old-ca-0 ", run_cmd.call_args_list[-2].args[0]
+        )
         assert (
             "/var/snap/opensearch/current/etc/opensearch"
             in named_temporary_file.call_args_list[0][1]["dir"]


### PR DESCRIPTION
## Description of issue or feature:
`list_cas` expects stored CA aliases to be suffixed with an index. Older revisions of the charm do not use this format for CA aliases and so this causes a ValueError to be raised after upgrading.

Additionally, the logic to remove CAs after a CA rotation does not account for the index format and only looks to remove a CA with alias `old-ca`, so the old CA/chain isn't actually removed.

## Solution
`list_cas`: Check first if the ca alias ends with a digit before attempting to cast it to an int.
`remove_ca`: Match CAs which start with the alias to remove all `<alias>-i`
