### PR TITLE
Bug-fix: removing the hard-coded unit value + acomodating for the mutual exclusivness of units and machines variables

### DIFF
--- a/terraform/charm/large_deployment/variables.tf
+++ b/terraform/charm/large_deployment/variables.tf
@@ -70,6 +70,7 @@ variable "self-signed-certificates" {
     channel     = optional(string, "1/stable")
     revision    = optional(string, null)
     base        = optional(string, "ubuntu@24.04")
+    units       = optional(number, 1)
     constraints = optional(string, "arch=amd64")
     machines    = optional(list(string), [])
     config      = optional(map(string), { "ca-common-name" : "CA" })

--- a/terraform/charm/simple_deployment/main.tf
+++ b/terraform/charm/simple_deployment/main.tf
@@ -63,7 +63,7 @@ resource "juju_application" "self-signed-certificates" {
 
   config = var.self-signed-certificates.config
 
-  units       = 1
+  units       = (var.self-signed-certificates.machines == null || length(var.self-signed-certificates.machines) == 0) ? var.self-signed-certificates.units : null
   constraints = var.self-signed-certificates.constraints
   machines    = (var.self-signed-certificates.machines == null || length(var.self-signed-certificates.machines) == 0) ? null : var.self-signed-certificates.machines
 }

--- a/terraform/charm/simple_deployment/variables.tf
+++ b/terraform/charm/simple_deployment/variables.tf
@@ -91,6 +91,7 @@ variable "self-signed-certificates" {
     channel     = optional(string, "latest/stable")
     revision    = optional(string, null)
     base        = optional(string, "ubuntu@22.04")
+    units       = optional(number, 1)
     constraints = optional(string, "arch=amd64")
     machines    = optional(list(string), [])
     config      = optional(map(string), { "ca-common-name" : "CA" })

--- a/terraform/product/large_deployment/variables.tf
+++ b/terraform/product/large_deployment/variables.tf
@@ -87,6 +87,7 @@ variable "self-signed-certificates" {
     channel     = optional(string, "1/stable")
     revision    = optional(string, null)
     base        = optional(string, "ubuntu@24.04")
+    units       = optional(number, 1)
     constraints = optional(string, "arch=amd64")
     machines    = optional(list(string), [])
     config      = optional(map(string), { "ca-common-name" : "CA" })

--- a/terraform/product/simple_deployment/variables.tf
+++ b/terraform/product/simple_deployment/variables.tf
@@ -43,6 +43,7 @@ variable "self-signed-certificates" {
     channel     = optional(string, "1/stable")
     revision    = optional(string, null)
     base        = optional(string, "ubuntu@24.04")
+    units       = optional(number, 1)
     constraints = optional(string, "arch=amd64")
     machines    = optional(list(string), [])
     config      = optional(map(string), { "ca-common-name" : "CA" })


### PR DESCRIPTION


## Description of issue or feature:
The bug is [here](https://github.com/canonical/opensearch-operator/blob/83eea3b52e0555cb387a875b33d7025539288db6/terraform/charm/simple_deployment/main.tf#L66)
The `units` value is hard-coded to 1 in the `self-signed-certificates` juju application definition. 

## Solution:
Changed the `units` value to follow `condition ? true_value : false_value` syntax. If the `machines ` value is not defined `units=var.self-signed-certificates.units`, but if  `machines ` value is defined, `units=null`.
This accommodates for the terrafrom juju [schema ](https://registry.terraform.io/providers/juju/juju/1.1.1/docs/resources/application#:~:text=machines%20(Set%20of%20String)%20Specify%20the%20target%20machines%20for%20the%20application%27s%20units.%20The%20number%20of%20machines%20in%20the%20set%20indicates%20the%20unit%20count%20for%20the%20application.%20Removing%20a%20machine%20from%20the%20set%20will%20remove%20the%20application%27s%20unit%20residing%20on%20it.%20machines%20is%20mutually%20exclusive%20with%20units.) that states that `machines` is mutually exclusive with `units`. 
Additionally made sure that all the `variables.tf` files expect `units` value.

## How was this change tested?
- [ ] Manually
- [ ] Unit tests
- [ ] Integration tests

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
