### PR TITLE
fix: Clear missing relations

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -398,15 +398,21 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
             if self._has_secret_and_no_relation(info["key"], info["relation_name"])
         ]
         if missing_relations:
+            missing_str = ", ".join(missing_relations)
+
             self.charm.status.set(
-                BlockedStatus(
-                    PClusterMissingStorageRelations.format(", ".join(missing_relations))
-                ),
+                BlockedStatus(PClusterMissingStorageRelations.format(missing_str)),
                 app=True,
             )
+            self.charm.state.app.relation_data.put(Scope.APP, "missing_relations", missing_str)
             return
+
+        # No missing relations, clean up any previous state
+        self.charm.state.app.relation_data.delete(Scope.APP, "missing_relations")
         self.charm.status.clear(
-            PClusterMissingStorageRelations, pattern=Status.CheckPattern.Interpolated, app=True
+            PClusterMissingStorageRelations,
+            pattern=Status.CheckPattern.Interpolated,
+            app=True,
         )
 
     def _has_secret_and_no_relation(self, key: str, relation_name: str) -> bool:

--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -398,7 +398,7 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
             if self._has_secret_and_no_relation(info["key"], info["relation_name"])
         ]
         if missing_relations:
-            missing_str = ", ".join(missing_relations)
+            missing_str = ", ".join(sorted(missing_relations))
 
             self.charm.status.set(
                 BlockedStatus(PClusterMissingStorageRelations.format(missing_str)),

--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -398,16 +398,15 @@ class OpenSearchPeerClusterProvider(OpenSearchPeerClusterRelation):
             if self._has_secret_and_no_relation(info["key"], info["relation_name"])
         ]
         if missing_relations:
-            details = ", ".join(sorted(missing_relations))
-            extra = f" Missing relations for: {details}"
-            extra = extra[:120]
-            full_msg = f"{PClusterMissingStorageRelations}{extra}"
-            logger.warning(full_msg)
-            self.charm.status.set(BlockedStatus(full_msg), app=True)
+            self.charm.status.set(
+                BlockedStatus(
+                    PClusterMissingStorageRelations.format(", ".join(missing_relations))
+                ),
+                app=True,
+            )
             return
-
         self.charm.status.clear(
-            PClusterMissingStorageRelations, pattern=Status.CheckPattern.Start, app=True
+            PClusterMissingStorageRelations, pattern=Status.CheckPattern.Interpolated, app=True
         )
 
     def _has_secret_and_no_relation(self, key: str, relation_name: str) -> bool:

--- a/lib/charms/opensearch/v0/opensearch_snapshots.py
+++ b/lib/charms/opensearch/v0/opensearch_snapshots.py
@@ -608,7 +608,12 @@ class OpenSearchSnapshotEvents(Object):
             event.defer()
             return
 
-        if self.charm.state.app.orchestrators and self.charm.state.app.orchestrators.main_rel_id:
+        if (
+            self.charm.state.app.orchestrators
+            and self.charm.state.app.orchestrators.main_app
+            and self.charm.state.app.orchestrators.main_app.name == event.relation.app.name
+            and len(event.relation.units) > 0
+        ):
             logger.debug(
                 "Main orchestrator still accessible; do not cleanup as it can be scale down"
             )

--- a/lib/charms/opensearch/v0/opensearch_snapshots.py
+++ b/lib/charms/opensearch/v0/opensearch_snapshots.py
@@ -69,6 +69,8 @@ from ops import (
 from pydantic import ValidationError
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
 
+from lib.charms.opensearch.v0.opensearch_internal_data import Scope
+
 # The unique Charmhub library identifier, never change it
 LIBID = "89db18e639c64a6ea223c63172c04dc6."
 
@@ -179,11 +181,35 @@ class OpenSearchSnapshotEvents(Object):
 
         if self.charm.unit.is_leader():
             self.charm.status.clear(BackupRelConflict, app=True)
-            self.charm.status.clear(
-                PClusterMissingStorageRelations.format(", ".join(["s3-integrator"])),
-                pattern=Status.CheckPattern.Equal,
+
+            raw = self.charm.state.app.relation_data.get(Scope.APP, "missing_relations")
+            if not raw:
+                return
+
+            missing_relations = [r.strip() for r in raw.split(",") if r.strip()]
+
+            if "s3-integrator" not in missing_relations:
+                return
+
+            missing_relations.remove("s3-integrator")
+
+            if not missing_relations:
+                # no missing relations left: clear status
+                self.charm.state.app.relation_data.delete(Scope.APP, "missing_relations")
+                self.charm.status.clear(
+                    PClusterMissingStorageRelations,
+                    pattern=Status.CheckPattern.Interpolated,
+                    app=True,
+                )
+                return
+
+            # Still have others missing: update status and stored string
+            missing_str = ", ".join(missing_relations)
+            self.charm.status.set(
+                BlockedStatus(PClusterMissingStorageRelations.format(missing_str)),
                 app=True,
             )
+            self.charm.state.app.relation_data.put(Scope.APP, "missing_relations", missing_str)
 
         object_storage_config = self.charm.snapshots_manager.get_storage_config(
             ObjectStorageType.S3
@@ -334,11 +360,35 @@ class OpenSearchSnapshotEvents(Object):
 
         if self.charm.unit.is_leader():
             self.charm.status.clear(BackupRelConflict, app=True)
-            self.charm.status.clear(
-                PClusterMissingStorageRelations.format(", ".join(["azure-storage-integrator"])),
-                pattern=Status.CheckPattern.Equal,
+
+            raw = self.charm.state.app.relation_data.get(Scope.APP, "missing_relations")
+            if not raw:
+                return
+
+            missing_relations = [r.strip() for r in raw.split(",") if r.strip()]
+
+            if "azure-storage-integrator" not in missing_relations:
+                return
+
+            missing_relations.remove("azure-storage-integrator")
+
+            if not missing_relations:
+                # no missing relations left: clear status
+                self.charm.state.app.relation_data.delete(Scope.APP, "missing_relations")
+                self.charm.status.clear(
+                    PClusterMissingStorageRelations,
+                    pattern=Status.CheckPattern.Interpolated,
+                    app=True,
+                )
+                return
+
+            # still have others missing: update status and stored string
+            missing_str = ", ".join(missing_relations)
+            self.charm.status.set(
+                BlockedStatus(PClusterMissingStorageRelations.format(missing_str)),
                 app=True,
             )
+            self.charm.state.app.relation_data.put(Scope.APP, "missing_relations", missing_str)
 
         object_storage_config = self.charm.snapshots_manager.get_storage_config(
             ObjectStorageType.AZURE

--- a/lib/charms/opensearch/v0/opensearch_snapshots.py
+++ b/lib/charms/opensearch/v0/opensearch_snapshots.py
@@ -355,7 +355,7 @@ class OpenSearchSnapshotEvents(Object):
 
             if raw := self.charm.state.app.relation_data.get(Scope.APP, "missing_relations"):
                 missing_relations = [r.strip() for r in raw.split(",") if r.strip()]
-                if "azure-store-integrator" in missing_relations:
+                if "azure-storage-integrator" in missing_relations:
                     missing_relations.remove("azure-storage-integrator")
                     # still have others missing: update status and stored string
                     if missing_relations:

--- a/lib/charms/opensearch/v0/opensearch_snapshots.py
+++ b/lib/charms/opensearch/v0/opensearch_snapshots.py
@@ -59,6 +59,7 @@ from charms.opensearch.v0.opensearch_exceptions import (
     OpenSearchHttpError,
 )
 from charms.opensearch.v0.opensearch_health import HealthColors
+from charms.opensearch.v0.opensearch_internal_data import Scope
 from charms.opensearch.v0.opensearch_locking import OpenSearchNodeLock
 from ops import (
     ActionEvent,
@@ -68,8 +69,6 @@ from ops import (
 )
 from pydantic import ValidationError
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
-
-from lib.charms.opensearch.v0.opensearch_internal_data import Scope
 
 # The unique Charmhub library identifier, never change it
 LIBID = "89db18e639c64a6ea223c63172c04dc6."

--- a/lib/charms/opensearch/v0/opensearch_snapshots.py
+++ b/lib/charms/opensearch/v0/opensearch_snapshots.py
@@ -181,34 +181,27 @@ class OpenSearchSnapshotEvents(Object):
         if self.charm.unit.is_leader():
             self.charm.status.clear(BackupRelConflict, app=True)
 
-            raw = self.charm.state.app.relation_data.get(Scope.APP, "missing_relations")
-            if not raw:
-                return
-
-            missing_relations = [r.strip() for r in raw.split(",") if r.strip()]
-
-            if "s3-integrator" not in missing_relations:
-                return
-
-            missing_relations.remove("s3-integrator")
-
-            if not missing_relations:
-                # no missing relations left: clear status
-                self.charm.state.app.relation_data.delete(Scope.APP, "missing_relations")
-                self.charm.status.clear(
-                    PClusterMissingStorageRelations,
-                    pattern=Status.CheckPattern.Interpolated,
-                    app=True,
-                )
-                return
-
-            # Still have others missing: update status and stored string
-            missing_str = ", ".join(missing_relations)
-            self.charm.status.set(
-                BlockedStatus(PClusterMissingStorageRelations.format(missing_str)),
-                app=True,
-            )
-            self.charm.state.app.relation_data.put(Scope.APP, "missing_relations", missing_str)
+            if raw := self.charm.state.app.relation_data.get(Scope.APP, "missing_relations"):
+                missing_relations = [r.strip() for r in raw.split(",") if r.strip()]
+                if "s3-integrator" in missing_relations:
+                    missing_relations.remove("s3-integrator")
+                    # still have others missing: update status and stored string
+                    if missing_relations:
+                        missing_str = ", ".join(sorted(missing_relations))
+                        self.charm.status.set(
+                            BlockedStatus(PClusterMissingStorageRelations.format(missing_str)),
+                            app=True,
+                        )
+                        self.charm.state.app.relation_data.put(
+                            Scope.APP, "missing_relations", missing_str
+                        )
+                    else:
+                        self.charm.state.app.relation_data.delete(Scope.APP, "missing_relations")
+                        self.charm.status.clear(
+                            PClusterMissingStorageRelations,
+                            pattern=Status.CheckPattern.Interpolated,
+                            app=True,
+                        )
 
         object_storage_config = self.charm.snapshots_manager.get_storage_config(
             ObjectStorageType.S3
@@ -360,34 +353,27 @@ class OpenSearchSnapshotEvents(Object):
         if self.charm.unit.is_leader():
             self.charm.status.clear(BackupRelConflict, app=True)
 
-            raw = self.charm.state.app.relation_data.get(Scope.APP, "missing_relations")
-            if not raw:
-                return
-
-            missing_relations = [r.strip() for r in raw.split(",") if r.strip()]
-
-            if "azure-storage-integrator" not in missing_relations:
-                return
-
-            missing_relations.remove("azure-storage-integrator")
-
-            if not missing_relations:
-                # no missing relations left: clear status
-                self.charm.state.app.relation_data.delete(Scope.APP, "missing_relations")
-                self.charm.status.clear(
-                    PClusterMissingStorageRelations,
-                    pattern=Status.CheckPattern.Interpolated,
-                    app=True,
-                )
-                return
-
-            # still have others missing: update status and stored string
-            missing_str = ", ".join(missing_relations)
-            self.charm.status.set(
-                BlockedStatus(PClusterMissingStorageRelations.format(missing_str)),
-                app=True,
-            )
-            self.charm.state.app.relation_data.put(Scope.APP, "missing_relations", missing_str)
+            if raw := self.charm.state.app.relation_data.get(Scope.APP, "missing_relations"):
+                missing_relations = [r.strip() for r in raw.split(",") if r.strip()]
+                if "azure-store-integrator" in missing_relations:
+                    missing_relations.remove("azure-storage-integrator")
+                    # still have others missing: update status and stored string
+                    if missing_relations:
+                        missing_str = ", ".join(sorted(missing_relations))
+                        self.charm.status.set(
+                            BlockedStatus(PClusterMissingStorageRelations.format(missing_str)),
+                            app=True,
+                        )
+                        self.charm.state.app.relation_data.put(
+                            Scope.APP, "missing_relations", missing_str
+                        )
+                    else:
+                        self.charm.state.app.relation_data.delete(Scope.APP, "missing_relations")
+                        self.charm.status.clear(
+                            PClusterMissingStorageRelations,
+                            pattern=Status.CheckPattern.Interpolated,
+                            app=True,
+                        )
 
         object_storage_config = self.charm.snapshots_manager.get_storage_config(
             ObjectStorageType.AZURE

--- a/lib/charms/opensearch/v0/opensearch_snapshots.py
+++ b/lib/charms/opensearch/v0/opensearch_snapshots.py
@@ -31,10 +31,12 @@ from charms.opensearch.v0.constants_charm import (
     BackupRelConflict,
     BackupRelDataIncomplete,
     BackupRelShouldNotExist,
+    PClusterMissingStorageRelations,
     PeerClusterOrchestratorRelationName,
     PeerClusterRelationName,
     RestoreInProgress,
 )
+from charms.opensearch.v0.helper_charm import Status
 from charms.opensearch.v0.helper_cluster import ClusterState
 from charms.opensearch.v0.helper_security import (
     list_cas,
@@ -66,9 +68,6 @@ from ops import (
 )
 from pydantic import ValidationError
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
-
-from lib.charms.opensearch.v0.constants_charm import PClusterMissingStorageRelations
-from lib.charms.opensearch.v0.helper_charm import Status
 
 # The unique Charmhub library identifier, never change it
 LIBID = "89db18e639c64a6ea223c63172c04dc6."

--- a/lib/charms/opensearch/v0/opensearch_snapshots.py
+++ b/lib/charms/opensearch/v0/opensearch_snapshots.py
@@ -180,7 +180,7 @@ class OpenSearchSnapshotEvents(Object):
         if self.charm.unit.is_leader():
             self.charm.status.clear(BackupRelConflict, app=True)
             self.charm.status.clear(
-                PClusterMissingStorageRelations.format(", ".join("s3-integrator")),
+                PClusterMissingStorageRelations.format(", ".join(["s3-integrator"])),
                 pattern=Status.CheckPattern.Equal,
                 app=True,
             )
@@ -335,7 +335,7 @@ class OpenSearchSnapshotEvents(Object):
         if self.charm.unit.is_leader():
             self.charm.status.clear(BackupRelConflict, app=True)
             self.charm.status.clear(
-                PClusterMissingStorageRelations.format(", ".join("azure-storage-integrator")),
+                PClusterMissingStorageRelations.format(", ".join(["azure-storage-integrator"])),
                 pattern=Status.CheckPattern.Equal,
                 app=True,
             )

--- a/lib/charms/opensearch/v0/opensearch_snapshots.py
+++ b/lib/charms/opensearch/v0/opensearch_snapshots.py
@@ -67,6 +67,9 @@ from ops import (
 from pydantic import ValidationError
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_fixed
 
+from lib.charms.opensearch.v0.constants_charm import PClusterMissingStorageRelations
+from lib.charms.opensearch.v0.helper_charm import Status
+
 # The unique Charmhub library identifier, never change it
 LIBID = "89db18e639c64a6ea223c63172c04dc6."
 
@@ -177,6 +180,11 @@ class OpenSearchSnapshotEvents(Object):
 
         if self.charm.unit.is_leader():
             self.charm.status.clear(BackupRelConflict, app=True)
+            self.charm.status.clear(
+                PClusterMissingStorageRelations.format(", ".join("s3-integrator")),
+                pattern=Status.CheckPattern.Equal,
+                app=True,
+            )
 
         object_storage_config = self.charm.snapshots_manager.get_storage_config(
             ObjectStorageType.S3
@@ -327,6 +335,11 @@ class OpenSearchSnapshotEvents(Object):
 
         if self.charm.unit.is_leader():
             self.charm.status.clear(BackupRelConflict, app=True)
+            self.charm.status.clear(
+                PClusterMissingStorageRelations.format(", ".join("azure-storage-integrator")),
+                pattern=Status.CheckPattern.Equal,
+                app=True,
+            )
 
         object_storage_config = self.charm.snapshots_manager.get_storage_config(
             ObjectStorageType.AZURE


### PR DESCRIPTION
## Description of issues:

1. When the failover orchestrator is promoted to main and if the previous main has a relation with object storage integrations, app status is stuck with the the `Missing storage relation: < storage integrator name>.
2. Although there is no S3 relation, no secret, it sometimes finds a secret label such as <Secret label='data49:app:s3-creds'> using cached_secret_meta. Then, it tries to remove this non-existing secret and raises SecretNotFound exception.


# Solutions

1. This PR clears the Blocked status of the app because of misssing S3 or Azure relation, when s3 or azure relation is joined. 
2. The SecretNotFound exception is handled in the def on _remove_juju_secret method.

## How was this change tested?
- [x] Manually
- [ ] Unit tests
- [ ] Integration tests


## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
