### PR TITLE
Set blocked message on verify repository fail

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -1533,8 +1533,7 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
 
         elif storage_type := self.charm.snapshots_manager.get_storage_type():
             try:
-                if not self.charm.snapshots_manager.verify_repository(storage_type):
-                    blocked_msg = "Object storage related but storage configuration is not completed in main orchestator yet."
+                self.charm.snapshots_manager.verify_repository(storage_type)
             except OpenSearchHttpError as e:
                 logger.warning(
                     "Failed to create/verify snapshot repository for %s. "
@@ -1543,6 +1542,7 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
                     e,
                     getattr(e, "response_body", None),
                 )
+                blocked_msg = "Object storage related but storage configuration is not completed in main orchestrator yet."
 
         if not blocked_msg:
             self._clear_errors(f"error_from_requirer-{event_rel_id}")

--- a/lib/charms/opensearch/v0/opensearch_snapshots.py
+++ b/lib/charms/opensearch/v0/opensearch_snapshots.py
@@ -1621,7 +1621,7 @@ class OpenSearchSnapshotsManager:
             return "gcs"
 
     @retry(stop=stop_after_attempt(3), wait=wait_fixed(3), reraise=True)
-    def verify_repository(self, object_storage_type: ObjectStorageType) -> bool:
+    def verify_repository(self, object_storage_type: ObjectStorageType) -> None:
         """Verify repository by listing snapshots.
 
         Args:
@@ -1641,7 +1641,6 @@ class OpenSearchSnapshotsManager:
             alt_hosts=self.charm.alt_hosts,
             timeout=30,
         )
-        return True
 
     @retry(stop=stop_after_attempt(3), wait=wait_fixed(3), reraise=True)
     def should_restart_for_full_setup(


### PR DESCRIPTION
## Description of issue or feature:
<!--- Please describe in detail what this PR is about. And a reference link to a Github issue or Jira ticket.  -->
The repository verification check in `_error_set_from_requirer` will never return `False`. The blocked message is not set on failure.

## Solution:

Set the blocked message in the except block.

This PR

- changes the return value of `opensearch_snapshots.py:verify_repository()` to `None`
- sets a blocked message when an `OpenSearchHttpError` is raised during verification

## How was this change tested?
- [ ] Manually
- [ ] Unit tests
- [ ] Integration tests

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
