### PR TITLE
Pin Terraform Version 

### DIFF
--- a/terraform/product/large_deployment/main.tf
+++ b/terraform/product/large_deployment/main.tf
@@ -34,7 +34,7 @@ module "opensearch" {
 
 # opensearch-dashboards in the main model
 module "opensearch-dashboards" {
-  source     = "git::https://github.com/canonical/opensearch-dashboards-operator//terraform?ref=2/edge"
+  source     = "git::https://github.com/canonical/opensearch-dashboards-operator//terraform?ref=5f8293bafa60b52486a0cc4b280578e8a0c2f3ea"
   model_uuid = var.main.model_uuid
 
   channel  = var.opensearch-dashboards.channel

--- a/terraform/product/large_deployment/main.tf
+++ b/terraform/product/large_deployment/main.tf
@@ -34,7 +34,7 @@ module "opensearch" {
 
 # opensearch-dashboards in the main model
 module "opensearch-dashboards" {
-  source     = "git::https://github.com/canonical/opensearch-dashboards-operator//terraform?ref=5f8293bafa60b52486a0cc4b280578e8a0c2f3ea"
+  source     = "git::https://github.com/canonical/opensearch-dashboards-operator//terraform?ref=rev60"
   model_uuid = var.main.model_uuid
 
   channel  = var.opensearch-dashboards.channel

--- a/terraform/product/simple_deployment/main.tf
+++ b/terraform/product/simple_deployment/main.tf
@@ -28,7 +28,7 @@ module "opensearch" {
 
 # OpenSearch dashboards
 module "opensearch-dashboards" {
-  source     = "git::https://github.com/canonical/opensearch-dashboards-operator//terraform?ref=2/edge"
+  source     = "git::https://github.com/canonical/opensearch-dashboards-operator//terraform?ref=5f8293bafa60b52486a0cc4b280578e8a0c2f3ea"
   model_uuid = var.opensearch.model_uuid
 
   channel  = var.opensearch-dashboards.channel

--- a/terraform/product/simple_deployment/main.tf
+++ b/terraform/product/simple_deployment/main.tf
@@ -28,7 +28,7 @@ module "opensearch" {
 
 # OpenSearch dashboards
 module "opensearch-dashboards" {
-  source     = "git::https://github.com/canonical/opensearch-dashboards-operator//terraform?ref=5f8293bafa60b52486a0cc4b280578e8a0c2f3ea"
+  source     = "git::https://github.com/canonical/opensearch-dashboards-operator//terraform?ref=rev60"
   model_uuid = var.opensearch.model_uuid
 
   channel  = var.opensearch-dashboards.channel


### PR DESCRIPTION
This Pull Request pins the version of opensearch dashboard terraform module that is used in opensearch terraform products. This is a fix to #768