### PR TITLE
Refactor code and verify repository after all units save creds

### DIFF
--- a/lib/charms/opensearch/v0/opensearch_snapshots.py
+++ b/lib/charms/opensearch/v0/opensearch_snapshots.py
@@ -7,7 +7,7 @@ import json
 import logging
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Optional, Tuple, Union
 
 from charms.data_platform_libs.v0.azure_storage import (
     AzureStorageRequires,
@@ -124,17 +124,17 @@ class OpenSearchSnapshotEvents(Object):
         self.azure_requirer = AzureStorageRequires(charm, AZURE_RELATION)
 
         # simple deployments or main orchestrator
-        self.framework.observe(
-            self.s3_requirer.on.credentials_changed, self._on_s3_credentials_changed
-        )
-        self.framework.observe(self.s3_requirer.on.credentials_gone, self._on_s3_credentials_gone)
-        self.framework.observe(
+        for event in [
+            self.s3_requirer.on.credentials_changed,
             self.azure_requirer.on.storage_connection_info_changed,
-            self._on_azure_credentials_changed,
-        )
-        self.framework.observe(
-            self.azure_requirer.on.storage_connection_info_gone, self._on_azure_credentials_gone
-        )
+        ]:
+            self.framework.observe(event, self._on_backup_credentials_changed)
+
+        for event in [
+            self.s3_requirer.on.credentials_gone,
+            self.azure_requirer.on.storage_connection_info_gone,
+        ]:
+            self.framework.observe(event, self._on_backup_credentials_gone)
 
         # large deployments with non-main orchestrator
         self.framework.observe(
@@ -151,12 +151,15 @@ class OpenSearchSnapshotEvents(Object):
         self.framework.observe(self.charm.on.list_backups_action, self._on_list_backups_action)
         self.framework.observe(self.charm.on.restore_action, self._on_restore_action)
 
-    def _on_s3_credentials_changed(self, event: CredentialsChangedEvent) -> None:  # noqa: C901
-        """Handler for s3 credentials changed event."""
+    def _on_backup_credentials_changed(
+        self, event: Union[CredentialsChangedEvent, StorageConnectionInfoChangedEvent]
+    ) -> None:
+        """Handler for backup credentials changed event."""
         if not (deployment_desc := self.charm.opensearch_peer_cm.deployment_desc()):
             logger.debug("Deployment description not ready; deferring %s", event)
             event.defer()
             return
+
         # block non-main orchestrators only when they are in a multi-app topology.
         if (
             deployment_desc.typ != DeploymentType.MAIN_ORCHESTRATOR
@@ -168,7 +171,6 @@ class OpenSearchSnapshotEvents(Object):
 
         object_storage_type = self.charm.snapshots_manager.get_storage_type()
 
-        logger.info(f"S3 credentials changed for object storage type {object_storage_type}")
         if object_storage_type == ObjectStorageType.CONFLICT:
             if self.charm.unit.is_leader():
                 self.charm.status.set(BlockedStatus(BackupRelConflict), app=True)
@@ -179,24 +181,37 @@ class OpenSearchSnapshotEvents(Object):
             self.charm.status.clear(BackupRelConflict, app=True)
 
         object_storage_config = self.charm.snapshots_manager.get_storage_config(
-            ObjectStorageType.S3
+            object_storage_type
         )
-        # handle case where this was deferred, then the S3 relation was severed
+
         if (
             not object_storage_config
-            or not object_storage_config.s3
-            or not object_storage_config.s3.credentials
+            or (
+                object_storage_type == ObjectStorageType.S3
+                and (not object_storage_config.s3 or not object_storage_config.s3.credentials)
+            )
+            or (
+                object_storage_type == ObjectStorageType.AZURE
+                and (
+                    not object_storage_config.azure or not object_storage_config.azure.credentials
+                )
+            )
         ):
-            logger.warning("No S3 object storage configuration.")
+            logger.warning("No %s object storage configuration.", object_storage_type)
             if self.charm.unit.is_leader():
                 self.charm.status.set(BlockedStatus(BackupRelDataIncomplete), app=True)
             return
-
         if self.charm.unit.is_leader():
             self.charm.status.clear(BackupRelDataIncomplete, app=True)
 
-        if not verify_s3_credentials(object_storage_config):
-            logger.warning("S3 object storage credentials not verified.")
+        if (
+            object_storage_type == ObjectStorageType.AZURE
+            and not verify_azure_credentials(object_storage_config)
+        ) or (
+            object_storage_type == ObjectStorageType.S3
+            and not verify_s3_credentials(object_storage_config)
+        ):
+            logger.warning("%s object storage credentials not verified.", object_storage_type)
             if self.charm.unit.is_leader():
                 self.charm.status.set(BlockedStatus(BackupCredentialIncorrect), app=True)
             return
@@ -204,168 +219,38 @@ class OpenSearchSnapshotEvents(Object):
         if self.charm.unit.is_leader():
             self.charm.status.clear(BackupCredentialIncorrect, app=True)
 
-        # apply locally (leader does cluster-level config)
-        self.charm.keystore_manager.put_entries(
-            {
-                "s3.client.default.access_key": object_storage_config.s3.credentials.access_key,
-                "s3.client.default.secret_key": object_storage_config.s3.credentials.secret_key,
-            }
-        )
-        logger.info("S3 credentials are added to keystore.")
-        self.charm.keystore_manager.reload()
+        if object_storage_type == ObjectStorageType.S3:
+            self.charm.keystore_manager.put_entries(
+                {
+                    "s3.client.default.access_key": object_storage_config.s3.credentials.access_key,
+                    "s3.client.default.secret_key": object_storage_config.s3.credentials.secret_key,
+                }
+            )
 
-        needs_custom_ca = self.charm.snapshots_manager.requires_custom_s3_ca(
-            object_storage_type, object_storage_config
-        )
-
-        if needs_custom_ca:
-            if not self.charm.snapshots_manager.is_custom_s3_ca_stored(
-                object_storage_config.s3.tls_ca_chain
-            ):
-                # Content differs: rotate / store new chain
-                self.charm.snapshots_manager.store_s3_ca(object_storage_config.s3.tls_ca_chain)
-                logger.info("S3 CA stored/updated.")
-                if not self.charm.unit.is_leader():
-                    return
-                if self.charm.snapshots_manager.should_restart_for_full_setup(
-                    object_storage_type, object_storage_config
+            if object_storage_config.s3.tls_ca_chain:
+                if not self.charm.snapshots_manager.is_custom_s3_ca_stored(
+                    object_storage_config.s3.tls_ca_chain
                 ):
-                    self.charm.request_opensearch_restart(reason="apply object storage CA change")
+                    # Content differs: rotate / store new chain
+                    self.charm.snapshots_manager.store_s3_ca(object_storage_config.s3.tls_ca_chain)
+                    logger.info("S3 CA stored/updated.")
+            else:
+                self.charm.snapshots_manager.remove_s3_ca()
 
-        elif self.charm.snapshots_manager.is_custom_s3_ca_stored():
-            # No CA configured now. If we had one, remove it
-            self.charm.snapshots_manager.remove_s3_ca()
-            logger.info("S3 CA removed.")
-            self.charm.request_opensearch_restart(reason="clean up the object storage CA")
-
-        try:
-            if not self.charm.unit.is_leader():
-                return
-            self.charm.snapshots_manager.ensure_repository(
-                object_storage_type, object_storage_config
+        elif object_storage_type == ObjectStorageType.AZURE:
+            self.charm.keystore_manager.put_entries(
+                {
+                    "azure.client.default.account": object_storage_config.azure.credentials.storage_account,
+                    "azure.client.default.key": object_storage_config.azure.credentials.secret_key,
+                }
             )
-            self.charm.snapshots_manager.verify_repository(ObjectStorageType.S3)
-        except OpenSearchHttpError as e:
-            logger.error(
-                "Failed to create/verify snapshot repository for %s. "
-                "Error: %s, response_body=%r",
-                object_storage_type,
-                e,
-                getattr(e, "response_body", None),
-            )
-            if self.charm.unit.is_leader():
-                self.charm.status.set(
-                    BlockedStatus(BackupMisconfiguration.format("s3", "s3 integrator")), app=True
-                )
-            event.defer()
-            return
 
-        if self.charm.unit.is_leader():
-            self.charm.status.clear(BackupMisconfiguration.format("s3", "s3 integrator"), app=True)
-
-        self.charm.peer_cluster_provider.refresh_relation_data(event, can_defer=False)
-
-    def _on_s3_credentials_gone(self, event: CredentialsGoneEvent) -> None:
-        """Handler for s3 credentials gone event."""
-        if self.charm.unit.is_leader():
-            self.charm.status.clear(BackupRelShouldNotExist, app=True)
-            self.charm.status.clear(BackupRelDataIncomplete, app=True)
-            self.charm.status.clear(BackupMisconfiguration.format("s3", "s3 integrator"), app=True)
-
-        keystore_entries = ["s3.client.default.access_key", "s3.client.default.secret_key"]
-        if not self.charm.snapshots_manager.cleanup(
-            object_storage_type=ObjectStorageType.S3,
-            keystore_entries=keystore_entries,
-            remove_repository=True,
-        ):
-            logger.warning("Cleanup for s3 credentials are failed.")
-            if self.charm.unit.is_leader():
-                self.charm.status.set(
-                    BlockedStatus(BackupCredentialCleanupFailed),
-                    app=True,
-                )
-            event.defer()
-            return
-
-        if self.charm.unit.is_leader():
-            self.charm.status.clear(BackupCredentialCleanupFailed, app=True)
-
-        if self.charm.snapshots_manager.is_custom_s3_ca_stored():
-            self.charm.snapshots_manager.remove_s3_ca()
-            self.charm.request_opensearch_restart(reason="clean up the object storage CA")
-
-        if self.charm.unit.is_leader():
-            self.charm.status.clear(BackupCredentialIncorrect, app=True)
-
-        self.charm.peer_cluster_provider.refresh_relation_data(event, can_defer=False)
-
-    def _on_azure_credentials_changed(  # noqa: C901
-        self, event: StorageConnectionInfoChangedEvent
-    ) -> None:
-        """Handler for azure credentials changed event."""
-        if not (deployment_desc := self.charm.opensearch_peer_cm.deployment_desc()):
-            logger.debug("Deployment description not ready; deferring %s", event)
-            event.defer()
-            return
-
-        # block non-main orchestrators only when they are in a multi-app topology.
-        if (
-            deployment_desc.typ != DeploymentType.MAIN_ORCHESTRATOR
-            and self._is_part_of_large_deployment()
-        ):
-            if self.charm.unit.is_leader():
-                self.charm.status.set(BlockedStatus(BackupRelShouldNotExist), app=True)
-            return
-
-        object_storage_type = self.charm.snapshots_manager.get_storage_type()
-
-        if object_storage_type == ObjectStorageType.CONFLICT:
-            if self.charm.unit.is_leader():
-                self.charm.status.set(BlockedStatus(BackupRelConflict), app=True)
-            event.defer()
-            return
-
-        if self.charm.unit.is_leader():
-            self.charm.status.clear(BackupRelConflict, app=True)
-
-        object_storage_config = self.charm.snapshots_manager.get_storage_config(
-            ObjectStorageType.AZURE
-        )
-        if (
-            not object_storage_config
-            or not object_storage_config.azure
-            or not object_storage_config.azure.credentials
-        ):
-            logger.warning("No Azure object storage configuration.")
-            if self.charm.unit.is_leader():
-                self.charm.status.set(BlockedStatus(BackupRelDataIncomplete), app=True)
-            return
-
-        if self.charm.unit.is_leader():
-            self.charm.status.clear(BackupRelDataIncomplete, app=True)
-
-        if not verify_azure_credentials(object_storage_config):
-            logger.warning("Azure object storage credentials not verified.")
-            if self.charm.unit.is_leader():
-                self.charm.status.set(
-                    BlockedStatus(BackupCredentialIncorrect),
-                    app=True,
-                )
-            return
-
-        if self.charm.unit.is_leader():
-            self.charm.status.clear(BackupCredentialIncorrect, app=True)
-
-        self.charm.keystore_manager.put_entries(
-            {
-                "azure.client.default.account": object_storage_config.azure.credentials.storage_account,
-                "azure.client.default.key": object_storage_config.azure.credentials.secret_key,
-            }
-        )
         self.charm.keystore_manager.reload()
+
+        if not self.charm.unit.is_leader():
+            return
+
         try:
-            if not self.charm.unit.is_leader():
-                return
             self.charm.snapshots_manager.ensure_repository(
                 object_storage_type, object_storage_config
             )
@@ -378,36 +263,50 @@ class OpenSearchSnapshotEvents(Object):
                 e,
                 getattr(e, "response_body", None),
             )
-            if self.charm.unit.is_leader():
-                self.charm.status.set(
-                    BlockedStatus(BackupMisconfiguration.format("azure", "azure integrator")),
-                    app=True,
-                )
+            self.charm.status.set(
+                BlockedStatus(BackupMisconfiguration.format("azure", "azure integrator")),
+                app=True,
+            )
             event.defer()
             return
 
-        if self.charm.unit.is_leader():
-            self.charm.status.clear(
-                BackupMisconfiguration.format("azure", "azure integrator"), app=True
-            )
+        self.charm.status.clear(
+            BackupMisconfiguration.format("azure", "azure integrator"), app=True
+        )
 
         self.charm.peer_cluster_provider.refresh_relation_data(event, can_defer=False)
 
-    def _on_azure_credentials_gone(self, event: StorageConnectionInfoGoneEvent) -> None:
-        """Handler for azure credentials gone event."""
+    def _on_backup_credentials_gone(
+        self, event: CredentialsGoneEvent | StorageConnectionInfoGoneEvent
+    ) -> None:
+        """Handler for s3 credentials gone event."""
+        object_storage_type = self.charm.snapshots_manager.get_storage_type()
+
+        if not object_storage_type:
+            return
+
         if self.charm.unit.is_leader():
             self.charm.status.clear(BackupRelShouldNotExist, app=True)
             self.charm.status.clear(BackupRelDataIncomplete, app=True)
             self.charm.status.clear(
-                BackupMisconfiguration.format("azure", "azure integrator"), app=True
+                BackupMisconfiguration.format(
+                    object_storage_type.value, f"{object_storage_type.value} integrator"
+                ),
+                app=True,
             )
 
-        keystore_entries = ["azure.client.default.account", "azure.client.default.key"]
+        keystore_entries = []
+        if object_storage_type == ObjectStorageType.S3:
+            keystore_entries = ["s3.client.default.access_key", "s3.client.default.secret_key"]
+        elif object_storage_type == ObjectStorageType.AZURE:
+            keystore_entries = ["azure.client.default.account", "azure.client.default.key"]
+
         if not self.charm.snapshots_manager.cleanup(
-            object_storage_type=ObjectStorageType.AZURE,
+            object_storage_type=object_storage_type,
             keystore_entries=keystore_entries,
             remove_repository=True,
         ):
+            logger.warning("Cleanup for %s credentials are failed.", object_storage_type)
             if self.charm.unit.is_leader():
                 self.charm.status.set(
                     BlockedStatus(BackupCredentialCleanupFailed),
@@ -415,6 +314,12 @@ class OpenSearchSnapshotEvents(Object):
                 )
             event.defer()
             return
+
+        if (
+            object_storage_type == ObjectStorageType.S3
+            and self.charm.snapshots_manager.is_custom_s3_ca_stored()
+        ):
+            self.charm.snapshots_manager.remove_s3_ca()
 
         if self.charm.unit.is_leader():
             self.charm.status.clear(BackupCredentialCleanupFailed, app=True)
@@ -1081,13 +986,12 @@ class OpenSearchSnapshotsManager:
             logger.error("Repository should be created by main orchestrator.")
             return False
 
-        if not self.is_repository_created(storage_type):
-            logger.info("Repository is missing; attempting to create.")
-            self.create_repository(
-                object_storage_type=storage_type,
-                object_storage_config=storage_cfg,
-            )
-            logger.info("Created snapshot repository for %s", storage_type)
+        logger.info("Creating/Updating snapshot repository for %s", storage_type)
+        self.create_repository(
+            object_storage_type=storage_type,
+            object_storage_config=storage_cfg,
+        )
+        logger.info("Created/Updated snapshot repository for %s", storage_type)
         return self.is_repository_created(storage_type)
 
     @retry(stop=stop_after_attempt(3), wait=wait_fixed(3), reraise=True)

--- a/lib/charms/opensearch/v0/opensearch_snapshots.py
+++ b/lib/charms/opensearch/v0/opensearch_snapshots.py
@@ -162,7 +162,7 @@ class OpenSearchSnapshotEvents(Object):
         self.framework.observe(self.charm.on.list_backups_action, self._on_list_backups_action)
         self.framework.observe(self.charm.on.restore_action, self._on_restore_action)
 
-    def _on_backup_credentials_changed(
+    def _on_backup_credentials_changed(  # noqa C901
         self, event: Union[CredentialsChangedEvent, StorageConnectionInfoChangedEvent]
     ) -> None:
         """Handler for backup credentials changed event."""
@@ -525,7 +525,6 @@ class OpenSearchSnapshotEvents(Object):
 
     def _on_verify_backup_credentials(self, event: VerifyBackupCredentialsEvent) -> None:
         """Verify that stored backup credentials are still valid."""
-
         credential_dict = {}
         object_storage_type = self.charm.snapshots_manager.get_storage_type()
         object_storage_config = self.charm.snapshots_manager.get_storage_config(

--- a/lib/charms/opensearch/v0/opensearch_snapshots.py
+++ b/lib/charms/opensearch/v0/opensearch_snapshots.py
@@ -348,6 +348,8 @@ class OpenSearchSnapshotEvents(Object):
             self.charm.status.clear(BackupCredentialCleanupFailed, app=True)
             self.charm.status.clear(BackupCredentialIncorrect, app=True)
 
+        self.charm.keystore_manager.reload()
+
         self.charm.peer_cluster_provider.refresh_relation_data(event, can_defer=False)
 
     def _on_peer_clusters_relation_changed_for_snapshots(self, event) -> None:  # noqa C901
@@ -458,6 +460,7 @@ class OpenSearchSnapshotEvents(Object):
         if self.charm.snapshots_manager.is_custom_s3_ca_stored():
             self.charm.snapshots_manager.remove_s3_ca()
 
+        self.charm.keystore_manager.reload()
         self.charm.snapshots_manager.set_credentials_saved(None)
 
     def _on_peer_clusters_relation_departed_for_snapshots(self, event) -> None:  # noqa C901
@@ -519,6 +522,8 @@ class OpenSearchSnapshotEvents(Object):
         # clean S3 CA if it was stored
         if self.charm.snapshots_manager.is_custom_s3_ca_stored():
             self.charm.snapshots_manager.remove_s3_ca()
+
+        self.charm.keystore_manager.reload()
 
     def _on_verify_backup_credentials(self, event: VerifyBackupCredentialsEvent) -> None:
         """Verify that stored backup credentials are still valid."""

--- a/lib/charms/opensearch/v0/opensearch_snapshots.py
+++ b/lib/charms/opensearch/v0/opensearch_snapshots.py
@@ -112,7 +112,7 @@ class ObjectStorageType(str, Enum):
 
 
 class VerifyBackupCredentialsEvent(EventBase):
-    """Event for cleaning up old CAs."""
+    """Event to verify backup credentials on main orchestrator leader unit."""
 
 
 class OpenSearchSnapshotEvents(Object):

--- a/lib/charms/opensearch/v0/opensearch_snapshots.py
+++ b/lib/charms/opensearch/v0/opensearch_snapshots.py
@@ -324,7 +324,10 @@ class OpenSearchSnapshotEvents(Object):
             return
 
         self.charm.status.clear(
-            BackupMisconfiguration.format("azure", "azure integrator"), app=True
+            BackupMisconfiguration.format(
+                object_storage_type.value, f"{object_storage_type.value} integrator"
+            ),
+            app=True,
         )
 
         self.charm.peer_cluster_provider.refresh_relation_data(event, can_defer=False)

--- a/lib/charms/opensearch/v0/opensearch_snapshots.py
+++ b/lib/charms/opensearch/v0/opensearch_snapshots.py
@@ -519,9 +519,6 @@ class OpenSearchSnapshotEvents(Object):
         # clean S3 CA if it was stored
         if self.charm.snapshots_manager.is_custom_s3_ca_stored():
             self.charm.snapshots_manager.remove_s3_ca()
-            self.charm.request_opensearch_restart(
-                reason="clean up object storage CA after peer-clusters departed"
-            )
 
     def _on_verify_backup_credentials(self, event: VerifyBackupCredentialsEvent) -> None:
         """Verify that stored backup credentials are still valid."""
@@ -1624,35 +1621,6 @@ class OpenSearchSnapshotsManager:
             timeout=30,
         )
         return True
-
-    @retry(stop=stop_after_attempt(3), wait=wait_fixed(3), reraise=True)
-    def should_restart_for_full_setup(
-        self, object_storage_type: ObjectStorageType, object_storage_config: ObjectStorageConfig
-    ) -> bool:
-        """Check if a restart is needed for full setup."""
-        if not self.charm.unit.is_leader():
-            return False
-        if not self.opensearch.is_started():
-            return False
-
-        try:
-            test_repository = (
-                f"tmp-{self.charm.unit_name}-{self.repository_name(object_storage_type)}"
-            )
-            self.create_repository(
-                object_storage_type, object_storage_config, name=test_repository
-            )
-            # best effort clean up
-            try:
-                self.remove_repository(object_storage_type, name=test_repository)
-            except Exception:
-                pass
-            # creation succeeded, no restart needed
-            return False
-        except OpenSearchHttpError as e:
-            if e.response_body.get("error", {}).get("type") == "repository_verification_exception":
-                return True
-            raise
 
     def ca_changed(self, new_chain: str | None) -> bool:
         """Return True if the installed CA differs from new_chain."""

--- a/lib/charms/opensearch/v0/opensearch_snapshots.py
+++ b/lib/charms/opensearch/v0/opensearch_snapshots.py
@@ -199,25 +199,35 @@ class OpenSearchSnapshotEvents(Object):
             self.charm.status.clear(BackupRelConflict, app=True)
             if raw := self.charm.state.app.relation_data.get(Scope.APP, "missing_relations"):
                 missing_relations = [r.strip() for r in raw.split(",") if r.strip()]
-                if "azure-storage-integrator" in missing_relations:
+
+                if (
+                    "azure-storage-integrator" in missing_relations
+                    and object_storage_type == ObjectStorageType.AZURE
+                ):
                     missing_relations.remove("azure-storage-integrator")
-                    # still have others missing: update status and stored string
-                    if missing_relations:
-                        missing_str = ", ".join(sorted(missing_relations))
-                        self.charm.status.set(
-                            BlockedStatus(PClusterMissingStorageRelations.format(missing_str)),
-                            app=True,
-                        )
-                        self.charm.state.app.relation_data.put(
-                            Scope.APP, "missing_relations", missing_str
-                        )
-                    else:
-                        self.charm.state.app.relation_data.delete(Scope.APP, "missing_relations")
-                        self.charm.status.clear(
-                            PClusterMissingStorageRelations,
-                            pattern=Status.CheckPattern.Interpolated,
-                            app=True,
-                        )
+                if (
+                    "s3-integrator" in missing_relations
+                    and object_storage_type == ObjectStorageType.S3
+                ):
+                    missing_relations.remove("s3-integrator")
+
+                # still have others missing: update status and stored string
+                if missing_relations:
+                    missing_str = ", ".join(sorted(missing_relations))
+                    self.charm.status.set(
+                        BlockedStatus(PClusterMissingStorageRelations.format(missing_str)),
+                        app=True,
+                    )
+                    self.charm.state.app.relation_data.put(
+                        Scope.APP, "missing_relations", missing_str
+                    )
+                else:
+                    self.charm.state.app.relation_data.delete(Scope.APP, "missing_relations")
+                    self.charm.status.clear(
+                        PClusterMissingStorageRelations,
+                        pattern=Status.CheckPattern.Interpolated,
+                        app=True,
+                    )
 
         object_storage_config = self.charm.snapshots_manager.get_storage_config(
             object_storage_type

--- a/lib/charms/opensearch/v0/opensearch_snapshots.py
+++ b/lib/charms/opensearch/v0/opensearch_snapshots.py
@@ -1419,50 +1419,6 @@ class OpenSearchSnapshotsManager:
 
         return GCS_REPOSITORY
 
-    @staticmethod
-    def requires_custom_s3_ca(
-        object_storage_type: ObjectStorageType, object_storage_config: ObjectStorageConfig
-    ) -> bool:
-        """Check if the current object storage setup requires the use of a custom CA.
-
-        Args:
-            object_storage_type: Object storage type
-            object_storage_config: Object storage config
-
-        Returns:
-            True if the current object storage setup requires the use of a custom CA, else False
-        """
-        if object_storage_type not in {"s3", "s3-pcluster"}:
-            return False
-
-        s3_cfg = object_storage_config.s3
-        chain = s3_cfg.tls_ca_chain if s3_cfg else None
-        if not chain:
-            return False
-
-        logger.info("S3 CA is required.")
-        return True
-
-    @staticmethod
-    def _alias_index(alias: str, prefix: str) -> int:
-        """Order aliases so that plain S3_CA_ALIAS comes first (if present)
-
-        Args:
-            alias: The alias to order
-            prefix: The prefix to order
-        Returns:
-            alias_order(int): alias index
-            S3_CA_ALIAS-0, S3_CA_ALIAS-1, etc. follow in numeric order
-        """
-        if alias == S3_CA_ALIAS:
-            return -1
-        suffix = alias[len(prefix) :]
-        try:
-            return int(suffix)
-        except ValueError:
-            # unknown format, keep but treat as 0
-            return 0
-
     def find_s3_chain_in_store(self) -> str:
         """Return the currently stored S3 CA chain from cacerts, or ''.
 
@@ -1668,29 +1624,6 @@ class OpenSearchSnapshotsManager:
             timeout=30,
         )
         return True
-
-    def ca_changed(self, new_chain: str | None) -> bool:
-        """Return True if the installed CA differs from new_chain."""
-        current_chain = self.charm.snapshots_manager.find_s3_chain_in_store()
-        # No CA installed and nothing new: no change
-        if not current_chain and not new_chain:
-            logger.debug("No CA installed and nothing new: no change")
-            return False
-
-        # Only one side has a chain: definitely changed
-        if bool(current_chain) != bool(new_chain):
-            logger.debug("The CA is added or removed: definitely changed")
-            return True
-
-        # Both non-empty: compare as unordered sets of normalized cert blocks
-        current_blocks = normalize_certificate_chain_unordered(current_chain)
-        new_blocks = normalize_certificate_chain_unordered(new_chain)
-        is_different = (
-            hashlib.sha256("".join(current_blocks).encode("utf-8")).hexdigest()
-            != hashlib.sha256("".join(new_blocks).encode("utf-8")).hexdigest()
-        )
-        logger.debug("The old and new CA chains are different: %s", is_different)
-        return is_different
 
     def set_credentials_saved(self, credentials: dict[str, str] | None) -> None:
         """Set in the peer relation data that credentials have been saved."""

--- a/lib/charms/opensearch/v0/opensearch_snapshots.py
+++ b/lib/charms/opensearch/v0/opensearch_snapshots.py
@@ -31,10 +31,12 @@ from charms.opensearch.v0.constants_charm import (
     BackupRelConflict,
     BackupRelDataIncomplete,
     BackupRelShouldNotExist,
+    PClusterMissingStorageRelations,
     PeerClusterOrchestratorRelationName,
     PeerClusterRelationName,
     RestoreInProgress,
 )
+from charms.opensearch.v0.helper_charm import Status
 from charms.opensearch.v0.helper_cluster import ClusterState
 from charms.opensearch.v0.helper_security import (
     list_cas,
@@ -57,6 +59,7 @@ from charms.opensearch.v0.opensearch_exceptions import (
     OpenSearchHttpError,
 )
 from charms.opensearch.v0.opensearch_health import HealthColors
+from charms.opensearch.v0.opensearch_internal_data import Scope
 from charms.opensearch.v0.opensearch_locking import OpenSearchNodeLock
 from ops import (
     ActionEvent,
@@ -194,6 +197,27 @@ class OpenSearchSnapshotEvents(Object):
 
         if self.charm.unit.is_leader():
             self.charm.status.clear(BackupRelConflict, app=True)
+            if raw := self.charm.state.app.relation_data.get(Scope.APP, "missing_relations"):
+                missing_relations = [r.strip() for r in raw.split(",") if r.strip()]
+                if "azure-storage-integrator" in missing_relations:
+                    missing_relations.remove("azure-storage-integrator")
+                    # still have others missing: update status and stored string
+                    if missing_relations:
+                        missing_str = ", ".join(sorted(missing_relations))
+                        self.charm.status.set(
+                            BlockedStatus(PClusterMissingStorageRelations.format(missing_str)),
+                            app=True,
+                        )
+                        self.charm.state.app.relation_data.put(
+                            Scope.APP, "missing_relations", missing_str
+                        )
+                    else:
+                        self.charm.state.app.relation_data.delete(Scope.APP, "missing_relations")
+                        self.charm.status.clear(
+                            PClusterMissingStorageRelations,
+                            pattern=Status.CheckPattern.Interpolated,
+                            app=True,
+                        )
 
         object_storage_config = self.charm.snapshots_manager.get_storage_config(
             object_storage_type
@@ -470,7 +494,12 @@ class OpenSearchSnapshotEvents(Object):
             event.defer()
             return
 
-        if self.charm.state.app.orchestrators and self.charm.state.app.orchestrators.main_rel_id:
+        if (
+            self.charm.state.app.orchestrators
+            and self.charm.state.app.orchestrators.main_app
+            and self.charm.state.app.orchestrators.main_app.name == event.relation.app.name
+            and len(event.relation.units) > 0
+        ):
             logger.debug(
                 "Main orchestrator still accessible; do not cleanup as it can be scale down"
             )

--- a/lib/charms/opensearch/v0/opensearch_snapshots.py
+++ b/lib/charms/opensearch/v0/opensearch_snapshots.py
@@ -61,6 +61,8 @@ from charms.opensearch.v0.opensearch_locking import OpenSearchNodeLock
 from ops import (
     ActionEvent,
     BlockedStatus,
+    EventBase,
+    EventSource,
     MaintenanceStatus,
     Object,
 )
@@ -109,8 +111,14 @@ class ObjectStorageType(str, Enum):
     CONFLICT = "conflict"
 
 
+class VerifyBackupCredentialsEvent(EventBase):
+    """Event for cleaning up old CAs."""
+
+
 class OpenSearchSnapshotEvents(Object):
     """Events class for Backups (snapshots)."""
+
+    verify_backup_credentials_event = EventSource(VerifyBackupCredentialsEvent)
 
     def __init__(
         self,
@@ -145,6 +153,9 @@ class OpenSearchSnapshotEvents(Object):
             charm.on[PeerClusterRelationName].relation_departed,
             self._on_peer_clusters_relation_departed_for_snapshots,
         )
+        self.framework.observe(
+            self.verify_backup_credentials_event, self._on_verify_backup_credentials
+        )
 
         # actions
         self.framework.observe(self.charm.on.create_backup_action, self._on_create_backup_action)
@@ -170,6 +181,10 @@ class OpenSearchSnapshotEvents(Object):
             return
 
         object_storage_type = self.charm.snapshots_manager.get_storage_type()
+
+        if not object_storage_type:
+            logger.warning("No object storage type could be determined.")
+            return
 
         if object_storage_type == ObjectStorageType.CONFLICT:
             if self.charm.unit.is_leader():
@@ -254,7 +269,7 @@ class OpenSearchSnapshotEvents(Object):
             self.charm.snapshots_manager.ensure_repository(
                 object_storage_type, object_storage_config
             )
-            self.charm.snapshots_manager.verify_repository(ObjectStorageType.AZURE)
+            self.verify_backup_credentials_event.emit()
         except OpenSearchHttpError as e:
             logger.error(
                 "Failed to create/verify snapshot repository for %s. "
@@ -264,7 +279,11 @@ class OpenSearchSnapshotEvents(Object):
                 getattr(e, "response_body", None),
             )
             self.charm.status.set(
-                BlockedStatus(BackupMisconfiguration.format("azure", "azure integrator")),
+                BlockedStatus(
+                    BackupMisconfiguration.format(
+                        object_storage_type.value, f"{object_storage_type.value} integrator"
+                    )
+                ),
                 app=True,
             )
             event.defer()
@@ -280,7 +299,11 @@ class OpenSearchSnapshotEvents(Object):
         self, event: CredentialsGoneEvent | StorageConnectionInfoGoneEvent
     ) -> None:
         """Handler for s3 credentials gone event."""
-        object_storage_type = self.charm.snapshots_manager.get_storage_type()
+        object_storage_type = (
+            ObjectStorageType.S3
+            if isinstance(event, CredentialsGoneEvent)
+            else ObjectStorageType.AZURE
+        )
 
         if not object_storage_type:
             return
@@ -346,15 +369,25 @@ class OpenSearchSnapshotEvents(Object):
             )
             return
 
+        info_to_save = s3_info if s3_info else azure_info
+        object_storage_type_to_clean = ObjectStorageType.AZURE if s3_info else ObjectStorageType.S3
+        keystore_entries_to_clean = (
+            [
+                "azure.client.default.account",
+                "azure.client.default.key",
+            ]
+            if s3_info
+            else [
+                "s3.client.default.access_key",
+                "s3.client.default.secret_key",
+            ]
+        )
         # only S3 provided: clean Azure, configure S3
-        if s3_info:
+        if info_to_save:
             # clean Azure keys from keystore.
             if not self.charm.snapshots_manager.cleanup(
-                object_storage_type=ObjectStorageType.AZURE,
-                keystore_entries=[
-                    "azure.client.default.account",
-                    "azure.client.default.key",
-                ],
+                object_storage_type=object_storage_type_to_clean,
+                keystore_entries=keystore_entries_to_clean,
             ):
                 if self.charm.unit.is_leader():
                     self.charm.status.set(
@@ -367,65 +400,34 @@ class OpenSearchSnapshotEvents(Object):
             if self.charm.unit.is_leader():
                 self.charm.status.clear(BackupCredentialCleanupFailed, app=True)
 
-            # apply S3 credentials
-            self.charm.keystore_manager.put_entries(
-                {
-                    "s3.client.default.access_key": s3_info["access_key"],
-                    "s3.client.default.secret_key": s3_info["secret_key"],
-                }
-            )
-            self.charm.keystore_manager.reload()
-            logger.info("S3 credentials are added to keystore.")
+            # apply credentials
+            if s3_info:
+                self.charm.keystore_manager.put_entries(
+                    {
+                        "s3.client.default.access_key": s3_info["access_key"],
+                        "s3.client.default.secret_key": s3_info["secret_key"],
+                    }
+                )
+            elif azure_info:
+                self.charm.keystore_manager.put_entries(
+                    {
+                        "azure.client.default.account": azure_info["storage_account"],
+                        "azure.client.default.key": azure_info["secret_key"],
+                    }
+                )
 
             # Optional CA chain
-            if s3_info.get("s3_tls_ca_chain"):
+            if s3_info and s3_info.get("s3_tls_ca_chain"):
                 logger.info("S3 TLS CA Chain detected.")
-                ca_changed = self.charm.snapshots_manager.ca_changed(s3_info["s3_tls_ca_chain"])
                 self.charm.snapshots_manager.store_s3_ca(s3_info["s3_tls_ca_chain"])
-                if ca_changed:
-                    self.charm.request_opensearch_restart(reason="apply object storage CA change")
 
             elif self.charm.snapshots_manager.is_custom_s3_ca_stored():
                 # If we had a custom CA but peer no longer provides one, clean it up
                 self.charm.snapshots_manager.remove_s3_ca()
-                self.charm.request_opensearch_restart(reason="clean up the object storage CA")
 
-            return
-
-        # only Azure provided: clean S3, configure Azure
-        if azure_info:
-            # clean S3 keys from keystore and CA from truststore
-            if not self.charm.snapshots_manager.cleanup(
-                object_storage_type=ObjectStorageType.S3,
-                keystore_entries=[
-                    "s3.client.default.access_key",
-                    "s3.client.default.secret_key",
-                ],
-            ):
-                if self.charm.unit.is_leader():
-                    self.charm.status.set(
-                        BlockedStatus(BackupCredentialCleanupFailed),
-                        app=True,
-                    )
-                event.defer()
-                return
-
-            if self.charm.unit.is_leader():
-                self.charm.status.clear(BackupCredentialCleanupFailed, app=True)
-
-            if self.charm.snapshots_manager.is_custom_s3_ca_stored():
-                self.charm.snapshots_manager.remove_s3_ca()
-                self.charm.request_opensearch_restart(reason="clean up the object storage CA")
-
-            # apply Azure credentials
-            self.charm.keystore_manager.put_entries(
-                {
-                    "azure.client.default.account": azure_info["storage_account"],
-                    "azure.client.default.key": azure_info["secret_key"],
-                }
-            )
-            logger.info("Azure storage credentials are added to keystore.")
             self.charm.keystore_manager.reload()
+            logger.info("%s credentials are added to keystore.", "S3" if s3_info else "Azure")
+            self.charm.snapshots_manager.set_credentials_saved(info_to_save)
             return
 
         # neither S3 nor Azure provided: clean everything.
@@ -455,9 +457,8 @@ class OpenSearchSnapshotEvents(Object):
         # clean S3 CA
         if self.charm.snapshots_manager.is_custom_s3_ca_stored():
             self.charm.snapshots_manager.remove_s3_ca()
-            self.charm.request_opensearch_restart(
-                reason="clean up object storage CA after backend removal"
-            )
+
+        self.charm.snapshots_manager.set_credentials_saved(None)
 
     def _on_peer_clusters_relation_departed_for_snapshots(self, event) -> None:  # noqa C901
         """Cleanup snapshot config if the orchestrator we depended on is gone."""
@@ -521,6 +522,84 @@ class OpenSearchSnapshotEvents(Object):
             self.charm.request_opensearch_restart(
                 reason="clean up object storage CA after peer-clusters departed"
             )
+
+    def _on_verify_backup_credentials(self, event: VerifyBackupCredentialsEvent) -> None:
+        """Verify that stored backup credentials are still valid."""
+
+        credential_dict = {}
+        object_storage_type = self.charm.snapshots_manager.get_storage_type()
+        object_storage_config = self.charm.snapshots_manager.get_storage_config(
+            object_storage_type
+        )
+
+        if not object_storage_type or not object_storage_config:
+            return
+
+        if object_storage_config.s3:
+            credential_dict = {
+                "access_key": object_storage_config.s3.credentials.access_key,
+                "secret_key": object_storage_config.s3.credentials.secret_key,
+                "s3_tls_ca_chain": object_storage_config.s3.tls_ca_chain,
+            }
+        elif object_storage_config.azure:
+            credential_dict = {
+                "storage_account": object_storage_config.azure.credentials.storage_account,
+                "secret_key": object_storage_config.azure.credentials.secret_key,
+            }
+
+        credentials_hash = self.charm.snapshots_manager.hash_credentials(credential_dict)
+
+        # check all other clusters if they have saved the credentials
+        all_relation_ids = [
+            rel.id
+            for rel in self.charm.model.relations[PeerClusterOrchestratorRelationName]
+            if len(rel.units) > 0
+        ]
+
+        for rel_id in all_relation_ids:
+            relation = self.charm.model.get_relation(PeerClusterOrchestratorRelationName, rel_id)
+            for unit in relation.units:
+                rel_data = relation.data.get(unit)
+                if not rel_data:
+                    continue
+                saved_hash = rel_data.get("credentials_saved")
+                if saved_hash != credentials_hash:
+                    logger.warning(
+                        "Unit %s in relation %s has not saved the latest backup credentials.",
+                        unit.name,
+                        rel_id,
+                    )
+                    event.defer()
+                    return
+
+        # all units have saved the latest credentials
+        logger.info("All peer-cluster units have saved the latest backup credentials.")
+        try:
+            self.charm.snapshots_manager.verify_repository(object_storage_type)
+        except OpenSearchHttpError as e:
+            self.charm.status.set(
+                BlockedStatus(
+                    BackupMisconfiguration.format(
+                        object_storage_type.value, f"{object_storage_type.value} integrator"
+                    )
+                ),
+                app=True,
+            )
+            logger.error(
+                "Failed to verify snapshot repository after credentials verification. "
+                "Error: %s, response_body=%r",
+                e,
+                getattr(e, "response_body", None),
+            )
+            event.defer()
+            return
+        self.charm.status.clear(
+            BackupMisconfiguration.format(
+                object_storage_type.value, f"{object_storage_type.value} integrator"
+            ),
+            app=True,
+        )
+        logger.info("Backup credentials verified successfully.")
 
     def _get_provider_rel_payload(self) -> PeerClusterRelData | None:  # noqa: C901
         """Return the payload from the main orchestrator relation, if any."""
@@ -1598,3 +1677,33 @@ class OpenSearchSnapshotsManager:
         )
         logger.debug("The old and new CA chains are different: %s", is_different)
         return is_different
+
+    def set_credentials_saved(self, credentials: dict[str, str] | None) -> None:
+        """Set in the peer relation data that credentials have been saved."""
+        orchestrators = self.charm.state.app.orchestrators
+
+        if not orchestrators or orchestrators.main_app is None:
+            return
+
+        # set the credentials_saved in the unit data bag with the main orchestrator
+        relation = self.charm.model.get_relation(
+            PeerClusterRelationName, orchestrators.main_rel_id
+        )
+
+        if not relation:
+            logger.warning("No peer-cluster relation found to set credentials_saved.")
+            return
+
+        if credentials is None:
+            relation.data[self.charm.unit].pop("credentials_saved", None)
+            return
+
+        relation.data[self.charm.unit].update(
+            {
+                "credentials_saved": self.hash_credentials(credentials),
+            }
+        )
+
+    def hash_credentials(self, credentials: dict[str, str]) -> str:
+        """Return a hash of the given credentials."""
+        return hashlib.sha1(json.dumps(credentials, sort_keys=True).encode()).hexdigest()


### PR DESCRIPTION
## Description of issue or feature:
<!--- Please describe in detail what this PR is about. And a reference link to a Github issue or Jira ticket.  -->
Fixes #771 
If the leader of the main orchestrator is different from the elected CM in OS the verification of the repository will fail. We need to propagate the credentials to all units of OS to make sure the elected CM has the credentials before we actually verify that the credentials are valid.
## Solution:
<!--- Please describe in detail what the solution implemented in this PR is. The changes made etc. -->
We propagate credentials to all units. Whenver a unit saves the credentials it addes its hash into the unit data bag. Once all units have credentials, the leader of the main orchestrator will verify the credentials.

This PR also includes refactoring code to use a single event handler for both s3/azure backends.
## How was this change tested?
- [x] Manually
- [ ] Unit tests
- [x] Integration tests
