### PR TITLE
patch: Remove tag job from release workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,18 +11,9 @@ on:
       - 2/edge
 
 jobs:
-  tag:
-    name: Create charm refresh compatibility version git tag
-    uses: canonical/data-platform-workflows/.github/workflows/tag_charm_edge.yaml@v50.0.0
-    with:
-      track: '2'
-    permissions:
-      contents: write  # Needed to create git tag
 
   ci-tests:
     name: Tests
-    needs:
-      - tag
     uses: ./.github/workflows/ci.yaml
     permissions:
       contents: write  # Needed for Allure Report
@@ -30,11 +21,10 @@ jobs:
   release-machine:
     name: Release machine charm
     needs:
-      - tag
       - ci-tests
     uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v50.0.0
     with:
-      track: ${{ needs.tag.outputs.track }}
+      track: "2"
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}
       path-to-charm-directory: machine
     secrets:
@@ -45,11 +35,10 @@ jobs:
   release-k8s:
     name: Release Kubernetes charm
     needs:
-      - tag
       - ci-tests
     uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v50.0.0
     with:
-      track: ${{ needs.tag.outputs.track }}
+      track: "2"
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}
       path-to-charm-directory: kubernetes
     secrets:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,30 +18,22 @@ jobs:
     permissions:
       contents: write  # Needed for Allure Report
 
-  release-machine:
-    name: Release machine charm
+  release:
+    name: Release charm | ${{ matrix.path }}
+    strategy:
+      matrix:
+        path:
+          - machine
+          - kubernetes
     needs:
       - ci-tests
     uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v50.0.0
     with:
+      path-to-charm-directory: ${{ matrix.path }}
       track: "2"
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}
-      path-to-charm-directory: machine
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
     permissions:
       contents: write  # Needed to create git tags
-
-  release-k8s:
-    name: Release Kubernetes charm
-    needs:
-      - ci-tests
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v50.0.0
-    with:
-      track: "2"
-      artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}
-      path-to-charm-directory: kubernetes
-    secrets:
-      charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
-    permissions:
-      contents: write  # Needed to create git tags
+      actions: read # Needed by reusable workflow


### PR DESCRIPTION
This Pull Request removes the `tag` job from the release workflow since this is used to generate the compatibility version which is not needed in refresh v2. If the release pipeline still fails, we may need to go back to the previous version of the workflow.