### PR TITLE
docs: Implement rediraffe redirects

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -224,13 +224,9 @@ sitemap_excludes = [
 # NOTE: If undefined, set to None, or empty,
 #       the sphinx_reredirects extension will be disabled.
 
-redirects = {
-    'reference/doc-cheat-sheet-myst/': '/reference/myst-syntax-reference',
-    'reference/doc-cheat-sheet/': '/reference/rst-syntax-reference',
-    'reference/style-guide-myst/': '/reference/myst-syntax-reference',
-    'reference/style-guide/': '/reference/rst-syntax-reference',
-}
+# redirects = {}
 
+rediraffe_redirects = "redirects.txt"
 
 ###########################
 # Link checker exceptions #
@@ -294,6 +290,7 @@ extensions = [
     "sphinx_last_updated_by_git",
     "sphinx.ext.intersphinx",
     "sphinx_sitemap",
+    "sphinxext.rediraffe",
 ]
 
 # Excludes files or directories from processing

--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -1,0 +1,74 @@
+# The redirects.txt file stores all the redirects for the published docs
+# If you change a filename, move or delete a file, you need a redirect here.
+# - Comment lines start with a hash (#) and are ignored
+# - Each redirect should appear on its own line
+
+# We are using the dirhtml builder, so files are treated as directories:
+# - A file is built like `filename/index.html`, not `filename.html`
+# - *Do* include a trailing slash at the end of the path
+# - *Do not* include a file extension or you'll get errors
+# - Paths don't need a slash in front of them
+
+# Example:
+# redirect/from/file/ redirect/to/file/
+
+# Tutorial
+
+tutorial/ tutorial/
+t-set-up/ tutorial/1-set-up-the-environment/
+t-deploy-opensearch/ tutorial/2-deploy-opensearch/
+t-enable-tls/ tutorial/3-enable-encryption/
+t-integrate/ tutorial/4-integrate-with-a-client-application/
+t-passwords/ tutorial/5-manage-passwords/
+t-horizontal-scaling/ tutorial/6-scale-horizontally/
+t-clean-up/ tutorial/7-clean-up-the-environment/
+
+# How-to guides
+
+how-to/ how-to/
+h-deploy/ how-to/deploy/
+h-deploy-lxd/ how-to/deploy/deploy-on-lxd/
+h-large-deployment/ how-to/deploy/launch-a-large-deployment/
+
+h-tls/ how-to/tls-encryption/
+h-enable-tls/ how-to/tls-encryption/enable-tls-encryption/
+h-rotate-tls-ca-certificates/ how-to/tls-encryption/rotate-tls-ca-certificates/
+
+h-horizontal-scaling/ how-to/scale-horizontally/
+h-integrate/ how-to/integrate-with-an-application/
+
+h-backups/ how-to/back-up-and-restore/
+h-configure-azure/ how-to/back-up-and-restore/configure-azure-storage/
+h-configure-s3/ how-to/back-up-and-restore/configure-s3/
+h-create-backup/ how-to/back-up-and-restore/create-a-backup/
+h-restore-backup/ how-to/back-up-and-restore/restore-a-local-backup/
+h-migrate-cluster/ how-to/back-up-and-restore/migrate-a-cluster/
+
+h-attached-storage/ how-to/recover-from-attached-storage/
+
+h-upgrade/ how-to/upgrade/
+h-minor-upgrade/ how-to/upgrade/perform-a-minor-upgrade/
+h-minor-rollback/ how-to/upgrade/perform-a-minor-rollback/
+
+h-oauth/ how-to/access-using-oauth/
+h-jwt-authentication/ how-to/enable-jwt-authentication/
+
+h-monitoring/ how-to/monitoring-cos/
+h-monitoring-enable/ how-to/monitoring-cos/enable-cos/
+h-load-testing/ how-to/monitoring-cos/perform-load-testing/
+
+h-cluster-performance/ how-to/optimize-cluster-performance/
+
+# Reference
+
+reference/ reference/
+release-notes/ reference/release-notes/
+revision-168/ reference/release-notes/revision-168/
+r-system-requirements/ reference/system-requirements/
+r-software-testing/ reference/software-testing/
+
+# Explanation
+
+explanation/ explanation/
+e-security/ explanation/security/
+e-cryptography/ explanation/security/cryptography/

--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -14,7 +14,6 @@
 
 # Tutorial
 
-tutorial/ tutorial/
 t-set-up/ tutorial/1-set-up-the-environment/
 t-deploy-opensearch/ tutorial/2-deploy-opensearch/
 t-enable-tls/ tutorial/3-enable-encryption/
@@ -25,7 +24,6 @@ t-clean-up/ tutorial/7-clean-up-the-environment/
 
 # How-to guides
 
-how-to/ how-to/
 h-deploy/ how-to/deploy/
 h-deploy-lxd/ how-to/deploy/deploy-on-lxd/
 h-large-deployment/ how-to/deploy/launch-a-large-deployment/
@@ -61,7 +59,6 @@ h-cluster-performance/ how-to/optimize-cluster-performance/
 
 # Reference
 
-reference/ reference/
 release-notes/ reference/release-notes/
 revision-168/ reference/release-notes/revision-168/
 r-system-requirements/ reference/system-requirements/
@@ -69,6 +66,5 @@ r-software-testing/ reference/software-testing/
 
 # Explanation
 
-explanation/ explanation/
 e-security/ explanation/security/
 e-cryptography/ explanation/security/cryptography/

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ packaging
 sphinxcontrib-svg2pdfconverter[CairoSVG]
 sphinx-last-updated-by-git
 sphinx-sitemap
+sphinxext-rediraffe


### PR DESCRIPTION
## Description of issue or feature:

This is a second part of the redirects solution from old docs addresses.

## Solution:

The first part is implemented by the web team on their side - they redirect the domain but leave the path.
We are redirecting from the old path to the new one.

## How was this change tested?
- [x] Manually
- [ ] Unit tests
- [ ] Integration tests

Open the https://canonical-charmed-opensearch--788.com.readthedocs.build/788/h-create-backup/ link and it must be redirected to https://canonical-charmed-opensearch--788.com.readthedocs.build/788/how-to/back-up-and-restore/create-a-backup/index.html

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
