### PR TITLE
chore: remove restart after CA add/remove

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_base_charm.py
+++ b/lib/charms/opensearch/v0/opensearch_base_charm.py
@@ -2049,20 +2049,6 @@ class OpenSearchBaseCharm(CharmBase, abc.ABC):
             )
         )
 
-    def request_opensearch_restart(
-        self,
-        reason: str | None = None,
-    ) -> None:
-        """Ask the charm to restart OpenSearch via its internal restart event.
-
-        Args:
-            reason: the reason for the restart.
-        """
-        if reason:
-            msg = f"Requesting OpenSearch restart for {reason}"
-            logger.info(msg)
-        self._restart_opensearch_event.emit()
-
     @property
     def unit_ip(self) -> str:
         """IP address of the current unit."""

--- a/lib/charms/opensearch/v0/opensearch_snapshots.py
+++ b/lib/charms/opensearch/v0/opensearch_snapshots.py
@@ -250,18 +250,11 @@ class OpenSearchSnapshotEvents(Object):
                 # Content differs: rotate / store new chain
                 self.charm.snapshots_manager.store_s3_ca(object_storage_config.s3.tls_ca_chain)
                 logger.info("S3 CA stored/updated.")
-                if not self.charm.unit.is_leader():
-                    return
-                if self.charm.snapshots_manager.should_restart_for_full_setup(
-                    object_storage_type, object_storage_config
-                ):
-                    self.charm.request_opensearch_restart(reason="apply object storage CA change")
 
         elif self.charm.snapshots_manager.is_custom_s3_ca_stored():
             # No CA configured now. If we had one, remove it
             self.charm.snapshots_manager.remove_s3_ca()
             logger.info("S3 CA removed.")
-            self.charm.request_opensearch_restart(reason="clean up the object storage CA")
 
         try:
             if not self.charm.unit.is_leader():
@@ -317,7 +310,6 @@ class OpenSearchSnapshotEvents(Object):
 
         if self.charm.snapshots_manager.is_custom_s3_ca_stored():
             self.charm.snapshots_manager.remove_s3_ca()
-            self.charm.request_opensearch_restart(reason="clean up the object storage CA")
 
         if self.charm.unit.is_leader():
             self.charm.status.clear(BackupCredentialIncorrect, app=True)
@@ -522,15 +514,11 @@ class OpenSearchSnapshotEvents(Object):
             # Optional CA chain
             if s3_info.get("s3_tls_ca_chain"):
                 logger.info("S3 TLS CA Chain detected.")
-                ca_changed = self.charm.snapshots_manager.ca_changed(s3_info["s3_tls_ca_chain"])
                 self.charm.snapshots_manager.store_s3_ca(s3_info["s3_tls_ca_chain"])
-                if ca_changed:
-                    self.charm.request_opensearch_restart(reason="apply object storage CA change")
 
             elif self.charm.snapshots_manager.is_custom_s3_ca_stored():
                 # If we had a custom CA but peer no longer provides one, clean it up
                 self.charm.snapshots_manager.remove_s3_ca()
-                self.charm.request_opensearch_restart(reason="clean up the object storage CA")
 
             return
 
@@ -557,7 +545,6 @@ class OpenSearchSnapshotEvents(Object):
 
             if self.charm.snapshots_manager.is_custom_s3_ca_stored():
                 self.charm.snapshots_manager.remove_s3_ca()
-                self.charm.request_opensearch_restart(reason="clean up the object storage CA")
 
             # apply Azure credentials
             self.charm.keystore_manager.put_entries(
@@ -597,9 +584,6 @@ class OpenSearchSnapshotEvents(Object):
         # clean S3 CA
         if self.charm.snapshots_manager.is_custom_s3_ca_stored():
             self.charm.snapshots_manager.remove_s3_ca()
-            self.charm.request_opensearch_restart(
-                reason="clean up object storage CA after backend removal"
-            )
 
     def _on_peer_clusters_relation_departed_for_snapshots(self, event) -> None:  # noqa C901
         """Cleanup snapshot config if the orchestrator we depended on is gone."""
@@ -665,9 +649,6 @@ class OpenSearchSnapshotEvents(Object):
         # clean S3 CA if it was stored
         if self.charm.snapshots_manager.is_custom_s3_ca_stored():
             self.charm.snapshots_manager.remove_s3_ca()
-            self.charm.request_opensearch_restart(
-                reason="clean up object storage CA after peer-clusters departed"
-            )
 
     def _get_provider_rel_payload(self) -> PeerClusterRelData | None:  # noqa: C901
         """Return the payload from the main orchestrator relation, if any."""
@@ -1693,35 +1674,6 @@ class OpenSearchSnapshotsManager:
             alt_hosts=self.charm.alt_hosts,
             timeout=30,
         )
-
-    @retry(stop=stop_after_attempt(3), wait=wait_fixed(3), reraise=True)
-    def should_restart_for_full_setup(
-        self, object_storage_type: ObjectStorageType, object_storage_config: ObjectStorageConfig
-    ) -> bool:
-        """Check if a restart is needed for full setup."""
-        if not self.charm.unit.is_leader():
-            return False
-        if not self.opensearch.is_started():
-            return False
-
-        try:
-            test_repository = (
-                f"tmp-{self.charm.unit_name}-{self.repository_name(object_storage_type)}"
-            )
-            self.create_repository(
-                object_storage_type, object_storage_config, name=test_repository
-            )
-            # best effort clean up
-            try:
-                self.remove_repository(object_storage_type, name=test_repository)
-            except Exception:
-                pass
-            # creation succeeded, no restart needed
-            return False
-        except OpenSearchHttpError as e:
-            if e.response_body.get("error", {}).get("type") == "repository_verification_exception":
-                return True
-            raise
 
     def ca_changed(self, new_chain: str | None) -> bool:
         """Return True if the installed CA differs from new_chain."""

--- a/lib/charms/opensearch/v0/opensearch_snapshots.py
+++ b/lib/charms/opensearch/v0/opensearch_snapshots.py
@@ -236,7 +236,6 @@ class OpenSearchSnapshotEvents(Object):
             }
         )
         logger.info("S3 credentials are added to keystore.")
-        self.charm.keystore_manager.reload()
 
         needs_custom_ca = self.charm.snapshots_manager.requires_custom_s3_ca(
             object_storage_type, object_storage_config
@@ -254,6 +253,8 @@ class OpenSearchSnapshotEvents(Object):
             # No CA configured now. If we had one, remove it
             self.charm.snapshots_manager.remove_s3_ca()
             logger.info("S3 CA removed.")
+
+        self.charm.keystore_manager.reload()
 
         try:
             if not self.charm.unit.is_leader():
@@ -507,7 +508,7 @@ class OpenSearchSnapshotEvents(Object):
                     "s3.client.default.secret_key": s3_info["secret_key"],
                 }
             )
-            self.charm.keystore_manager.reload()
+
             logger.info("S3 credentials are added to keystore.")
 
             # Optional CA chain
@@ -518,6 +519,8 @@ class OpenSearchSnapshotEvents(Object):
             elif self.charm.snapshots_manager.is_custom_s3_ca_stored():
                 # If we had a custom CA but peer no longer provides one, clean it up
                 self.charm.snapshots_manager.remove_s3_ca()
+
+            self.charm.keystore_manager.reload()
 
             return
 

--- a/lib/charms/opensearch/v0/opensearch_snapshots.py
+++ b/lib/charms/opensearch/v0/opensearch_snapshots.py
@@ -2,7 +2,6 @@
 # See LICENSE file for licensing details.
 
 """OpenSearch Snapshots."""
-import hashlib
 import json
 import logging
 from datetime import datetime
@@ -1674,26 +1673,3 @@ class OpenSearchSnapshotsManager:
             alt_hosts=self.charm.alt_hosts,
             timeout=30,
         )
-
-    def ca_changed(self, new_chain: str | None) -> bool:
-        """Return True if the installed CA differs from new_chain."""
-        current_chain = self.charm.snapshots_manager.find_s3_chain_in_store()
-        # No CA installed and nothing new: no change
-        if not current_chain and not new_chain:
-            logger.debug("No CA installed and nothing new: no change")
-            return False
-
-        # Only one side has a chain: definitely changed
-        if bool(current_chain) != bool(new_chain):
-            logger.debug("The CA is added or removed: definitely changed")
-            return True
-
-        # Both non-empty: compare as unordered sets of normalized cert blocks
-        current_blocks = normalize_certificate_chain_unordered(current_chain)
-        new_blocks = normalize_certificate_chain_unordered(new_chain)
-        is_different = (
-            hashlib.sha256("".join(current_blocks).encode("utf-8")).hexdigest()
-            != hashlib.sha256("".join(new_blocks).encode("utf-8")).hexdigest()
-        )
-        logger.debug("The old and new CA chains are different: %s", is_different)
-        return is_different

--- a/tests/unit/resources/config/opensearch-security/internal_users.yml
+++ b/tests/unit/resources/config/opensearch-security/internal_users.yml
@@ -10,7 +10,7 @@ _meta:
 ## Demo users
 
 admin:
-  hash: $2b$12$mAXCJ7AiHGDGxLiqwQ4HCefDIeyQIVsjT8zBhm2qZg6TCnBVnZ9lq
+  hash: $2b$12$c1DyD43aWo48vZndyFeEt.QUNB18yeKmZBMqWbbNhDDInoVqQ4MJS
   reserved: false
   backend_roles:
   - admin
@@ -19,6 +19,6 @@ admin:
   - all_access
   description: Admin user
 kibanaserver:
-  hash: $2b$12$p54pyKyc0tWo.yoAlKfk5ekpLJhzEuwL./yIJURFWF5o4aXwcDVbu
+  hash: $2b$12$aAz/Hal3iLqheQrFj2nxUeYdoJJSU7mNOqMIsto.tNBe54O7B/3Sy
   reserved: false
   description: Kibanaserver user

--- a/tests/unit/resources/config/opensearch-security/internal_users.yml
+++ b/tests/unit/resources/config/opensearch-security/internal_users.yml
@@ -10,7 +10,7 @@ _meta:
 ## Demo users
 
 admin:
-  hash: $2b$12$c1DyD43aWo48vZndyFeEt.QUNB18yeKmZBMqWbbNhDDInoVqQ4MJS
+  hash: $2b$12$mAXCJ7AiHGDGxLiqwQ4HCefDIeyQIVsjT8zBhm2qZg6TCnBVnZ9lq
   reserved: false
   backend_roles:
   - admin
@@ -19,6 +19,6 @@ admin:
   - all_access
   description: Admin user
 kibanaserver:
-  hash: $2b$12$aAz/Hal3iLqheQrFj2nxUeYdoJJSU7mNOqMIsto.tNBe54O7B/3Sy
+  hash: $2b$12$p54pyKyc0tWo.yoAlKfk5ekpLJhzEuwL./yIJURFWF5o4aXwcDVbu
   reserved: false
   description: Kibanaserver user


### PR DESCRIPTION
## Description of issue or feature:

Were are restarting Opensearch service if a new CA added/changed/removed. In the upstream guides, there is no any hot-reload mechanism. But in reality, hot-reload helps the CA updates takes effect. We tested that although we remove all the service restarts after CA changes and run a  hot-reload, it all works well. 

## Solution:

This PR removes all the Opensearch service restarts and just runs `keystore_manager.reload()`.

## How was this change tested?
- [x] Manually
- [ ] Unit tests
- [x] Integration tests

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
