### PR TITLE
Update terraform bases and channels

### DIFF
--- a/terraform/charm/large_deployment/variables.tf
+++ b/terraform/charm/large_deployment/variables.tf
@@ -14,7 +14,7 @@ variable "main" {
     model_uuid        = string
     config            = optional(map(string), {})
     channel           = optional(string, "2/stable")
-    base              = optional(string, "ubuntu@22.04")
+    base              = optional(string, "ubuntu@24.04")
     revision          = optional(string, null)
     units             = optional(number, 3)
     constraints       = optional(string, "arch=amd64")
@@ -32,7 +32,7 @@ variable "failover" {
     model_uuid        = string
     config            = optional(map(string), { "init_hold" : "true" })
     channel           = optional(string, "2/stable")
-    base              = optional(string, "ubuntu@22.04")
+    base              = optional(string, "ubuntu@24.04")
     revision          = optional(string, null)
     units             = optional(number, 3)
     constraints       = optional(string, "arch=amd64")
@@ -51,7 +51,7 @@ variable "apps" {
     model_uuid        = string
     config            = optional(map(string), { "init_hold" : "true" })
     channel           = optional(string, "2/stable")
-    base              = optional(string, "ubuntu@22.04")
+    base              = optional(string, "ubuntu@24.04")
     revision          = optional(string, null)
     units             = optional(number, 3)
     constraints       = optional(string, "arch=amd64")
@@ -67,9 +67,9 @@ variable "apps" {
 variable "self-signed-certificates" {
   description = "Configuration for the self-signed-certificates app"
   type = object({
-    channel     = optional(string, "latest/stable")
+    channel     = optional(string, "1/stable")
     revision    = optional(string, null)
-    base        = optional(string, "ubuntu@22.04")
+    base        = optional(string, "ubuntu@24.04")
     constraints = optional(string, "arch=amd64")
     machines    = optional(list(string), [])
     config      = optional(map(string), { "ca-common-name" : "CA" })

--- a/terraform/charm/simple_deployment/variables.tf
+++ b/terraform/charm/simple_deployment/variables.tf
@@ -16,7 +16,7 @@ variable "channel" {
 variable "base" {
   description = "Charm base (old name: series)"
   type        = string
-  default     = "ubuntu@22.04"
+  default     = "ubuntu@24.04"
 }
 
 variable "config" {
@@ -88,9 +88,9 @@ variable "expose" {
 variable "self-signed-certificates" {
   description = "Configuration for the self-signed-certificates app"
   type = object({
-    channel     = optional(string, "latest/stable")
+    channel     = optional(string, "1/stable")
     revision    = optional(string, null)
-    base        = optional(string, "ubuntu@22.04")
+    base        = optional(string, "ubuntu@24.04")
     constraints = optional(string, "arch=amd64")
     machines    = optional(list(string), [])
     config      = optional(map(string), { "ca-common-name" : "CA" })

--- a/terraform/product/large_deployment/variables.tf
+++ b/terraform/product/large_deployment/variables.tf
@@ -14,7 +14,7 @@ variable "main" {
     model_uuid        = string
     config            = optional(map(string), {})
     channel           = optional(string, "2/stable")
-    base              = optional(string, "ubuntu@22.04")
+    base              = optional(string, "ubuntu@24.04")
     revision          = optional(string, null)
     units             = optional(number, 3)
     constraints       = optional(string, "arch=amd64")
@@ -32,7 +32,7 @@ variable "failover" {
     model_uuid        = string
     config            = optional(map(string), { "init_hold" : "true" })
     channel           = optional(string, "2/stable")
-    base              = optional(string, "ubuntu@22.04")
+    base              = optional(string, "ubuntu@24.04")
     revision          = optional(string, null)
     units             = optional(number, 3)
     constraints       = optional(string, "arch=amd64")
@@ -51,7 +51,7 @@ variable "apps" {
     model_uuid        = string
     config            = optional(map(string), { "init_hold" : "true" })
     channel           = optional(string, "2/stable")
-    base              = optional(string, "ubuntu@22.04")
+    base              = optional(string, "ubuntu@24.04")
     revision          = optional(string, null)
     units             = optional(number, 3)
     constraints       = optional(string, "arch=amd64")
@@ -84,9 +84,9 @@ variable "opensearch-dashboards" {
 variable "self-signed-certificates" {
   description = "Configuration for the self-signed-certificates app"
   type = object({
-    channel     = optional(string, "latest/stable")
+    channel     = optional(string, "1/stable")
     revision    = optional(string, null)
-    base        = optional(string, "ubuntu@22.04")
+    base        = optional(string, "ubuntu@24.04")
     constraints = optional(string, "arch=amd64")
     machines    = optional(list(string), [])
     config      = optional(map(string), { "ca-common-name" : "CA" })

--- a/terraform/product/simple_deployment/variables.tf
+++ b/terraform/product/simple_deployment/variables.tf
@@ -7,8 +7,8 @@ variable "opensearch" {
     app_name          = optional(string, "opensearch")
     model_uuid        = string
     config            = optional(map(string), { "cluster_name" : "opensearch" })
-    channel           = optional(string, "2/stable")
-    base              = optional(string, "ubuntu@22.04")
+    channel           = optional(string, "2/edge")
+    base              = optional(string, "ubuntu@24.04")
     revision          = optional(string, null)
     units             = optional(number, 3)
     constraints       = optional(string, "arch=amd64")
@@ -24,8 +24,8 @@ variable "opensearch-dashboards" {
   type = object({
     app_name          = optional(string, "opensearch-dashboards")
     config            = optional(map(string), {})
-    channel           = optional(string, "2/stable")
-    base              = optional(string, "ubuntu@22.04")
+    channel           = optional(string, "2/edge")
+    base              = optional(string, "ubuntu@24.04")
     revision          = optional(string, null)
     units             = optional(number, 1)
     constraints       = optional(string, "arch=amd64")
@@ -40,9 +40,9 @@ variable "opensearch-dashboards" {
 variable "self-signed-certificates" {
   description = "Configuration for the self-signed-certificates app"
   type = object({
-    channel     = optional(string, "latest/stable")
+    channel     = optional(string, "1/stable")
     revision    = optional(string, null)
-    base        = optional(string, "ubuntu@22.04")
+    base        = optional(string, "ubuntu@24.04")
     constraints = optional(string, "arch=amd64")
     machines    = optional(list(string), [])
     config      = optional(map(string), { "ca-common-name" : "CA" })
@@ -60,7 +60,7 @@ variable "grafana-agent" {
   type = object({
     channel     = optional(string, "1/stable")
     revision    = optional(string, null)
-    base        = optional(string, "ubuntu@22.04")
+    base        = optional(string, "ubuntu@24.04")
     constraints = optional(string, "arch=amd64")
     config      = optional(map(string), {})
   })


### PR DESCRIPTION
Based on @akram09 investigation!

This pull request updates the default operating system base for several Terraform charm deployment variables from `ubuntu@22.04` to `ubuntu@24.04`, ensuring compatibility with the latest Ubuntu LTS release. Additionally, it standardizes the default channel for the `self-signed-certificates` app to `1/stable` across all deployment configurations.

**Base OS version updates:**

* Changed the default `base` from `ubuntu@22.04` to `ubuntu@24.04` in all major deployment variable blocks in `terraform/charm/large_deployment/variables.tf`, including `main`, `failover`, `apps`, and `self-signed-certificates`. [[1]](diffhunk://#diff-b771e7563d07e2c3742c9ba9a55b3e715db80e184e31efaf665a5dce7eafb548L17-R17) [[2]](diffhunk://#diff-b771e7563d07e2c3742c9ba9a55b3e715db80e184e31efaf665a5dce7eafb548L35-R35) [[3]](diffhunk://#diff-b771e7563d07e2c3742c9ba9a55b3e715db80e184e31efaf665a5dce7eafb548L54-R54) [[4]](diffhunk://#diff-b771e7563d07e2c3742c9ba9a55b3e715db80e184e31efaf665a5dce7eafb548L70-R72)
* Updated the default `base` from `ubuntu@22.04` to `ubuntu@24.04` in `terraform/charm/simple_deployment/variables.tf` for both the general deployment and `self-signed-certificates` app. [[1]](diffhunk://#diff-7130630b9e9524b6f9390adca3d556f2af669f9ddde314200ef9d3f3ff62cf81L19-R19) [[2]](diffhunk://#diff-7130630b9e9524b6f9390adca3d556f2af669f9ddde314200ef9d3f3ff62cf81L91-R93)
* Applied the same base version update to `main`, `failover`, `apps`, and `self-signed-certificates` in `terraform/product/large_deployment/variables.tf`. [[1]](diffhunk://#diff-ff7cd07c89cb2832f76d79b3eba292cf895409fe805579f1dbd5dfdb1c100463L17-R17) [[2]](diffhunk://#diff-ff7cd07c89cb2832f76d79b3eba292cf895409fe805579f1dbd5dfdb1c100463L35-R35) [[3]](diffhunk://#diff-ff7cd07c89cb2832f76d79b3eba292cf895409fe805579f1dbd5dfdb1c100463L54-R54) [[4]](diffhunk://#diff-ff7cd07c89cb2832f76d79b3eba292cf895409fe805579f1dbd5dfdb1c100463L87-R89)

**Channel standardization:**

* Changed the default channel for the `self-signed-certificates` app from `latest/stable` to `1/stable` in all affected variable blocks. [[1]](diffhunk://#diff-b771e7563d07e2c3742c9ba9a55b3e715db80e184e31efaf665a5dce7eafb548L70-R72) [[2]](diffhunk://#diff-7130630b9e9524b6f9390adca3d556f2af669f9ddde314200ef9d3f3ff62cf81L91-R93) [[3]](diffhunk://#diff-ff7cd07c89cb2832f76d79b3eba292cf895409fe805579f1dbd5dfdb1c100463L87-R89)

These updates help keep the deployment configurations current and consistent with the latest supported platform and application channel standards.