### PR TITLE
[DPE-9332] docs: Add Dashboard docs content as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "docs/dashboards"]
+	path = docs/dashboards
+	url = git@github.com:canonical/opensearch-dashboards-operator.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "docs/dashboards"]
 	path = docs/dashboards
-	url = git@github.com:canonical/opensearch-dashboards-operator.git
+	url = https://github.com/canonical/opensearch-dashboards-operator.git

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,12 @@
 # Required
 version: 2
 
+# Initialize submodules
+submodules:
+  include:
+    - docs/dashboards
+  recursive: false
+
 # Set the version of Python and other tools you might need
 build:
   os: ubuntu-22.04

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -76,6 +76,8 @@ pymarkdownlnt-install:
 	@. $(VENV); test -d $(SPHINXDIR)/venv/lib/python*/site-packages/pymarkdown || pip install pymarkdownlnt
 
 install: $(VENVDIR)
+	@echo "... pulling submodule in dashboards folder"
+	@git submodule update --init dashboards
 
 run: install
 	. $(VENV); $(VENVDIR)/bin/sphinx-autobuild -b dirhtml --host $(SPHINX_HOST) --port $(SPHINX_PORT) "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -301,6 +301,7 @@ extensions = [
 
 exclude_patterns = [
     "doc-cheat-sheet*",
+    "**/README*",
 ]
 
 # Adds custom CSS files, located under 'html_static_path'

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,5 +85,12 @@ tutorial/index
 how-to/index
 reference/index
 explanation/index
-Dashboards charm docs<https://canonical-charmed-opensearch-dashboards.readthedocs-hosted.com/>
+```
+
+```{toctree}
+:caption: OpenSearch Dashboards
+:titlesonly:
+:hidden:
+
+Dashboards documentation <dashboards/docs/index>
 ```


### PR DESCRIPTION
## Description of issue or feature:

We want the OpenSearch Dashboards documentation content to be published on the same website as the OpenSearch docs.

## Solution:

Add Dashboards repo as a submodule, add the docs content to the Nav Menu.

See how it looks and feels – I'm experimenting with the structure and design. For example, category name to separate Dashboards docs. Let me know how it feels.

## How was this change tested?

- [x] Manually
- [ ] Unit tests
- [x] Integration tests

Use `make run` to build and serve locally.
Or use the PR preview below.

## Checklist

- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
