### PR TITLE
Re-enable charmcraft build cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -177,7 +177,6 @@ jobs:
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v32.1.0
     with:
       path-to-charm-directory: ${{ matrix.path }}
-      cache: false
 
   integration-test:
     name: Integration test charm


### PR DESCRIPTION
## Description of issue or feature:
Re-enable Charmcraft build with cache after opensearch-operator has been added [again](https://github.com/canonical/charmcraftcache-hub/actions/runs/22095632498) to the ccc-hub

## Solution:
<!--- Please describe in detail what the solution implemented in this PR is. The changes made etc. -->

## How was this change tested?
- [ ] Manually
- [ ] Unit tests
- [ ] Integration tests

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Checklist
- [ ] I have added or updated any relevant documentation.
- [ ] I have cleaned any remaining cloud resources from my accounts.
