### PR TITLE
SSC 1/stable track support

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -700,7 +700,8 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             # No cluster managers left in the cluster fleet
             # raise so we do not lose the cluster state
             if (
-                len(
+                self.opensearch.is_started()
+                and len(
                     [
                         app
                         for app in self.opensearch_peer_cm.apps_in_fleet()

--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -700,7 +700,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             # No cluster managers left in the cluster fleet
             # raise so we do not lose the cluster state
             if (
-                self.opensearch.is_started()
+                self.opensearch.is_node_up()
                 and len(
                     [
                         app

--- a/tests/integration/ha/test_large_deployments_relations.py
+++ b/tests/integration/ha/test_large_deployments_relations.py
@@ -197,7 +197,9 @@ async def test_invalid_conditions(ops_test: OpsTest) -> None:
 
     # delete the invalid app name
     await ops_test.model.remove_application(
-        INVALID_APP, block_until_done=True, force=True, destroy_storage=True, no_wait=True
+        INVALID_APP,
+        block_until_done=True,
+        timeout=1000,
     )
 
 

--- a/tests/integration/tls/test_tls.py
+++ b/tests/integration/tls/test_tls.py
@@ -35,7 +35,8 @@ logger = logging.getLogger(__name__)
 
 
 TLS_CERTIFICATES_APP_NAME = "self-signed-certificates"
-TLS_STABLE_CHANNEL = "latest/stable"
+# TODO update the docs to reflect the new channel once released
+TLS_STABLE_CHANNEL = "1/stable"
 # The expiry time of the secret carrying the certificate is set to 3 minutes for testing
 SECRET_EXPIRY_TIME = 180
 # Wait time for the secret to expire and be renewed


### PR DESCRIPTION
This pull request introduces several updates to improve reliability and maintainability across both the OpenSearch charm logic and its integration tests. The changes focus on ensuring correct cluster state handling, refining test application removal, and updating channel references for TLS certificates.

### OpenSearch charm logic:

* Added a check to ensure `self.opensearch.is_started()` before evaluating the number of cluster managers during storage detaching, which helps prevent cluster state loss when the service is not running.

### Integration tests:

* Updated the removal of invalid applications in `test_invalid_conditions` to use a `timeout` parameter instead of `force`, `destroy_storage`, and `no_wait`, streamlining the cleanup process and improving test reliability.

### TLS certificates configuration:

* Changed the stable channel for TLS certificates from `"latest/stable"` to `"1/stable"` and added a TODO to update documentation once the new channel is released, ensuring consistency with current deployment practices.