### PR TITLE
[Docs] Fix the 404 error page

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -169,7 +169,7 @@ html_context = {
 # TODO: If your documentation is hosted on https://docs.ubuntu.com/,
 #       uncomment and update as needed.
 
-slug = 'charmed-opensearch'
+# slug = 'charmed-opensearch'
 
 #######################
 # Sitemap configuration: https://sphinx-sitemap.readthedocs.io/


### PR DESCRIPTION
## Description of issue or feature:

The 404 page is broken due to the slug option being incorrectly applied to the canonical RTD URL (instead of documentation.ubuntu.com/).

## Solution:

Remove the slug option by commenting it out.

## How was this change tested?

- [x] Manually
- [ ] Unit tests
- [ ] Integration tests

https://canonical-charmed-opensearch--787.com.readthedocs.build/787/how-to/yolo/ -- should show the usual 404 page.

## Checklist

- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
