### PR TITLE
docs: Add autogenerated metadata description

### DIFF
--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: "Deep-dive explanations of Charmed OpenSearch concepts including security, encryption, authentication, and deployment architecture."
+    description: "Deep-dive explanations of Charmed OpenSearch concepts including security, encryption, and authentication."
 ---
 
 (explanation-index)=

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Deep-dive explanations of Charmed OpenSearch concepts including security, encryption, authentication, and deployment architecture."
+---
+
 (explanation-index)=
 # Explanation
 

--- a/docs/explanation/security/cryptography.md
+++ b/docs/explanation/security/cryptography.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Understand cryptography implementation in Charmed OpenSearch including resource checksums, source verification, and SHA validation."
+---
+
 (explanation-security-cryptography)=
 # Cryptography
 

--- a/docs/explanation/security/index.md
+++ b/docs/explanation/security/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Comprehensive security hardening guide for Charmed OpenSearch covering cloud security, Juju security, and deployment best practices."
+---
+
 (explanation-security-index)=
 # Security hardening guide
 

--- a/docs/how-to/access-using-oauth.md
+++ b/docs/how-to/access-using-oauth.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Secure Charmed OpenSearch with OAuth authentication using Canonical Identity Platform (Hydra) and query with OAuth tokens."
+---
+
 (how-to-access-using-oauth)=
 # How to access OpenSearch using OAuth
 

--- a/docs/how-to/back-up-and-restore/configure-azure-storage.md
+++ b/docs/how-to/back-up-and-restore/configure-azure-storage.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Set up Azure Storage for Charmed OpenSearch backups using the Azure Storage Integrator charm and configure integration."
+---
+
 (how-to-back-up-configure-azure-storage)=
 # How to configure Azure storage
 

--- a/docs/how-to/back-up-and-restore/configure-s3.md
+++ b/docs/how-to/back-up-and-restore/configure-s3.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Configure AWS S3 or Ceph RadosGW storage for Charmed OpenSearch backups using the S3 Integrator charm with Juju."
+---
+
 (how-to-back-up-configure-s3)=
 # How to configure S3 storage 
 

--- a/docs/how-to/back-up-and-restore/create-a-backup.md
+++ b/docs/how-to/back-up-and-restore/create-a-backup.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Create and manage backups of your Charmed OpenSearch cluster to S3-compatible storage for disaster recovery and data protection."
+---
+
 (how-to-create-a-backup)=
 # How to create a backup
 

--- a/docs/how-to/back-up-and-restore/index.md
+++ b/docs/how-to/back-up-and-restore/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Complete backup and restore guides for Charmed OpenSearch including S3, Azure storage configuration, and cluster migration."
+---
+
 (how-to-guides-back-up-and-restore-index)=
 # Back up and restore
 

--- a/docs/how-to/back-up-and-restore/migrate-a-cluster.md
+++ b/docs/how-to/back-up-and-restore/migrate-a-cluster.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Migrate your Charmed OpenSearch cluster by restoring backups from a different cluster to a new deployment."
+---
+
 (how-to-migrate-a-cluster)=
 # How to migrate to a new cluster via restore
 

--- a/docs/how-to/back-up-and-restore/restore-a-local-backup.md
+++ b/docs/how-to/back-up-and-restore/restore-a-local-backup.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Restore Charmed OpenSearch data from local S3-compatible backups to recover from failures or data corruption."
+---
+
 (how-to-restore-a-local-backup)=
 # How to restore a local backup
 

--- a/docs/how-to/deploy/deploy-on-lxd.md
+++ b/docs/how-to/deploy/deploy-on-lxd.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Deploy Charmed OpenSearch on LXD containers with Juju, including prerequisites, sysctl configuration, and bootstrap steps."
+---
+
 (how-to-deploy-lxd)=
 # How to deploy on LXD
 

--- a/docs/how-to/deploy/index.md
+++ b/docs/how-to/deploy/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Deployment guides for Charmed OpenSearch including LXD setup and large-scale production deployments with Juju."
+---
+
 (how-to-guides-deploy-index)=
 # Deploy
 

--- a/docs/how-to/deploy/launch-a-large-deployment.md
+++ b/docs/how-to/deploy/launch-a-large-deployment.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Deploy large-scale Charmed OpenSearch clusters with node roles, data tiers, and production configurations for high-performance workloads."
+---
+
 (how-to-deploy-large)=
 # How to launch a large deployment
 

--- a/docs/how-to/enable-jwt-authentication.md
+++ b/docs/how-to/enable-jwt-authentication.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Enable JSON Web Token (JWT) authentication in Charmed OpenSearch using the JWT integrator charm for secure token-based access."
+---
+
 (how-to-guides-enable-jwt-authentication)=
 # How to enable JWT Authentication
 

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Step-by-step guides for deploying, managing, and maintaining Charmed OpenSearch including TLS, backups, monitoring, and scaling."
+---
+
 (how-to-index)=
 # How-to guides
 

--- a/docs/how-to/integrate-with-an-application.md
+++ b/docs/how-to/integrate-with-an-application.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Integrate client applications with Charmed OpenSearch using the opensearch_client interface or data-integrator charm."
+---
+
 (how-to-integrate-with-an-application)=
 # How to integrate OpenSearch with an application
 

--- a/docs/how-to/monitoring-cos/enable-cos.md
+++ b/docs/how-to/monitoring-cos/enable-cos.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Enable monitoring for Charmed OpenSearch by integrating with COS Lite bundle, Grafana, Loki, and Prometheus."
+---
+
 (how-to-monitoring-enable-cos)=
 # How to enable monitoring (COS)
 

--- a/docs/how-to/monitoring-cos/index.md
+++ b/docs/how-to/monitoring-cos/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Monitor Charmed OpenSearch with Canonical Observability Stack (COS) using Grafana, Prometheus metrics, and alert rules."
+---
+
 (how-to-monitoring-cos-index)=
 # Monitoring (COS)
 

--- a/docs/how-to/monitoring-cos/perform-load-testing.md
+++ b/docs/how-to/monitoring-cos/perform-load-testing.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Perform load testing on Charmed OpenSearch deployments with COS monitoring on AWS and other cloud platforms."
+---
+
 (how-to-perform-load-testing)=
 # How to perform load testing on Charmed OpenSearch
 

--- a/docs/how-to/optimize-cluster-performance.md
+++ b/docs/how-to/optimize-cluster-performance.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Optimize Charmed OpenSearch performance using testing and production profiles to configure resources and JVM heap size."
+---
+
 (how-to-optimize-cluster-performance)=
 # How to optimize cluster performance with profiles
 

--- a/docs/how-to/recover-from-attached-storage.md
+++ b/docs/how-to/recover-from-attached-storage.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Reuse and recover OpenSearch data from Juju-managed disks containing existing cluster metadata and data."
+---
+
 (how-to-recover-from-attached-storage)=
 # How to recover from attached storage
 

--- a/docs/how-to/scale-horizontally.md
+++ b/docs/how-to/scale-horizontally.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Safely scale down Charmed OpenSearch clusters by removing units while preventing data loss and maintaining high availability."
+---
+
 (how-to-scale-horizontally)=
 # How to safely scale down
 

--- a/docs/how-to/tls-encryption/enable-tls-encryption.md
+++ b/docs/how-to/tls-encryption/enable-tls-encryption.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Enable TLS encryption in Charmed OpenSearch using self-signed certificates or X.509 certificate authorities for secure communication."
+---
+
 (how-to-enable-tls-encryption)=
 # How to enable TLS encryption
 

--- a/docs/how-to/tls-encryption/index.md
+++ b/docs/how-to/tls-encryption/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Secure your Charmed OpenSearch deployment with TLS encryption guides including certificate management and rotation."
+---
+
 (how-to-guides-tls-encryption-index)=
 # TLS encryption
 

--- a/docs/how-to/tls-encryption/rotate-tls-ca-certificates.md
+++ b/docs/how-to/tls-encryption/rotate-tls-ca-certificates.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Rotate TLS and CA certificates in Charmed OpenSearch manually or automatically for enhanced security and compliance."
+---
+
 (how-to-rotate-tls-ca-certificates)=
 # How to rotate TLS/CA certificates
 

--- a/docs/how-to/upgrade/index.md
+++ b/docs/how-to/upgrade/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Upgrade guides for Charmed OpenSearch including minor version upgrades and rollback procedures."
+---
+
 (how-to-guides-upgrade-index)=
 # Upgrade
 

--- a/docs/how-to/upgrade/perform-a-minor-rollback.md
+++ b/docs/how-to/upgrade/perform-a-minor-rollback.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Roll back a failed Charmed OpenSearch minor upgrade to restore stability and investigate upgrade failures safely."
+---
+
 (how-to-minor-rollback)=
 # How to perform a minor rollback
 

--- a/docs/how-to/upgrade/perform-a-minor-upgrade.md
+++ b/docs/how-to/upgrade/perform-a-minor-upgrade.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Upgrade Charmed OpenSearch from one minor version to another with pre-upgrade checks, in-place upgrades, and health verification."
+---
+
 (how-to-minor-upgrade)=
 # How to perform a minor upgrade
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Official documentation for Charmed OpenSearch - deploy, manage, and scale OpenSearch clusters with Juju on AWS, Azure, OpenStack, and VMware."
+---
+
 (index)=
 # Charmed OpenSearch Documentation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: "Official documentation for Charmed OpenSearch - deploy, manage, and scale OpenSearch clusters with Juju on AWS, Azure, OpenStack, and VMware."
+    description: "Deploy and manage OpenSearch clusters with automated operations, TLS encryption, backups, and horizontal scaling on any cloud using Juju."
 ---
 
 (index)=

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Technical reference documentation for Charmed OpenSearch including release notes, system requirements, and software testing."
+---
+
 (reference-index)=
 # Reference
 

--- a/docs/reference/release-notes/index.md
+++ b/docs/reference/release-notes/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Release notes for all Charmed OpenSearch versions with new features, bug fixes, and upgrade information."
+---
+
 (reference-release-notes-index)=
 # Release notes
 

--- a/docs/reference/release-notes/revision-168.md
+++ b/docs/reference/release-notes/revision-168.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Charmed OpenSearch Revision 168 release notes - large scale deployments, security automations, monitoring, and backup features."
+---
+
 (reference-release-notes-revision-168)=
 # Revision 168 release notes
 <sub>24 September 2024</sub>

--- a/docs/reference/release-notes/revision-315.md
+++ b/docs/reference/release-notes/revision-315.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Charmed OpenSearch Revision 315 release notes - Ubuntu 24.04 support, OAuth/JWT authentication, and OpenSearch 2.19.4 upgrade."
+---
+
 (reference-release-notes-revision-315)=
 # Revision 315
 

--- a/docs/reference/software-testing.md
+++ b/docs/reference/software-testing.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Software testing guide for Charmed OpenSearch covering unit tests, integration tests, and performance benchmarking procedures."
+---
+
 (reference-software-testing)=
 # Software testing for charms
 

--- a/docs/reference/system-requirements.md
+++ b/docs/reference/system-requirements.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Minimum software and hardware requirements for deploying Charmed OpenSearch including Ubuntu, Juju, LXD, and storage specifications."
+---
+
 (reference-system-requirements)=
 # System requirements
 

--- a/docs/tutorial/1-set-up-the-environment.md
+++ b/docs/tutorial/1-set-up-the-environment.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to set up your development environment with LXD and Juju to deploy Charmed OpenSearch on Ubuntu."
+---
+
 (tutorial-1-set-up-the-environment)=
 # 1. Set up the environment
 

--- a/docs/tutorial/2-deploy-opensearch.md
+++ b/docs/tutorial/2-deploy-opensearch.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Deploy a three-unit Charmed OpenSearch cluster with Juju using performance profiles for optimal resource usage."
+---
+
 (tutorial-2-deploy-opensearch)=
 # 2. Deploy OpenSearch
 

--- a/docs/tutorial/3-enable-encryption.md
+++ b/docs/tutorial/3-enable-encryption.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Enable TLS encryption in Charmed OpenSearch by integrating with the Self Signed Certificates charm for secure data transmission."
+---
+
 (tutorial-3-enable-encryption)=
 # 3. Enable encryption
 

--- a/docs/tutorial/4-integrate-with-a-client-application.md
+++ b/docs/tutorial/4-integrate-with-a-client-application.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Connect client applications to Charmed OpenSearch using the Data Integrator charm to manage users, credentials, and access permissions."
+---
+
 (tutorial-4-integrate-with-a-client-application)=
 # 4. Integrate with a client application
 

--- a/docs/tutorial/5-manage-passwords.md
+++ b/docs/tutorial/5-manage-passwords.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Learn how to retrieve and rotate admin passwords in Charmed OpenSearch for enhanced security and credential management."
+---
+
 (tutorial-5-manage-passwords)=
 # 5. Manage passwords
 

--- a/docs/tutorial/6-scale-horizontally.md
+++ b/docs/tutorial/6-scale-horizontally.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Scale your Charmed OpenSearch cluster horizontally by adding or removing Juju units to handle growing data and traffic demands."
+---
+
 (tutorial-6-scale-horizontally)=
 # 6. Scale horizontally
 

--- a/docs/tutorial/7-clean-up-the-environment.md
+++ b/docs/tutorial/7-clean-up-the-environment.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Remove your Charmed OpenSearch deployment and clean up Juju resources to free up system resources after completing the tutorial."
+---
+
 (tutorial-7-clean-up-the-environment)=
 # 7. Clean up the environment
 

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: "Complete hands-on tutorial to deploy Charmed OpenSearch with Juju, enable TLS encryption, integrate applications, and scale your cluster."
+---
+
 (tutorial-index)=
 # Tutorial
 


### PR DESCRIPTION
## Description of issue or feature:

We need metadata description for every page of our documentation.

Metadata Format: All files use MyST Markdown YAML frontmatter with `html_meta`: `description` field
Description Lengths: within optimal SEO range: 120-160
HTML Output: Meta description tags are correctly generated in all HTML files

Keywords are no longer relevant ([source](https://developers.google.com/search/blog/2009/09/google-does-not-use-keywords-meta-tag)).

## Solution:

Added SEO metadata descriptions to all 43 documentation files in the Charmed OpenSearch documentation repository.

## How was this change tested?

- [x] Manually
- [ ] Unit tests
- [ ] Integration tests

Builds locally w/o errors.
All pages have metadata description in the header (not visible by naked eye, check source code of an HTML page).

## Checklist

- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
