### PR TITLE
fix: Fix spread installation

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up environment
         run: |
           sudo snap install go --classic
-          go install github.com/snapcore/spread/cmd/spread@latest
+          go install github.com/canonical/spread/cmd/spread@latest
           pipx install tox poetry
       - name: Collect spread jobs
         id: collect-jobs
@@ -105,7 +105,7 @@ jobs:
       # https://github.com/canonical/charmcraft/issues/2130 fixed
       - run: |
           sudo snap install go --classic
-          go install github.com/snapcore/spread/cmd/spread@latest
+          go install github.com/canonical/spread/cmd/spread@latest
       - name: Download packed charm(s)
         timeout-minutes: 5
         uses: actions/download-artifact@v4


### PR DESCRIPTION
This pull request updates the installation source for the `spread` tool in the integration test GitHub Actions workflow. The tool is now installed from the `canonical` GitHub organization instead of `snapcore`.

Dependency source update:

* Changed the `go install` command to use `github.com/canonical/spread/cmd/spread@latest` instead of `github.com/snapcore/spread/cmd/spread@latest` in two locations within `.github/workflows/integration_test.yaml`. [[1]](diffhunk://#diff-f61384d930ecca9b388b7d547b0c10b6c977f087b106b0747d64dad87a96daa0L23-R23) [[2]](diffhunk://#diff-f61384d930ecca9b388b7d547b0c10b6c977f087b106b0747d64dad87a96daa0L108-R108)