### PR TITLE
Enable Jammy integration tests

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -117,8 +117,7 @@ environment:
   PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
   CONCIERGE_JUJU_CHANNEL: 3.6/stable
   CHARM_UBUNTU_BASE/ubuntu24: 24.04
-  # TODO Add back when snapd problem is resolved on jammy
-  # CHARM_UBUNTU_BASE/ubuntu22: 22.04
+  CHARM_UBUNTU_BASE/ubuntu22: 22.04
 prepare: |
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -29,3 +29,11 @@ def charm(ubuntu_base):
     # juju bundle files expect local charms to begin with `./` or `/` to distinguish them from
     # Charmhub charms.
     return f"./opensearch_ubuntu@{ubuntu_base}-amd64.charm"
+
+
+# workaround for https://bugs.launchpad.net/snapd/+bug/2127244
+@pytest.fixture(autouse=True)
+async def fix_ubuntu_22_image(ops_test, ubuntu_base: str):
+    """Ensure that Ubuntu 22.04 uses the daily image stream to avoid image resolution issues."""
+    if ubuntu_base == "22.04":
+        await ops_test.model.set_config({"image-stream": "daily"})


### PR DESCRIPTION
## Description of issue or feature:
<!--- Please describe in detail what this PR is about. And a reference link to a Github issue or Jira ticket.  -->

This pull request re-enables support for Ubuntu 22.04 in the test environment and introduces a workaround for a known snapd issue affecting this version. The main changes are grouped into environment configuration updates and test reliability improvements.


## Solution:
<!--- Please describe in detail what the solution implemented in this PR is. The changes made etc. -->

* Re-enabled the `CHARM_UBUNTU_BASE/ubuntu22` configuration in `spread.yaml`, allowing tests to run against Ubuntu 22.04 again.

* Added a pytest fixture in `tests/integration/conftest.py` that automatically sets the `image-stream` to `daily` for Ubuntu 22.04 during tests, working around a snapd image resolution bug.

## How was this change tested?
- [ ] Manually
- [ ] Unit tests
- [ ] Integration tests

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
