### PR TITLE
Fix charm Build 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -177,6 +177,7 @@ jobs:
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v32.1.0
     with:
       path-to-charm-directory: ${{ matrix.path }}
+      cache: false
 
   integration-test:
     name: Integration test charm

--- a/poetry.lock
+++ b/poetry.lock
@@ -1641,21 +1641,6 @@ files = [
 ]
 
 [[package]]
-name = "jproperties"
-version = "2.1.2"
-description = "Java Property file parser and writer for Python"
-optional = false
-python-versions = ">=2.7"
-groups = ["main"]
-files = [
-    {file = "jproperties-2.1.2-py2.py3-none-any.whl", hash = "sha256:4108e868353a9f4a12bb86a92df5462d0e18d00119169533972ce473029be79a"},
-    {file = "jproperties-2.1.2.tar.gz", hash = "sha256:036fcd52c10a8a1c21e6fa2a1c292c93892e759b76490acc4809213a36ddc329"},
-]
-
-[package.dependencies]
-six = ">=1.13,<2.0"
-
-[[package]]
 name = "jsonschema"
 version = "4.26.0"
 description = "An implementation of JSON Schema validation for Python"
@@ -3639,4 +3624,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "5f3523173e00b01d6510c1dfe36a0600904a25492df6b0aa12e21ccaacb5f87a"
+content-hash = "b1ad1fceb35b3ebb95e5a279afe9653e768ff2059e0384a55154c8fa9aec41ab"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ requests = "2.32.4"
 # Official name: ruamel.yaml, but due to Poetry GH#109 - replace dots with dashs
 ruamel-yaml = "0.18.14"
 shortuuid = "1.0.13"
-jproperties = "2.1.2"
 pydantic = "^1.10.17, <2"
 cryptography = "^45.0.4"
 jsonschema = "^4.24.0"


### PR DESCRIPTION
## Description of issue or feature:
Charm is failing to build due to an issue with the `jproperties` package using setuptools-scm as reported [here](https://github.com/canonical/operator/pull/2310) . 

## Solution:
Remove `jproperties` package since it is not being used in this charm anyway. It is used in build from source.

## How was this change tested?
- [ ] Manually
- [ ] Unit tests
- [ ] Integration tests

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
