### PR TITLE
Extract microk8s to spread

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -98,6 +98,7 @@ backends:
       GCP_ACCESS_KEY: '$(HOST: echo $GCP_ACCESS_KEY)'
       GCP_SECRET_KEY: '$(HOST: echo $GCP_SECRET_KEY)'
       GCP_SERVICE_ACCOUNT: '$(HOST: echo $GCP_SERVICE_ACCOUNT)'
+      DOCKERHUB_MIRROR: '$(HOST: echo $DOCKERHUB_MIRROR)'
       # To install pipx on self-hosted runners
       CONCIERGE_EXTRA_DEBS: pipx
     systems:
@@ -125,6 +126,45 @@ prepare: |
   cd "$SPREAD_PATH"
   snap install --classic concierge
 
+  if [[ -n "$DOCKERHUB_MIRROR" ]] && ([[ $SPREAD_TASK == *"oauth"* ]])
+  then
+    # Running on IS-hosted runner; configure microk8s to use Docker Hub mirror
+    # Run before concierge prepare because of https://github.com/canonical/concierge/issues/75
+    sudo snap install microk8s  --classic
+    sudo snap install kubectl --classic 
+    sudo snap install yq
+    
+    # Wait for microk8s to populate iptables
+    # https://chat.canonical.com/canonical/pl/jo5cg6wqjjrudqd5ybj6hhttee
+    until [[ -n $(iptables --list | grep -i "microk8s") ]]
+    do
+      echo "MicroK8s has not yet configured iptables."
+      sleep 10
+    done
+    tee /var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml << EOF
+    server = "$DOCKERHUB_MIRROR"
+    [host."${DOCKERHUB_MIRROR#'https://'}"]
+    capabilities = ["pull", "resolve"]
+  EOF
+    microk8s stop
+    microk8s start
+    microk8s enable dns
+    microk8s enable hostpath-storage
+    microk8s enable metallb:10.64.140.43-10.64.140.49
+    mkdir -p ~/.kube
+    microk8s config > ~/.kube/config
+
+    
+    echo "Waiting for all pods to be in 'Running' phase..."
+    until kubectl get po -A --field-selector=status.phase!=Running 2>&1 | grep -q "No resources found"; do
+      echo "Some pods are not running. Retrying in 5 seconds..."
+      sleep 5
+    done
+    echo "Success: All pods are running!"
+  fi
+
+  juju add-k8s uk8s $(juju show-controller | yq "keys | .[0]")
+
   # Install charmcraft & pipx (on lxd-vm backend)
   concierge prepare --trace
 
@@ -144,4 +184,4 @@ prepare-each: |
   # https://bugs.launchpad.net/juju/+bug/2065050
   juju set-model-constraints arch="$(dpkg --print-architecture)"
 
-# Only restore on lxd backend—no need to restore on CI
+# Only restore on lxd backend. No need to restore on CI

--- a/spread.yaml
+++ b/spread.yaml
@@ -147,7 +147,7 @@ prepare: |
       server = "$DOCKERHUB_MIRROR"
       [host."${DOCKERHUB_MIRROR#'https://'}"]
       capabilities = ["pull", "resolve"]
-      EOF
+  EOF
     fi
 
     microk8s stop

--- a/spread.yaml
+++ b/spread.yaml
@@ -130,9 +130,9 @@ prepare: |
   then
     # Running on IS-hosted runner; configure microk8s to use Docker Hub mirror
     # Run before concierge prepare because of https://github.com/canonical/concierge/issues/75
-    sudo snap install microk8s  --classic
-    sudo snap install kubectl --classic 
-    sudo snap install yq
+    snap install microk8s  --classic
+    snap install kubectl --classic 
+    snap install yq
     
     if [[ -n "$DOCKERHUB_MIRROR" ]]
     then
@@ -144,9 +144,9 @@ prepare: |
         sleep 10
       done
       tee /var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml << EOF
-      server = "$DOCKERHUB_MIRROR"
-      [host."${DOCKERHUB_MIRROR#'https://'}"]
-      capabilities = ["pull", "resolve"]
+  server = "$DOCKERHUB_MIRROR"
+  [host."${DOCKERHUB_MIRROR#'https://'}"]
+  capabilities = ["pull", "resolve"]
   EOF
     fi
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -126,11 +126,7 @@ prepare: |
   cd "$SPREAD_PATH"
   snap install --classic concierge
 
-
-  # Install charmcraft & pipx (on lxd-vm backend)
-  concierge prepare --trace
-
-  if [[ -n "$DOCKERHUB_MIRROR" ]] && ([[ $SPREAD_TASK == *"oauth"* ]])
+  if [[ $SPREAD_TASK == *"oauth"* ]]
   then
     # Running on IS-hosted runner; configure microk8s to use Docker Hub mirror
     # Run before concierge prepare because of https://github.com/canonical/concierge/issues/75
@@ -138,18 +134,22 @@ prepare: |
     sudo snap install kubectl --classic 
     sudo snap install yq
     
-    # Wait for microk8s to populate iptables
-    # https://chat.canonical.com/canonical/pl/jo5cg6wqjjrudqd5ybj6hhttee
-    until [[ -n $(iptables --list | grep -i "microk8s") ]]
-    do
-      echo "MicroK8s has not yet configured iptables."
-      sleep 10
-    done
-    tee /var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml << EOF
-    server = "$DOCKERHUB_MIRROR"
-    [host."${DOCKERHUB_MIRROR#'https://'}"]
-    capabilities = ["pull", "resolve"]
-  EOF
+    if [[ -n "$DOCKERHUB_MIRROR" ]]
+    then
+      # Wait for microk8s to populate iptables
+      # https://chat.canonical.com/canonical/pl/jo5cg6wqjjrudqd5ybj6hhttee
+      until [[ -n $(iptables --list | grep -i "microk8s") ]]
+      do
+        echo "MicroK8s has not yet configured iptables."
+        sleep 10
+      done
+      tee /var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml << EOF
+      server = "$DOCKERHUB_MIRROR"
+      [host."${DOCKERHUB_MIRROR#'https://'}"]
+      capabilities = ["pull", "resolve"]
+    EOF
+    fi
+
     microk8s stop
     microk8s start
     microk8s enable dns
@@ -157,7 +157,6 @@ prepare: |
     microk8s enable metallb:10.64.140.43-10.64.140.49
     mkdir -p ~/.kube
     microk8s config > ~/.kube/config
-
     
     echo "Waiting for all pods to be in 'Running' phase..."
     until kubectl get po -A --field-selector=status.phase!=Running 2>&1 | grep -q "No resources found"; do
@@ -165,6 +164,13 @@ prepare: |
       sleep 5
     done
     echo "Success: All pods are running!"
+  fi
+
+  # Install charmcraft & pipx (on lxd-vm backend)
+  concierge prepare --trace
+
+  if [[ $SPREAD_TASK == *"oauth"* ]]
+  then
     /snap/bin/juju add-k8s uk8s --client --controller $(/snap/bin/juju show-controller | yq "keys | .[0]")
   fi
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -168,13 +168,13 @@ prepare: |
 
   # Install charmcraft & pipx (on lxd-vm backend)
   concierge prepare --trace
+  pipx install tox poetry
 
   if [[ $SPREAD_TASK == *"oauth"* ]]
   then
     /snap/bin/juju add-k8s uk8s --client --controller $(/snap/bin/juju show-controller | yq "keys | .[0]")
   fi
 
-  pipx install tox poetry
 prepare-each: |
   cd "$SPREAD_PATH"
   if [[ $SPREAD_VARIANT == *"juju29"* ]]

--- a/spread.yaml
+++ b/spread.yaml
@@ -147,7 +147,7 @@ prepare: |
       server = "$DOCKERHUB_MIRROR"
       [host."${DOCKERHUB_MIRROR#'https://'}"]
       capabilities = ["pull", "resolve"]
-    EOF
+      EOF
     fi
 
     microk8s stop

--- a/spread.yaml
+++ b/spread.yaml
@@ -167,7 +167,7 @@ prepare: |
     echo "Success: All pods are running!"
   fi
 
-  /snap/bin/juju add-k8s uk8s $(/snap/bin/juju show-controller | yq "keys | .[0]")
+  /snap/bin/juju add-k8s uk8s --client --controller $(/snap/bin/juju show-controller | yq "keys | .[0]")
 
   pipx install tox poetry
 prepare-each: |

--- a/spread.yaml
+++ b/spread.yaml
@@ -126,6 +126,10 @@ prepare: |
   cd "$SPREAD_PATH"
   snap install --classic concierge
 
+
+  # Install charmcraft & pipx (on lxd-vm backend)
+  concierge prepare --trace
+
   if [[ -n "$DOCKERHUB_MIRROR" ]] && ([[ $SPREAD_TASK == *"oauth"* ]])
   then
     # Running on IS-hosted runner; configure microk8s to use Docker Hub mirror
@@ -164,9 +168,6 @@ prepare: |
   fi
 
   /snap/bin/juju add-k8s uk8s $(/snap/bin/juju show-controller | yq "keys | .[0]")
-
-  # Install charmcraft & pipx (on lxd-vm backend)
-  concierge prepare --trace
 
   pipx install tox poetry
 prepare-each: |

--- a/spread.yaml
+++ b/spread.yaml
@@ -163,7 +163,7 @@ prepare: |
     echo "Success: All pods are running!"
   fi
 
-  juju add-k8s uk8s $(juju show-controller | yq "keys | .[0]")
+  /snap/bin/juju add-k8s uk8s $(/snap/bin/juju show-controller | yq "keys | .[0]")
 
   # Install charmcraft & pipx (on lxd-vm backend)
   concierge prepare --trace

--- a/spread.yaml
+++ b/spread.yaml
@@ -165,9 +165,8 @@ prepare: |
       sleep 5
     done
     echo "Success: All pods are running!"
+    /snap/bin/juju add-k8s uk8s --client --controller $(/snap/bin/juju show-controller | yq "keys | .[0]")
   fi
-
-  /snap/bin/juju add-k8s uk8s --client --controller $(/snap/bin/juju show-controller | yq "keys | .[0]")
 
   pipx install tox poetry
 prepare-each: |

--- a/tests/integration/relations/conftest.py
+++ b/tests/integration/relations/conftest.py
@@ -3,16 +3,12 @@
 # See LICENSE file for licensing details.
 
 import asyncio
-import pathlib
-import subprocess
 from typing import Any, AsyncGenerator
 
 import pytest
-import yaml
 from juju.controller import Controller
 from juju.model import Model
 from pytest_operator.plugin import OpsTest
-from tenacity import Retrying, stop_after_delay, wait_fixed
 
 MICROK8S_CLOUD_NAME = "uk8s"
 
@@ -24,85 +20,7 @@ async def application_charm() -> str:
 
 
 @pytest.fixture(scope="module")
-async def microk8s_cloud(ops_test: OpsTest) -> AsyncGenerator[None, Any]:
-    """Install and configure MicroK8s as second cloud on the same juju controller.
-
-    Skips if it configured already. Automatically removes connection to the created
-    cloud and removes MicroK8s from system unless keep models parameter is used.
-    """
-    controller_name = next(
-        iter(yaml.safe_load(subprocess.check_output(["juju", "show-controller"])))
-    )
-
-    clouds = await ops_test._controller.clouds()
-    if f"cloud-{MICROK8S_CLOUD_NAME}" in clouds.clouds:
-        yield None
-        return
-
-    try:
-        subprocess.run(["sudo", "snap", "install", "--classic", "microk8s"], check=True)
-        subprocess.run(["sudo", "snap", "install", "--classic", "kubectl"], check=True)
-        subprocess.run(["sudo", "microk8s", "enable", "dns"], check=True)
-        subprocess.run(["sudo", "microk8s", "enable", "hostpath-storage"], check=True)
-        subprocess.run(
-            ["sudo", "microk8s", "enable", "metallb:10.64.140.43-10.64.140.49"],
-            check=True,
-        )
-
-        # Configure kubectl now
-        subprocess.run(["mkdir", "-p", str(pathlib.Path.home() / ".kube")], check=True)
-        kubeconfig = subprocess.check_output(["sudo", "microk8s", "config"])
-        with open(str(pathlib.Path.home() / ".kube" / "config"), "w") as f:
-            f.write(kubeconfig.decode())
-        for attempt in Retrying(stop=stop_after_delay(150), wait=wait_fixed(15)):
-            with attempt:
-                if (
-                    len(
-                        subprocess.check_output(
-                            "kubectl get po -A  --field-selector=status.phase!=Running",
-                            shell=True,
-                            stderr=subprocess.DEVNULL,
-                        ).decode()
-                    )
-                    != 0
-                ):  # We got sth different from "No resources found." in stderr
-                    raise Exception()
-
-        # Add microk8s to the kubeconfig
-        subprocess.run(
-            [
-                "juju",
-                "add-k8s",
-                MICROK8S_CLOUD_NAME,
-                "--client",
-                "--controller",
-                controller_name,
-            ],
-            check=True,
-        )
-    except subprocess.CalledProcessError as e:
-        pytest.exit(str(e))
-
-    yield None
-
-    if not ops_test.keep_model:
-        subprocess.run(
-            [
-                "juju",
-                "remove-cloud",
-                "--client",
-                "--controller",
-                controller_name,
-                MICROK8S_CLOUD_NAME,
-            ],
-            check=True,
-        )
-        subprocess.run(["sudo", "snap", "remove", "--purge", "microk8s"], check=True)
-        subprocess.run(["sudo", "snap", "remove", "--purge", "kubectl"], check=True)
-
-
-@pytest.fixture(scope="module")
-async def microk8s_model(ops_test: OpsTest, microk8s_cloud: None) -> AsyncGenerator[Model, Any]:
+async def microk8s_model(ops_test: OpsTest) -> AsyncGenerator[Model, Any]:
     """Create new Juju model on the connected MicroK8s cloud.
 
     Automatically destroys that model unless keep models parameter is used.


### PR DESCRIPTION
This pull request updates the setup and testing workflow for MicroK8s integration, focusing on streamlining configuration and removing redundant code. The main changes include adding support for a Docker Hub mirror, improving MicroK8s setup logic in the CI pipeline, and simplifying integration test fixtures by removing duplicate MicroK8s installation/configuration steps.

**CI/CD Pipeline Improvements**
* Added support for configuring a Docker Hub mirror via the `DOCKERHUB_MIRROR` environment variable in the `spread.yaml` backend configuration.
* Updated the `prepare` script in `spread.yaml` to conditionally install and configure MicroK8s with Docker Hub mirror settings when running OAuth-related tasks on IS-hosted runners. This includes waiting for MicroK8s to be fully initialized and ensuring all pods are running before proceeding.

**Integration Test Simplification**
* Removed the `microk8s_cloud` fixture from `tests/integration/relations/conftest.py`, which previously handled MicroK8s installation and configuration. The logic is now handled in the CI pipeline, reducing redundancy and simplifying test setup.
* Cleaned up unused imports in `tests/integration/relations/conftest.py` that were only required for the removed fixture.

**Documentation/Comment Updates**
* Clarified comments in `spread.yaml` regarding backend restoration logic, specifying that restoration is only needed for the LXD backend and not for CI.