### PR TITLE
fix: handle the situation that opensearch_failover does not exist

### DIFF
--- a/terraform/charm/large_deployment/main.tf
+++ b/terraform/charm/large_deployment/main.tf
@@ -12,7 +12,7 @@ locals {
   ]
   apps_not_in_failover_model = [
     for app in local.apps :
-    app if app.model_uuid != var.failover.model_uuid
+    app if var.failover == null || app.model_uuid != var.failover.model_uuid
   ]
 
   all_models = distinct(concat(

--- a/terraform/charm/large_deployment/outputs.tf
+++ b/terraform/charm/large_deployment/outputs.tf
@@ -24,9 +24,9 @@ output "app_names" {
   description = "Output of all deployed application names."
   value = {
     opensearch_main     = module.opensearch_main.app_names["opensearch"]
-    opensearch_failover = module.opensearch_failover.app_names["opensearch"]
+    opensearch_failover = try(module.opensearch_failover["deployed"].app_names["opensearch"], null)
     opensearch_apps = [
-      for app_module in module.opensearch_non_orchestrator_apps :
+      for app_module in values(module.opensearch_non_orchestrator_apps) :
       app_module.app_names["opensearch"]
     ]
     self-signed-certificates = module.opensearch_main.app_names["self-signed-certificates"]


### PR DESCRIPTION
## Description of issue or feature:

This PR fixes Terraform evaluation errors in the large deployment configuration when the failover orchestrator is optional.

When failover is not provided, Terraform was attempting to dereference var.failover.model_uuid and access outputs from modules created with for_each, causing failures during terraform module validation.

## Solution

- Guarded access to var.failover.model_uuid in locals [1](https://github.com/canonical/opensearch-operator/pull/781/changes#diff-a05ae41a3894f6cd0e8a3198516ce7ca6fca5616d285b6c7a8ec2b3f0fcb57efR15)
- Fixed output handling by using try(..., null) to avoid failures when failover is not deployed [2](https://github.com/canonical/opensearch-operator/pull/781/changes#diff-d9a43fd5511c20c497a0b452603dcb9adcf6c11506eb026792f9722ffea81ea3R27) [3](https://github.com/canonical/opensearch-operator/pull/781/changes#diff-d9a43fd5511c20c497a0b452603dcb9adcf6c11506eb026792f9722ffea81ea3R29)

## How was this change tested?
- [x] Manually
- [ ] Unit tests
- [ ] Integration tests


## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
