### PR TITLE
fix: remove verify repository from requirer error checks

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
+++ b/lib/charms/opensearch/v0/opensearch_relation_peer_cluster.py
@@ -1536,19 +1536,6 @@ class OpenSearchPeerClusterRequirer(OpenSearchPeerClusterRelation):
             ):
                 blocked_msg = "Cannot relate 2 clusters with different 'cluster_name' values."
 
-        elif storage_type := self.charm.snapshots_manager.get_storage_type():
-            try:
-                self.charm.snapshots_manager.verify_repository(storage_type)
-            except OpenSearchHttpError as e:
-                logger.warning(
-                    "Failed to create/verify snapshot repository for %s. "
-                    "Error: %s, response_body=%r",
-                    storage_type,
-                    e,
-                    getattr(e, "response_body", None),
-                )
-                blocked_msg = "Object storage related but storage configuration is not completed in main orchestrator yet."
-
         if not blocked_msg:
             self._clear_errors(f"error_from_requirer-{event_rel_id}")
             return False


### PR DESCRIPTION
## Description of issue or feature:

OpensearchPeerClusterRequirer performs some checks regarding peer-cluster-relation. There was a check for repository verification but this is not useful. This was aiming not publish creds to subclusters if main orhestrator do not finish checks and preparations. However, `self.refresh_relation_data` method is called in several places and triggers peer_relation_changed event  in the subclusters. By this way, they may get the creds any time. This change does not prevent it, so removing.


## Solution:

We are removing the verify_repository check from the method `_error_set_from_requirer` which is not useful.

## How was this change tested?
- [x] Manually
- [ ] Unit tests
- [x] Integration tests

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
