### PR TITLE
chore: update rust toolchain

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -74,7 +74,7 @@ parts:
       # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
-      rustup default 1.83.0  # renovate: charmcraft-rust-latest
+      rustup default 1.92.0  # renovate: charmcraft-rust-latest
 
       craftctl default
       # Include requirements.txt in *.charm artifact for easier debugging


### PR DESCRIPTION
## Description of issue or feature:
Because of an outdated rust version, building the charm cache for opensearch fails ([see ccc-hub](https://github.com/canonical/charmcraftcache-hub/actions/runs/20845106225/job/59886869169)).

## Solution:
update rust used for charm build to version 1.92.0

## How was this change tested?
- [ ] Manually
- [ ] Unit tests
- [X] Integration tests