### PR TITLE
Pin juju to 3.6.11

### DIFF
--- a/concierge.yaml
+++ b/concierge.yaml
@@ -4,7 +4,7 @@ juju:
 providers:
   lxd:
     enable: true
-    bootstrap: true
+    bootstrap: false
 host:
   snaps:
     jhack:

--- a/spread.yaml
+++ b/spread.yaml
@@ -128,6 +128,9 @@ prepare: |
   # Install charmcraft & pipx (on lxd-vm backend)
   concierge prepare --trace
 
+  /snap/bin/juju bootstrap localhost concierge-lxd --verbose --model-default 'logging-config=<root>=INFO; unit=DEBUG' --agent-version=3.6.11
+  /snap/bin/juju add-model -c concierge-lxd testing
+
   pipx install tox poetry
 prepare-each: |
   cd "$SPREAD_PATH"


### PR DESCRIPTION
This pull request updates the Juju bootstrap process to be handled explicitly in the test preparation script rather than automatically by the concierge configuration. The main change is to disable automatic bootstrapping in `concierge.yaml` and add explicit Juju bootstrap and model creation commands to `spread.yaml`.

Juju bootstrap configuration:

* Set `bootstrap` to `false` for the `lxd` provider in `concierge.yaml`, disabling automatic bootstrapping.

Test preparation improvements:

* Added explicit commands in `spread.yaml` to bootstrap Juju and create a testing model, ensuring more control and verbosity during test setup.