### PR TITLE
Fixing Terraform Flaky Tests due to Limited storage on github runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,6 +70,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: (Github hosted) Mount /mnt to have more storage 
+        run: |
+          sudo mkdir -p /mnt/lxd/storage-pools
+          sudo mkdir -p /var/snap/lxd/common/lxd/storage-pools
+          sudo mount --bind /mnt/lxd/storage-pools /var/snap/lxd/common/lxd/storage-pools
+
       - name: (GitHub hosted) Free up disk space
         run: |
           printf '\nDisk usage before cleanup\n'
@@ -78,9 +84,6 @@ jobs:
           rm -r /opt/hostedtoolcache/
           printf '\nDisk usage after cleanup\n'
           df --human-readable
-
-      - name: (self hosted) Disk usage
-        run: df --human-readable
 
       - name: Install terraform snap
         run: |


### PR DESCRIPTION
This Pull Request adds a fix for flaky Terraform tests caused by limited storage availability on GitHub runners. The solution is to mount /dev/sdb and use it as the LXD storage pool. This approach was previously used in the [data-integrator](https://github.com/canonical/data-integrator/blob/9cd98d71a90e55696201003acce0cbc7b0c09de5/.github/workflows/integration_test_charm.yaml#L215C7-L220C90) charm to resolve a similar issue.