### PR TITLE
docs: Replace Discourse docs with a charm description on Charmhub

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -6,7 +6,7 @@ display-name: OpenSearch
 
 description: |
   Machine charm for OpenSearch
-docs: https://discourse.charmhub.io/t/charmed-opensearch-documentation/9729
+docs: https://discourse.charmhub.io/t/charmed-opensearch-documentation/19417
 summary: |
   Machine charm for OpenSearch
 


### PR DESCRIPTION
## Description of issue or feature:

The [Charmhub page](https://charmhub.io/opensearch) has a full set of Discourse-based documentation published on it.

## Solution:

We are replacing the outdated Discourse-based documentation on Charmhub with a single-page description of the charm.

## How was this change tested?
- [x] Manually
- [ ] Unit tests
- [ ] Integration tests

Tests are not needed. A single line on change, and it's a link to a Discourse post.

## Checklist

- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
