### PR TITLE
Fix CA rotation edge case on small deployments

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -1061,6 +1061,7 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
                         logger.info("on_tls_conf_set: Detected CA rotation complete in cluster")
                         self.tls.on_ca_certs_rotation_complete()
             else:
+                logger.debug("TLS not fully configured yet, deferring event.")
                 event.defer()
                 return
 

--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -773,7 +773,11 @@ class OpenSearchTLS(Object):
             return
 
         # if this flag is set, the CA rotation routine is complete for this unit
-        if self.charm.peers_data.get(Scope.UNIT, "tls_ca_renewed", False):
+        if (
+            self.charm.peers_data.get(Scope.UNIT, "tls_ca_renewed", False)
+            and self.ca_and_certs_rotation_complete_in_cluster()
+        ):
+            # both CA rotation and certs rotation completed in the cluster
             self.charm.peers_data.delete(Scope.UNIT, "tls_ca_renewing")
             self.charm.peers_data.delete(Scope.UNIT, "tls_ca_renewed")
             self.update_tls_flag_to_peer_cluster_relation(
@@ -782,15 +786,17 @@ class OpenSearchTLS(Object):
             self.update_tls_flag_to_peer_cluster_relation(
                 flag="tls_ca_renewed", operation="remove"
             )
-        else:
-            # this means only the CA rotation completed, still need to create certificates
-            self.charm.peers_data.put(Scope.UNIT, "tls_ca_renewed", True)
-            self.update_tls_flag_to_peer_cluster_relation(flag="tls_ca_renewed", operation="add")
+            return
+
+        # this means only the CA rotation completed, still need to create certificates
+        self.charm.peers_data.put(Scope.UNIT, "tls_ca_renewed", True)
+        self.update_tls_flag_to_peer_cluster_relation(flag="tls_ca_renewed", operation="add")
 
     def ca_rotation_complete_in_cluster(self) -> bool:
         """Check whether the CA rotation completed in all units."""
         rotation_happening = False
         rotation_complete = True
+
         # check current unit
         logger.debug(
             "current unit tls_ca_renewing:%s | tls_ca_renewed:%s",
@@ -799,11 +805,11 @@ class OpenSearchTLS(Object):
         )
         if self.charm.peers_data.get(Scope.UNIT, "tls_ca_renewing", False):
             rotation_happening = True
-            if not self.charm.peers_data.get(Scope.UNIT, "tls_ca_renewed", False):
-                logger.debug(
-                    f"TLS CA rotation ongoing in unit: {self.charm.unit.name}, will not update tls certificates."
-                )
-                rotation_complete = False
+        if not self.charm.peers_data.get(Scope.UNIT, "tls_ca_renewed", False):
+            logger.debug(
+                f"TLS CA rotation ongoing in unit: {self.charm.unit.name}, will not update tls certificates."
+            )
+            rotation_complete = False
 
         for relation_type in [
             PeerRelationName,
@@ -820,11 +826,11 @@ class OpenSearchTLS(Object):
                     if relation.data[unit].get("tls_ca_renewing"):
                         rotation_happening = True
 
-                        if not relation.data[unit].get("tls_ca_renewed"):
-                            logger.debug(
-                                f"TLS CA rotation ongoing in unit {unit}, will not update tls certificates."
-                            )
-                            rotation_complete = False
+                    if not relation.data[unit].get("tls_ca_renewed"):
+                        logger.debug(
+                            f"TLS CA rotation ongoing in unit {unit}, will not update tls certificates."
+                        )
+                        rotation_complete = False
         logger.debug(
             "CA rotation happening in cluster: %s | \
                 rotation complete in cluster: %s | return value: %s \

--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -847,15 +847,12 @@ class OpenSearchTLS(Object):
         rotation_complete = True
 
         # the current unit is not in the relation.units list
-        if (
-            self.charm.peers_data.get(Scope.UNIT, "tls_ca_renewing")
-            or self.charm.peers_data.get(
-                Scope.UNIT,
-                "tls_ca_renewed",
-            )
-            or self.charm.peers_data.get(Scope.UNIT, "tls_configured") is not True
+        # if tls is not configured or in the middle of rotation, return False
+        if not self.charm.peers_data.get(Scope.UNIT, "tls_configured", False) or (
+            self.charm.peers_data.get(Scope.UNIT, "tls_ca_renewing", False)
+            and not self.charm.peers_data.get(Scope.UNIT, "tls_ca_renewed", False)
         ):
-            logger.debug("TLS CA rotation ongoing on this unit.")
+            logger.debug("TLS CA and/or Cert rotation ongoing on this unit.")
             return False
 
         for relation_type in [
@@ -866,13 +863,13 @@ class OpenSearchTLS(Object):
             for relation in self.model.relations[relation_type]:
                 logger.debug(f"Checking relation {relation}: units: {relation.units}")
                 for unit in relation.units:
-                    if (
-                        "tls_ca_renewing" in relation.data[unit]
-                        or "tls_ca_renewed" in relation.data[unit]
-                        or relation.data[unit].get("tls_configured") != "True"
+
+                    if relation.data[unit].get("tls_configured") != "True" or (
+                        relation.data[unit].get("tls_ca_renewing", False)
+                        and not relation.data[unit].get("tls_ca_renewed", False)
                     ):
                         logger.debug(
-                            f"TLS CA rotation not complete for unit {unit}: {relation} \
+                            f"TLS CA and or Cert rotation not complete for unit {unit}: {relation} \
                                 | tls_ca_renewing: {relation.data[unit].get('tls_ca_renewing')} \
                                 | tls_ca_renewed: {relation.data[unit].get('tls_ca_renewed')} \
                                 | tls_configured: {relation.data[unit].get('tls_configured')}"

--- a/lib/charms/opensearch/v0/opensearch_tls.py
+++ b/lib/charms/opensearch/v0/opensearch_tls.py
@@ -626,7 +626,7 @@ class OpenSearchTLS(Object):
         if not secrets.get("key"):
             logging.error("TLS key not found, quitting.")
             return
-
+        logger.debug(f"Storing {cert_type.val} TLS resources on disk.")
         store_key_pair(
             name=cert_type.val,
             store_pwd=secrets.get("keystore-password"),
@@ -792,13 +792,18 @@ class OpenSearchTLS(Object):
         rotation_happening = False
         rotation_complete = True
         # check current unit
+        logger.debug(
+            "current unit tls_ca_renewing:%s | tls_ca_renewed:%s",
+            self.charm.peers_data.get(Scope.UNIT, "tls_ca_renewing", False),
+            self.charm.peers_data.get(Scope.UNIT, "tls_ca_renewed", False),
+        )
         if self.charm.peers_data.get(Scope.UNIT, "tls_ca_renewing", False):
             rotation_happening = True
-        if not self.charm.peers_data.get(Scope.UNIT, "tls_ca_renewed", False):
-            logger.debug(
-                f"TLS CA rotation ongoing in unit: {self.charm.unit.name}, will not update tls certificates."
-            )
-            rotation_complete = False
+            if not self.charm.peers_data.get(Scope.UNIT, "tls_ca_renewed", False):
+                logger.debug(
+                    f"TLS CA rotation ongoing in unit: {self.charm.unit.name}, will not update tls certificates."
+                )
+                rotation_complete = False
 
         for relation_type in [
             PeerRelationName,
@@ -807,6 +812,11 @@ class OpenSearchTLS(Object):
         ]:
             for relation in self.model.relations[relation_type]:
                 for unit in relation.units:
+                    logger.debug(
+                        f"Checking unit {unit} in relation {relation}: \
+                            tls_ca_renewing: {relation.data[unit].get('tls_ca_renewing')} \
+                            | tls_ca_renewed: {relation.data[unit].get('tls_ca_renewed')}"
+                    )
                     if relation.data[unit].get("tls_ca_renewing"):
                         rotation_happening = True
 
@@ -815,7 +825,14 @@ class OpenSearchTLS(Object):
                                 f"TLS CA rotation ongoing in unit {unit}, will not update tls certificates."
                             )
                             rotation_complete = False
-
+        logger.debug(
+            "CA rotation happening in cluster: %s | \
+                rotation complete in cluster: %s | return value: %s \
+                ",
+            rotation_happening,
+            rotation_complete,
+            not rotation_happening or rotation_complete,
+        )
         # if no unit is renewing the CA, or all of them renewed it, the rotation is complete
         return not rotation_happening or rotation_complete
 

--- a/tests/integration/tls/test_ca_rotation.py
+++ b/tests/integration/tls/test_ca_rotation.py
@@ -81,6 +81,7 @@ async def test_build_and_deploy_active(ops_test: OpsTest, charm, series) -> None
         units_statuses=["active"],
         timeout=1800,
         wait_for_exact_units=len(UNIT_IDS),
+        idle_period=IDLE_PERIOD,
     )
 
 


### PR DESCRIPTION
## Description of issue or feature:
<!--- Please describe in detail what this PR is about. And a reference link to a Github issue or Jira ticket.  -->
Shards are still initializing when we run the CA rotation on the small deployment. It was a side effect. The real problem was the one of the units updating its certificate before all the untis save the new CA into the keystore.

## Solution:
The main changes focus on ensuring CA and certificate rotations are only marked complete when all units are fully configured, and provide more granular debug logging to aid in troubleshooting and cluster state visibility.

**TLS Rotation Logic Improvements**
* The `reset_ca_rotation_state` method now only clears CA rotation flags when both CA and certificate rotations have completed across the cluster, preventing premature state updates. [[1]](diffhunk://#diff-fcbdb57c37f5d32b5ecf046327cfa9ee91a33f156714ea7fb6f000a48d2c4ca4L776-R780) [[2]](diffhunk://#diff-fcbdb57c37f5d32b5ecf046327cfa9ee91a33f156714ea7fb6f000a48d2c4ca4L785-R790)
* The `ca_and_certs_rotation_complete_in_cluster` method refines its checks to ensure TLS is fully configured and no rotations are in progress before reporting completion, improving cluster-wide consistency. [[1]](diffhunk://#diff-fcbdb57c37f5d32b5ecf046327cfa9ee91a33f156714ea7fb6f000a48d2c4ca4L827-R855) [[2]](diffhunk://#diff-fcbdb57c37f5d32b5ecf046327cfa9ee91a33f156714ea7fb6f000a48d2c4ca4L846-R872)

**Debug Logging Enhancements**
* Added detailed debug logging throughout the CA rotation and certificate storage processes, including per-unit status and overall cluster rotation state, making it easier to diagnose issues. [[1]](diffhunk://#diff-fcbdb57c37f5d32b5ecf046327cfa9ee91a33f156714ea7fb6f000a48d2c4ca4R799-R805) [[2]](diffhunk://#diff-fcbdb57c37f5d32b5ecf046327cfa9ee91a33f156714ea7fb6f000a48d2c4ca4R821-R825) [[3]](diffhunk://#diff-fcbdb57c37f5d32b5ecf046327cfa9ee91a33f156714ea7fb6f000a48d2c4ca4L818-R841) [[4]](diffhunk://#diff-fcbdb57c37f5d32b5ecf046327cfa9ee91a33f156714ea7fb6f000a48d2c4ca4L629-R629)
* Added a debug log when TLS is not yet fully configured and an event is deferred, clarifying event handling during setup.

**Test Improvements**
* Updated the integration test for CA rotation to use the `idle_period` parameter, ensuring more reliable test timing.

## How was this change tested?
- [x] Manually
- [x] Unit tests
- [x] Integration tests

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
