### PR TITLE
ci: add permissions: contents: read to automatic-doc-checks

### DIFF
--- a/.github/workflows/automatic-doc-checks.yml
+++ b/.github/workflows/automatic-doc-checks.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   documentation-checks:
     uses: canonical/documentation-workflows/.github/workflows/documentation-checks.yaml@main


### PR DESCRIPTION
Adds an explicit workflow-level `permissions:` block to `automatic-doc-checks.yml`.

Scope set: `contents: read` (the minimum for checkout + the read-only steps this workflow runs).

Checklist:

- [x] Workflow does not push commits, create releases, or write issues/PRs
- [x] No `pull_request_target` trigger; this is a regular `push`/`pull_request` workflow
- [x] No `actions/cache@v3+` save path (would need `actions: write`)
- [x] YAML re-parses with `yaml.safe_load`
- [x] Matches the pattern recommended in GitHub's [token hardening docs](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token)

This is one of the lowest-effort items on the OpenSSF Scorecard Token-Permissions check, and one of the cheaper defenses against incidents like tj-actions/changed-files compromise in March 2025 (CVE-2025-30066).
