### PR TITLE
docs: Finalise Url migration

### DIFF
--- a/docs/.sphinx/_static/overwritelinks.js
+++ b/docs/.sphinx/_static/overwritelinks.js
@@ -1,0 +1,23 @@
+ // Replace oldDomain with newDomain
+ const oldDomain = 'canonical-charmed-opensearch.readthedocs-hosted.com/2';
+ const newDomain = 'canonical.com/data/opensearch/docs';
+
+ // Use a MutationObserver to wait for the RTD flyout element to appear in the DOM
+ const observer = new MutationObserver(function(mutations, obs) {
+     const rtdFlyout = document.querySelector('readthedocs-flyout');
+     if (!rtdFlyout) return;
+
+     obs.disconnect();
+
+     rtdFlyout.addEventListener('click', function() {
+         const shadowRoot = rtdFlyout.shadowRoot;
+         if (!shadowRoot) return;
+
+         const anchors = shadowRoot.querySelectorAll('a');
+         anchors.forEach(anchor => {
+             anchor.href = anchor.href.replace(new RegExp(oldDomain, 'g'), newDomain);
+         });
+     });
+ });
+
+ observer.observe(document.body, { childList: true, subtree: true });

--- a/docs/.sphinx/_static/overwritelinks.js
+++ b/docs/.sphinx/_static/overwritelinks.js
@@ -1,9 +1,27 @@
- // Replace oldDomain with newDomain
- const oldDomain = 'canonical-charmed-opensearch.readthedocs-hosted.com';
+ // Replaces oldDomain with newDomain in relevant anchor tags
+ const oldDomain = 'canonical-opensearch-charm.readthedocs-hosted.com';
  const newDomain = 'canonical.com/data/opensearch/docs';
+
+ function escapeRegExp(value) {
+     return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+ }
+
+ function overwriteMatchingAnchorUrls(container) {
+     if (!container) return;
+
+     const anchors = container.querySelectorAll('a[href], link[href]');
+     const oldDomainRegex = new RegExp(escapeRegExp(oldDomain), 'g');
+
+     anchors.forEach(anchor => {
+         anchor.href = anchor.href.replace(oldDomainRegex, newDomain);
+     });
+ }
+
+ overwriteMatchingAnchorUrls(document.querySelector('header'));
 
  // Use a MutationObserver to wait for the RTD flyout element to appear in the DOM
  const observer = new MutationObserver(function(mutations, obs) {
+
      const rtdFlyout = document.querySelector('readthedocs-flyout');
      if (!rtdFlyout) return;
 
@@ -13,10 +31,7 @@
          const shadowRoot = rtdFlyout.shadowRoot;
          if (!shadowRoot) return;
 
-         const anchors = shadowRoot.querySelectorAll('a');
-         anchors.forEach(anchor => {
-             anchor.href = anchor.href.replace(new RegExp(oldDomain, 'g'), newDomain);
-         });
+         overwriteMatchingAnchorUrls(shadowRoot);
      });
  });
 

--- a/docs/.sphinx/_static/overwritelinks.js
+++ b/docs/.sphinx/_static/overwritelinks.js
@@ -1,5 +1,5 @@
  // Replace oldDomain with newDomain
- const oldDomain = 'canonical-charmed-opensearch.readthedocs-hosted.com/2';
+ const oldDomain = 'canonical-charmed-opensearch.readthedocs-hosted.com';
  const newDomain = 'canonical.com/data/opensearch/docs';
 
  // Use a MutationObserver to wait for the RTD flyout element to appear in the DOM

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,7 +70,7 @@ copyright = "%s CC-BY-SA, %s" % (datetime.date.today().year, author)
 # NOTE: The Open Graph Protocol (OGP) enhances page display in a social graph
 #       and is used by social media platforms; see https://ogp.me/
 
-ogp_site_url = f"https://canonical.com/data/opensearch/docs/{version}/"
+ogp_site_url = os.environ.get("READTHEDOCS_CANONICAL_URL", "/")
 
 
 # Preview name of the documentation website
@@ -177,7 +177,7 @@ slug = 'data/opensearch/docs'
 
 # Base URL of RTD hosted project
 
-html_baseurl = f"https://canonical.com/data/opensearch/docs/{version}/"
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "/")
 
 # URL scheme. Add language and version scheme elements.
 # When configured with RTD variables, check for RTD environment so manual runs succeed:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,7 +70,7 @@ copyright = "%s CC-BY-SA, %s" % (datetime.date.today().year, author)
 # NOTE: The Open Graph Protocol (OGP) enhances page display in a social graph
 #       and is used by social media platforms; see https://ogp.me/
 
-ogp_site_url = "https://canonical-charmed-spark.readthedocs-hosted.com/"
+ogp_site_url = f"https://canonical.com/data/opensearch/docs/{version}/"
 
 
 # Preview name of the documentation website
@@ -169,7 +169,7 @@ html_context = {
 # TODO: If your documentation is hosted on https://docs.ubuntu.com/,
 #       uncomment and update as needed.
 
-# slug = 'charmed-opensearch'
+slug = 'data/opensearch/docs'
 
 #######################
 # Sitemap configuration: https://sphinx-sitemap.readthedocs.io/
@@ -177,7 +177,7 @@ html_context = {
 
 # Base URL of RTD hosted project
 
-html_baseurl = 'https://canonical-starter-pack.readthedocs-hosted.com/'
+html_baseurl = f"https://canonical.com/data/opensearch/docs/{version}/"
 
 # URL scheme. Add language and version scheme elements.
 # When configured with RTD variables, check for RTD environment so manual runs succeed:
@@ -314,6 +314,7 @@ html_css_files = [
 
 html_js_files = [
     "bundle.js",
+    "overwritelinks.js",
 ]
 
 # Specifies a reST snippet to be appended to each .rst file

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,6 +62,10 @@ html_title = project + " documentation"
 
 copyright = "%s CC-BY-SA, %s" % (datetime.date.today().year, author)
 
+version_slug = f"{os.environ.get('READTHEDOCS_VERSION', 'local')}"
+
+
+
 
 # Documentation website URL
 #
@@ -70,7 +74,7 @@ copyright = "%s CC-BY-SA, %s" % (datetime.date.today().year, author)
 # NOTE: The Open Graph Protocol (OGP) enhances page display in a social graph
 #       and is used by social media platforms; see https://ogp.me/
 
-ogp_site_url = "https://canonical.com/data/opensearch/docs/"
+ogp_site_url = f"https://canonical.com/data/opensearch/docs/{version_slug}/"
 
 
 # Preview name of the documentation website
@@ -177,16 +181,18 @@ slug = 'data/opensearch/docs'
 
 # Base URL of RTD hosted project
 
-html_baseurl = "https://canonical.com/data/opensearch/docs/"
+html_baseurl = f"https://canonical.com/data/opensearch/docs/{version_slug}/"
 
 # URL scheme. Add language and version scheme elements.
 # When configured with RTD variables, check for RTD environment so manual runs succeed:
 
-if 'READTHEDOCS_VERSION' in os.environ:
-    version = os.environ["READTHEDOCS_VERSION"]
-    sitemap_url_scheme = '{version}{link}'
-else:
-    sitemap_url_scheme = 'MANUAL/{link}'
+sitemap_url_scheme = "{link}"
+
+# if 'READTHEDOCS_VERSION' in os.environ:
+#     version = os.environ["READTHEDOCS_VERSION"]
+#     sitemap_url_scheme = '{version}{link}'
+# else:
+#     sitemap_url_scheme = 'MANUAL/{link}'
 
 # Include `lastmod` dates in the sitemap:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,7 +70,7 @@ copyright = "%s CC-BY-SA, %s" % (datetime.date.today().year, author)
 # NOTE: The Open Graph Protocol (OGP) enhances page display in a social graph
 #       and is used by social media platforms; see https://ogp.me/
 
-ogp_site_url = os.environ.get("READTHEDOCS_CANONICAL_URL", "/")
+ogp_site_url = "https://canonical.com/data/opensearch/docs/"
 
 
 # Preview name of the documentation website
@@ -177,7 +177,7 @@ slug = 'data/opensearch/docs'
 
 # Base URL of RTD hosted project
 
-html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "/")
+html_baseurl = "https://canonical.com/data/opensearch/docs/"
 
 # URL scheme. Add language and version scheme elements.
 # When configured with RTD variables, check for RTD environment so manual runs succeed:


### PR DESCRIPTION
## Description of issue or feature:

To finalise URL migration, we want to merge the changes from URL migration branch into the default (2/edge) branch.

## Solution:

The [new URL](https://canonical.com/data/opensearch/docs/) is being published from the [new RTD project](https://app.readthedocs.com/projects/canonical-opensearch-charm/) from URL migration branch.
We want to merge the branch, so we can change settings to publish the new URL docs from the default branch again.


## How was this change tested?
- [x] Manually
- [ ] Unit tests
- [ ] Integration tests

The URL migration branch is now published at the canonical.com/data/opensearch/docs address.

## Checklist
- [x] I have added or updated any relevant documentation.
- [x] I have cleaned any remaining cloud resources from my accounts.
